### PR TITLE
Add TFLiteModelImpl

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -135,7 +135,8 @@ def CloudInstallAndTest(cloudTarget) {
     sh """
     ls -lh *.whl
     pip3 install *.whl
-    pip3 install tensorflow
+    sudo pip3 install --upgrade --force-reinstall tensorflow
+    type toco_from_protos
     """
     echo "Running integration tests..."
     unstash name: 'srcs'
@@ -144,6 +145,7 @@ def CloudInstallAndTest(cloudTarget) {
     python3 tests/python/integration/load_and_run_treelite_model.py
     python3 -m pytest -v --fulltrace -s tests/python/unittest/test_get_set_input.py
     python3 -m pytest -v --fulltrace -s tests/python/unittest/test_tf_model.py
+    python3 -m pytest -v --fulltrace -s tests/python/unittest/test_tflite_model.py
     """
   }
 }

--- a/python/dlr/api.py
+++ b/python/dlr/api.py
@@ -3,8 +3,9 @@ from __future__ import absolute_import as _abs
 
 import abc
 import glob
+import logging
 import os
-import sys
+
 
 # Interface
 class IDLRModel:
@@ -26,27 +27,48 @@ class IDLRModel:
     def run(self, input_data):
         raise NotImplementedError
 
+
+def _find_model_file(model_path, ext):
+    if os.path.isfile(model_path) and model_path.endswith(ext):
+        return model_path
+    model_files = glob.glob(os.path.abspath(os.path.join(model_path, ext)))
+    if len(model_files) > 1:
+        raise ValueError('Multiple {} files found under {}'.format(ext, mdel_path))
+    elif len(model_files) == 1:
+        return model_files[0]
+    return None
+
+
 # Wrapper class
 class DLRModel(IDLRModel):
-    def __init__(self, model_path, dev_type='cpu', dev_id=0):
-        #Determine if 3rdparty package needed
-        tf_model_path = None
-        if os.path.isfile(model_path):    
-            if model_path.endswith('.pb'):
-                tf_model_path = model_path
-        else:
-            model_files = glob.glob(os.path.abspath(os.path.join(model_path, '*.pb')))
-            if len(model_files) > 1:
-                raise ValueError('Multiple .pb files found under ' + model_path)
-            elif len(model_files) == 1:
-                tf_model_path = model_files[0]
-        # Default to DLR model
+    def __init__(self, model_path, dev_type=None, dev_id=None):
+        # Find correct runtime implementation for the model
+        tf_model_path = _find_model_file(model_path, '.pb')
+        tflite_model_path = _find_model_file(model_path, '.tflite')
+        # Check if found both Tensorflow and TFLite files
+        if tf_model_path is not None and tflite_model_path is not None:
+            raise ValueError('Found both .pb and .tflite files under {}'.format(mdel_path))
+        # Tensorflow
         if tf_model_path is not None:
             from .tf_model import TFModelImpl
             self._impl = TFModelImpl(tf_model_path, dev_type, dev_id)
-        else:
-            from .dlr_model import DLRModelImpl
-            self._impl = DLRModelImpl(model_path, dev_type, dev_id) 
+            return
+        # TFLite
+        if tflite_model_path is not None:
+            if dev_type is not None:
+                logging.warning("dev_type parameter is not supported")
+            if dev_id is not None:
+                logging.warning("dev_id parameter is not supported")
+            from .tflite_model import TFLiteModelImpl
+            self._impl = TFLiteModelImpl(tflite_model_path)
+            return
+        # Default to TVM+Treelite
+        from .dlr_model import DLRModelImpl
+        if dev_type is None:
+            dev_type = 'cpu'
+        if dev_id is None:
+            dev_id = 0
+        self._impl = DLRModelImpl(model_path, dev_type, dev_id)
 
     def run(self, input_values):
         return self._impl.run(input_values)

--- a/python/dlr/tf_model.py
+++ b/python/dlr/tf_model.py
@@ -74,7 +74,7 @@ def _get_input_and_output_names(graph):
 
 class TFModelImpl(IDLRModel):
     """
-    TFModelImpl is a wrapper on top of tensorflow which implements DLRModel API
+    TFModelImpl is a wrapper on top of Tensorflow which implements IDLRModel API
 
     Parameters
     ----------
@@ -86,8 +86,10 @@ class TFModelImpl(IDLRModel):
         Optional. Device ID
     """
     def __init__(self, frozen_graph_file, dev_type=None, dev_id=None):
+        if not frozen_graph_file.endswith(".pb"):
+            raise ValueError("Not a frozen graph file: {}".format(frozen_graph_file))
         if not os.path.exists(frozen_graph_file):
-            raise ValueError("frozen_graph_file %s doesn't exist" % frozen_graph_file)
+            raise ValueError("Frozen graph file {} doesn't exist".format(frozen_graph_file))
         self.frozen_graph_file = frozen_graph_file
 
         device = None

--- a/python/dlr/tflite_model.py
+++ b/python/dlr/tflite_model.py
@@ -1,0 +1,125 @@
+import logging
+import os
+from collections import OrderedDict
+import tensorflow.lite as lite
+from .api import IDLRModel
+
+
+def _get_input_and_output_names(intrp):
+    """
+    Get input and output tensor names
+
+    Parameters
+    ----------
+    intrp : :py:class:`str`tf.lite.Interpreter`
+        TFLite Interpreter
+
+    Returns
+    -------
+    input_tensor_dict : Input tensor Dict which maps tensor_name to tensor_id
+    output_tensor_dict : Output tensor Dict which maps tensor_name to tensor_id
+    """
+    # Use OrderedDict to keep tensor names order
+    input_tensor_dict = OrderedDict()
+    output_tensor_dict = OrderedDict()
+    for d in intrp.get_input_details():
+        input_tensor_dict[d["name"]] = d["index"]
+    for d in intrp.get_output_details():
+        output_tensor_dict[d["name"]] = d["index"]
+    return input_tensor_dict, output_tensor_dict
+
+
+class TFLiteModelImpl(IDLRModel):
+    """
+    TFLiteModelImpl is a wrapper on top of Tensorflow Lite which implements IDLRModel API
+
+    Parameters
+    ----------
+    tflite_file : :py:class:`str`
+        Full path to TFLite file (.tflite file)
+    """
+    def __init__(self, tflite_file):
+        if not tflite_file.endswith(".tflite"):
+            raise ValueError("Not a TFLite file: {}".format(tflite_file))
+        if not os.path.exists(tflite_file):
+            raise ValueError("TFLite file {} doesn't exist".format(tflite_file))
+
+        logging.info("Loading TFLite file: {}".format(tflite_file))
+        self._intrp = lite.Interpreter(model_path=tflite_file)
+        self._intrp.allocate_tensors()
+        self._input_tensor_dict, self._output_tensor_dict = _get_input_and_output_names(self._intrp)
+
+    def _validate_input_name(self, name):
+        if name not in self._input_tensor_dict:
+            raise ValueError(
+                "Invalid input tensor name '{}'. List of input tensor names: {}".format(name, self.get_input_names()))
+
+    def _validate_input(self, input_values):
+        if isinstance(input_values, dict):
+            for k in input_values.keys():
+                if not isinstance(k, str):
+                    raise ValueError("input key must be string")
+                self._validate_input_name(k)
+        else:
+            raise ValueError("input_values must be of type dict")
+
+    def get_input_names(self):
+        """
+        Get all input names
+
+        Returns
+        -------
+        out : list of :py:class:`str`
+        """
+        return list(self._input_tensor_dict.keys())
+
+    def get_output_names(self):
+        """
+        Get all output names
+
+        Returns
+        -------
+        out : list of :py:class:`str`
+        """
+        return list(self._output_tensor_dict.keys())
+
+    def get_input(self, name, shape=None):
+        """
+        Get the current value of an input
+
+        Parameters
+        ----------
+        name : :py:class:`str`
+            The name of an input
+        shape : :py:class:`np.array` (optional)
+            If given, use as the shape of the returned array. Otherwise, the shape of
+            the returned array will be inferred from the last call to set_input().
+        """
+        self._validate_input_name(name)
+        tensor_index = self._input_tensor_dict[name]
+        out = self._intrp.get_tensor(tensor_index)
+        if shape is not None:
+            out = out.reshape(shape)
+        return out
+
+    def run(self, input_values):
+        """
+        Run inference with given input(s)
+
+        Parameters
+        ----------
+        input_values : a dictionary where keys are input
+            names (of type :py:class:`str`) and values are input tensors (of any type).
+            Multiple inputs are allowed.
+
+        Returns
+        -------
+        out : :py:class:`list`
+            Prediction result. Multiple outputs are possible.
+        """
+        self._validate_input(input_values)
+        for k, v in input_values.items():
+            tensor_index = self._input_tensor_dict[k]
+            self._intrp.set_tensor(tensor_index, v)
+        self._intrp.invoke()
+        return [self._intrp.get_tensor(v) for v in self._output_tensor_dict.values()]

--- a/tests/python/unittest/test_tf_model.py
+++ b/tests/python/unittest/test_tf_model.py
@@ -2,9 +2,9 @@
 from __future__ import print_function
 from dlr import DLRModel
 import numpy as np
-import os
 
 FROZEN_GRAPH_PATH = "/tmp/test_graph.pb"
+
 
 def _generate_frozen_graph():
     import tensorflow as tf
@@ -58,6 +58,7 @@ def test_tf_model_on_cpu_0():
 
 def test_tf_model_on_gpu_0():
     test_tf_model("gpu", 0)
+
 
 if __name__ == '__main__':
     test_tf_model()

--- a/tests/python/unittest/test_tflite_model.py
+++ b/tests/python/unittest/test_tflite_model.py
@@ -1,0 +1,54 @@
+# coding: utf-8
+from __future__ import print_function
+from dlr import DLRModel
+import numpy as np
+
+TFLITE_FILE_PATH = "/tmp/test_model.tflite"
+
+
+def _generate_tflite_file():
+    import tensorflow as tf
+    import tensorflow.lite as lite
+    a = tf.placeholder(tf.float32, shape=[2, 2], name="input1")
+    b = tf.placeholder(tf.float32, shape=[2, 2], name="input2")
+    ab = tf.matmul(a, b)
+    mm = tf.matmul(a, ab, name="preproc/mm")
+    out0 = tf.square(mm, name="preproc/output1")
+    mm_flat = tf.reshape(mm, shape=[-1])
+    out1 = tf.argmax(mm_flat, name="preproc/output2")
+    with tf.Session() as sess:
+        converter = lite.TFLiteConverter.from_session(sess, input_tensors=[a, b], output_tensors=[out0, out1])
+        tflite_model = converter.convert()
+        with open(TFLITE_FILE_PATH, "wb") as f:
+            f.write(tflite_model)
+
+
+def test_tflite_model():
+    _generate_tflite_file()
+
+    m = DLRModel(TFLITE_FILE_PATH)
+    inp_names = m.get_input_names()
+    assert inp_names == ['input1', 'input2']
+
+    out_names = m.get_output_names()
+    assert out_names == ['preproc/output1', 'preproc/output2']
+
+    inp1 = np.array([[4., 1.], [3., 2.]]).astype("float32")
+    inp2 = np.array([[0., 1.], [1., 0.]]).astype("float32")
+
+    res = m.run({'input1': inp1, 'input2': inp2})
+    assert res is not None
+    assert len(res) == 2
+    exp_out0 = np.array([[36., 361.], [49.,  324.]]).astype("float32")
+    assert np.alltrue(res[0] == exp_out0)
+    assert res[1] == 1
+
+    m_inp1 = m.get_input('input1')
+    m_inp2 = m.get_input('input2')
+    assert np.alltrue(m_inp1 == inp1)
+    assert np.alltrue(m_inp2 == inp2)
+
+
+if __name__ == '__main__':
+    test_tflite_model()
+    print('All tests passed!')


### PR DESCRIPTION
*Description of changes:*

`TFLiteModelImpl` is a wrapper on top of Tensorflow Lite which implements `IDLRModel` API

`test_tflite_model.py` contains unit tests. The unit test generates `/tmp/test_model.tflite` file and tests that DLRModel can:

1. load `/tmp/test_model.tflite` file
2. get input / output tensor names
3. run the model
4. get input values by name