### PR TITLE
Detect special SageMaker files when absolute paths are used

### DIFF
--- a/src/dlr.cc
+++ b/src/dlr.cc
@@ -7,6 +7,7 @@
 #include <iterator>
 #include <vector>
 #include <cstring>
+#include <string>
 #include <numeric>
 
 /* OS-specific library file extension */
@@ -25,6 +26,35 @@ namespace {
 constexpr const char* SAGEMAKER_AUXILIARY_JSON_FILES[] = {
   "model-shapes.json", "hyperparams.json"
 };
+
+inline std::string GetBasename(const std::string& path) {
+#ifdef _WIN32
+  /* remove any trailing backward or forward slashes
+     (UNIX does this automatically) */
+  std::string path_;
+  std::string::size_type tmp = path.find_last_of("/\\");
+  if (tmp == path.length() - 1) {
+    size_t i = tmp;
+    while ((path[i] == '/' || path[i] == '\\') && i >= 0) {
+      --i;
+    }
+    path_ = path.substr(0, i + 1);
+  } else {
+    path_ = path;
+  }
+  std::vector<char> fname(path_.length() + 1);
+  std::vector<char> ext(path_.length() + 1);
+  _splitpath_s(path_.c_str(), NULL, 0, NULL, 0,
+    &fname[0], path_.length() + 1, &ext[0], path_.length() + 1);
+  return std::string(&fname[0]) + std::string(&ext[0]);
+#else
+  char* path_ = strdup(path.c_str());
+  char* base = basename(path_);
+  std::string ret(base);
+  free(path_);
+  return ret;
+#endif
+}
 
 }
 
@@ -88,11 +118,12 @@ ModelPath get_tvm_paths(const std::string &dirname) {
   std::vector<std::string> paths_vec;
   listdir(dirname, paths_vec);
   for (auto filename : paths_vec) {
+    std::string basename = GetBasename(filename);
     if (endsWith(filename, ".json")
         && std::all_of(std::begin(SAGEMAKER_AUXILIARY_JSON_FILES),
                        std::end(SAGEMAKER_AUXILIARY_JSON_FILES),
-                       [filename](const std::string& s)
-                                 { return (s != filename); })
+                       [basename](const std::string& s)
+                                 { return (s != basename); })
         && filename != "version.json") {
       paths.model_json = filename;
     } else if (endsWith(filename, LIBEXT)) {


### PR DESCRIPTION
When DLR is run inside a Docker container, all paths are often absolute. Currently, SageMaker special files are not detected when absolute paths are used. Fix: take the base name prior to doing lookup in `SAGEMAKER_AUXILIARY_JSON_FILES`.