### PR TITLE
remove decorator dependency

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -34,7 +34,7 @@ setup(
     version="1.0",
 
     zip_safe=False,
-    install_requires=['numpy', 'decorator'],
+    install_requires=['numpy'],
 
     # declare your packages
     packages=find_packages(),


### PR DESCRIPTION
Removes decorator dependency since it's not used in DLR python pkg for now. 