### PR TITLE
Do not close TF session at the end of run method

### DIFF
--- a/tests/python/unittest/test_tf_model.py
+++ b/tests/python/unittest/test_tf_model.py
@@ -14,42 +14,38 @@ def _generate_frozen_graph():
     tf.square(mm, name="output1")
     mm_flat = tf.reshape(mm, shape=[-1])
     tf.argmax(mm_flat, name="output2")
-
     with tf.Session() as sess:
-        output_graph_def = tf.compat.v1.graph_util.convert_variables_to_constants(
+        output_graph_def = tf.graph_util.convert_variables_to_constants(
             sess,
             tf.get_default_graph().as_graph_def(),
             ["output1", "output2"]
         )
-
         with tf.gfile.GFile(FROZEN_GRAPH_PATH, "wb") as f:
             f.write(output_graph_def.SerializeToString())
-    sess.close()
 
 
 def test_tf_model(dev_type=None, dev_id=None):
     _generate_frozen_graph()
-    m = TFModelImpl(FROZEN_GRAPH_PATH, dev_type, dev_id)
+    with TFModelImpl(FROZEN_GRAPH_PATH, dev_type, dev_id) as m:
+        inp_names = m.get_input_names()
+        assert inp_names == ['import/input1:0', 'import/input2:0']
 
-    inp_names = m.get_input_names()
-    assert inp_names == ['import/input1:0', 'import/input2:0']
+        out_names = m.get_output_names()
+        assert out_names == ['import/output1:0', 'import/output2:0']
 
-    out_names = m.get_output_names()
-    assert out_names == ['import/output1:0', 'import/output2:0']
+        inp1 = [[4., 1.], [3., 2.]]
+        inp2 = [[0., 1.], [1., 0.]]
 
-    inp1 = [[4., 1.], [3., 2.]]
-    inp2 = [[0., 1.], [1., 0.]]
+        res = m.run({'import/input1:0': inp1, 'import/input2:0': inp2})
+        assert res is not None
+        assert len(res) == 2
+        assert np.alltrue(res[0] == [[36., 361.], [49.,  324.]])
+        assert res[1] == 1
 
-    res = m.run({'import/input1:0': inp1, 'import/input2:0': inp2})
-    assert res is not None
-    assert len(res) == 2
-    assert np.alltrue(res[0] == [[36., 361.], [49.,  324.]])
-    assert res[1] == 1
-
-    m_inp1 = m.get_input('import/input1:0')
-    m_inp2 = m.get_input('import/input2:0')
-    assert np.alltrue(m_inp1 == inp1)
-    assert np.alltrue(m_inp2 == inp2)
+        m_inp1 = m.get_input('import/input1:0')
+        m_inp2 = m.get_input('import/input2:0')
+        assert np.alltrue(m_inp1 == inp1)
+        assert np.alltrue(m_inp2 == inp2)
 
 
 def test_tf_model_on_cpu_0():


### PR DESCRIPTION
*Description of changes:*
When I run `mobilenet_v1_0.25_224_quant_frozen.pb` on ARMv8 RK3399 device I noticed that each run takes about 750 ms.
I refactored TFModelImpl code to not close TF session after each run(). After that change the second and consequent calls of run() method take just 130 ms.
```
m.run...
m.run done, duration 754 ms
m.run...
m.run done, duration 122 ms
m.run...
m.run done, duration 126 ms
m.run...
m.run done, duration 134 ms
m.run...
m.run done, duration 125 ms
```

I also implemented `__enter__` and `__exit__` methods in `TFModelImpl`.
It allows to use `TFModelImpl` with Context manager
```
with TFModelImpl(FROZEN_GRAPH_PATH, dev_type, dev_id) as m:
    for i in range(100):
        res = m.run(...)
```
