### PR TITLE
Use new interface for input names in image classification container

### DIFF
--- a/container/neo_template_image_classification.py
+++ b/container/neo_template_image_classification.py
@@ -49,7 +49,7 @@ class NeoImageClassificationPredictor():
         self.initialized = False
 
     def inference(self, data):
-        return self.model.run({self.model.input_names[0]: data})
+        return self.model.run({self.input_names[0]: data})
 
     def postprocess(self, preds):
         assert len(preds) == 1
@@ -77,6 +77,7 @@ class NeoImageClassificationPredictor():
             self.model = dlr.DLRModel(model_dir, dev_type='gpu')
         else:
             self.model = dlr.DLRModel(model_dir)
+        self.input_names = self.model.get_input_names()
         self.initialized = True
 
     def preprocess(self, context, data):


### PR DESCRIPTION
Since DLR now supports multiple backends, we need to call the polymorphic `get_input_names()` function to get the input names.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
