### PR TITLE
Support multi-line request in XGBoost container

### DIFF
--- a/container/neo_template_xgboost.py
+++ b/container/neo_template_xgboost.py
@@ -3,6 +3,7 @@ import pickle as pkl
 import csv
 import numpy as np
 from scipy.sparse import csr_matrix
+import io
 import os
 import dlr
 
@@ -22,8 +23,11 @@ class NeoXGBoostPredictor():
 
     def postprocess(self, preds):
         assert len(preds) == 1
-        ret = [','.join([str(x) for x in row]) for row in preds[0].tolist()]
-        return ret
+        preds = preds[0]
+        with io.StringIO() as f:
+            np.savetxt(f, preds, delimiter=',', newline='\n')
+            ret = f.getvalue()
+        return [ret]
 
     def initialize(self, context):
         manifest = context.manifest
@@ -42,7 +46,7 @@ class NeoXGBoostPredictor():
         batch_size = len(req_ids)
 
         if batch_size != 1:
-            raise Exception('Batch prediction not yet supported')
+            raise Exception('Batching multiple requests is not yet supported')
 
         for k in range(batch_size):
             req_id = req_ids[k]

--- a/container/neo_template_xgboost.py
+++ b/container/neo_template_xgboost.py
@@ -24,6 +24,9 @@ class NeoXGBoostPredictor():
     def postprocess(self, preds):
         assert len(preds) == 1
         preds = preds[0]
+        assert preds.ndim == 2
+        if preds.shape[1] == 1:
+            preds = preds.reshape((1, -1))
         with io.StringIO() as f:
             np.savetxt(f, preds, delimiter=',', newline='\n')
             ret = f.getvalue()


### PR DESCRIPTION
*Description of changes:* Current XGBoost container returns a 503 if the user submits a request with multiple data points. Fix the MMS-interfacing code to support this use case.

*How to test*: In Python shell, run:
```python
import requests

# Open a LIBSVM file with multiple data points (rows)
with open('tests/python/integration/xgboost/letor.libsvm', 'r') as f:
    data = f.read()

# Send request to a locally running Docker container
r = requests.post('http://localhost:8888/invocations', data=data,
                  headers={'Content-type': 'text/libsvm'})
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
