### PR TITLE
Add op top level filter to _get_input_and_output_names

### DIFF
--- a/python/dlr/tf_model.py
+++ b/python/dlr/tf_model.py
@@ -50,7 +50,8 @@ def _get_input_and_output_names(graph):
     output_tensor_names = set()
     op_prefix = PREFIX + "/"
     for op in graph.get_operations():
-        if not op.name.startswith(op_prefix):
+        # Ignore operators which are not directly under PREFIX node
+        if not op.name.startswith(op_prefix) or op.name.find('/', len(op_prefix)) > -1:
             continue
         if op.type == 'Placeholder' and op.inputs.__len__() == 0 and op.outputs.__len__() == 1:
             input_tensor_names.append(op.outputs[0].name)

--- a/tests/python/unittest/test_tf_model.py
+++ b/tests/python/unittest/test_tf_model.py
@@ -10,7 +10,8 @@ def _generate_frozen_graph():
     a = tf.placeholder(tf.float32, shape=[2, 2], name="input1")
     b = tf.placeholder(tf.float32, shape=[2, 2], name="input2")
     ab = tf.matmul(a, b)
-    mm = tf.matmul(a, ab)
+    mm = tf.matmul(a, ab, name="preproc/mm")
+    tf.argmax(mm, name="preproc/mm_argmax")
     tf.square(mm, name="output1")
     mm_flat = tf.reshape(mm, shape=[-1])
     tf.argmax(mm_flat, name="output2")
@@ -18,7 +19,7 @@ def _generate_frozen_graph():
         output_graph_def = tf.graph_util.convert_variables_to_constants(
             sess,
             tf.get_default_graph().as_graph_def(),
-            ["output1", "output2"]
+            ["output1", "output2", "preproc/mm_argmax"]
         )
         with tf.gfile.GFile(FROZEN_GRAPH_PATH, "wb") as f:
             f.write(output_graph_def.SerializeToString())


### PR DESCRIPTION
### Description of changes:
I tried to run `ssd_mobilenet_v1_coco` frozen graph today and found that `tf_model._get_input_and_output_names` utils method returns big list of output tensor names:
```
'import/detection_boxes:0'
'import/detection_classes:0'
'import/detection_scores:0'
'import/num_detections:0'
'import/Postprocessor/BatchMultiClassNonMaxSuppression/map/while/PadOrClipBoxList/cond_3/switch_t:0'
'import/Postprocessor/BatchMultiClassNonMaxSuppression/map/while/PadOrClipBoxList/cond_3/switch_f:0'
'import/Postprocessor/BatchMultiClassNonMaxSuppression/map/while/PadOrClipBoxList/cond_3/cond/switch_t:0'
'import/Postprocessor/BatchMultiClassNonMaxSuppression/map/while/PadOrClipBoxList/cond_1/switch_t:0'
'import/Postprocessor/BatchMultiClassNonMaxSuppression/map/while/PadOrClipBoxList/cond/switch_t:0'
'import/Postprocessor/BatchMultiClassNonMaxSuppression/map/while/PadOrClipBoxList/cond_1/cond/switch_f:0'
'import/Postprocessor/BatchMultiClassNonMaxSuppression/map/while/PadOrClipBoxList/cond/cond/switch_t:0'
'import/Postprocessor/BatchMultiClassNonMaxSuppression/map/while/PadOrClipBoxList/cond/switch_f:0'
'import/Postprocessor/BatchMultiClassNonMaxSuppression/map/while/PadOrClipBoxList/cond_3/cond/switch_f:0'
'import/Postprocessor/BatchMultiClassNonMaxSuppression/map/while/PadOrClipBoxList/cond_1/cond/switch_t:0'
'import/Postprocessor/BatchMultiClassNonMaxSuppression/map/while/PadOrClipBoxList/cond_1/switch_f:0'
'import/Postprocessor/BatchMultiClassNonMaxSuppression/map/while/PadOrClipBoxList/cond/cond/switch_f:0'
```

I think we only need 4 output tensors located directly under prefix node `import/`

This PR fixes `tf_model._get_input_and_output_names` method to return tensor names located directly under PREFIX node.

### Links
`ssd_mobilenet_v1_coco` link:
https://github.com/tensorflow/models/blob/master/research/object_detection/g3doc/detection_model_zoo.md