### PR TITLE
Update api.py _find_model_file

### DIFF
--- a/python/dlr/api.py
+++ b/python/dlr/api.py
@@ -31,7 +31,7 @@ class IDLRModel:
 def _find_model_file(model_path, ext):
     if os.path.isfile(model_path) and model_path.endswith(ext):
         return model_path
-    model_files = glob.glob(os.path.abspath(os.path.join(model_path, ext)))
+    model_files = glob.glob(os.path.abspath(os.path.join(model_path, '*'+ext)))
     if len(model_files) > 1:
         raise ValueError('Multiple {} files found under {}'.format(ext, mdel_path))
     elif len(model_files) == 1:


### PR DESCRIPTION
*Issue #, if available:*
If we only specify the folder path instead of the pb file path, it will not find the file.

*Description of changes:*
Make sure it can fild the pb or tflite file if we only specify the folder path

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
