### PR TITLE
Fix missing header in dev branch of 3rdparty/tvm

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -160,6 +160,12 @@ def BuildInferenceContainer(app, target) {
   node(nodeReq) {
     unstash name: 'srcs'
     echo "Building inference container ${app} for target ${target}"
+    if (target == "gpu") {
+      // Download TensorRT library
+      s3Download(file: 'container/TensorRT-5.0.2.6.Ubuntu-18.04.1.x86_64-gnu.cuda-10.0.cudnn7.3.tar.gz',
+                 bucket: 'neo-ai-dlr-jenkins-artifacts',
+                 path: 'TensorRT-5.0.2.6.Ubuntu-18.04.1.x86_64-gnu.cuda-10.0.cudnn7.3.tar.gz')
+    }
     sh """
     cd container
     docker build --build-arg APP=${app} -t ${app}-${target} -f Dockerfile.${target} .

--- a/container/Dockerfile.gpu
+++ b/container/Dockerfile.gpu
@@ -42,6 +42,7 @@ RUN mkdir -p /home/model-server && cd /home/model-server \
     && git submodule update --init --recursive \
     && cd 3rdparty/tvm \
     && git checkout dev \
+    && sed -i '1s;^;#include <cstring>\n;' src/runtime/cuda/cuda_device_api.cc \
     && cd ../.. \
     && mkdir build && cd build && cmake .. -DUSE_CUDA=ON -DUSE_CUDNN=ON -DUSE_TENSORRT=/packages/TensorRT-5.0.2.6 \
     && make -j15 && cd ../python && python3 setup.py bdist_wheel \


### PR DESCRIPTION
When I was building the GPU Image Classification container, I got error
```
error: strlen was not declared in this scope
```
because the header `<cstring>` was missing from the file `src/runtime/cuda/cuda_device_api.cc`. (This error only happens when CUDA is enabled.)

We should fix 3rdparty/tvm, but for now I use `sed` to add the line `#include <cstring>` to `src/runtime/cuda/cuda_device_api.cc` on the fly. Update. The fix is now submitted to upstream: dmlc/tvm#3621.

Also, this pull request adds GPU image classification container to the Jenkins CI pipeline.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
