### PR TITLE
Fix configuration for MMS to optimize XGBoost inference performance

### DIFF
--- a/container/Dockerfile.cpu
+++ b/container/Dockerfile.cpu
@@ -46,6 +46,7 @@ COPY dockerd-entrypoint.sh /usr/local/bin/dockerd-entrypoint.sh
 COPY config.properties /home/model-server/config.properties
 
 COPY neo_template_$APP.py /home/model-server/neo_template.py
+COPY mms_config_$APP.sh /home/model-server/mms_config.sh
 
 RUN chmod +x /usr/local/bin/dockerd-entrypoint.sh \
     && chown -R model-server /home/model-server

--- a/container/Dockerfile.gpu
+++ b/container/Dockerfile.gpu
@@ -56,6 +56,7 @@ COPY dockerd-entrypoint.sh /usr/local/bin/dockerd-entrypoint.sh
 COPY config.properties /home/model-server/config.properties
 
 COPY neo_template_$APP.py /home/model-server/neo_template.py
+COPY mms_config_$APP.sh /home/model-server/mms_config.sh
 
 RUN chmod +x /usr/local/bin/dockerd-entrypoint.sh \
     && chown -R model-server /home/model-server

--- a/container/dockerd-entrypoint.sh
+++ b/container/dockerd-entrypoint.sh
@@ -2,8 +2,8 @@
 set -e
 set -x
 
-MMS_NUM_WORKER=1
-MMS_NUM_THREAD_PER_WORKER=`nproc`
+source /home/model-server/mms_config.sh
+
 if [[ "$1" = "serve" ]]; then
     shift 1
     cp -v -r /opt/ml/model/* /home/model-server/model

--- a/container/mms_config_image_classification.sh
+++ b/container/mms_config_image_classification.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+MMS_NUM_WORKER=1
+MMS_NUM_THREAD_PER_WORKER=`nproc`

--- a/container/mms_config_mxnet_byom.sh
+++ b/container/mms_config_mxnet_byom.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+MMS_NUM_WORKER=1
+MMS_NUM_THREAD_PER_WORKER=`nproc`

--- a/container/mms_config_xgboost.sh
+++ b/container/mms_config_xgboost.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+MMS_NUM_WORKER=`nproc`
+MMS_NUM_THREAD_PER_WORKER=1

--- a/src/dlr.cc
+++ b/src/dlr.cc
@@ -7,6 +7,7 @@
 #include <iterator>
 #include <vector>
 #include <cstring>
+#include <cstdlib>
 #include <string>
 #include <numeric>
 
@@ -228,7 +229,10 @@ void DLRModel::SetupTVMModule(const std::string& model_path) {
 
 void DLRModel::SetupTreeliteModule(const std::string& model_path) {
   ModelPath paths = get_treelite_paths(model_path);
-  int num_worker_threads = -1; // use the maximum amount of threads
+  // If OMP_NUM_THREADS is set, use it to determine number of threads;
+  // if not, use the maximum amount of threads
+  const char* val = std::getenv("OMP_NUM_THREADS");
+  int num_worker_threads = (val ? std::atoi(val) : -1);
   num_inputs_ = 1;
   num_outputs_ = 1;
   // Give a dummy input name to Treelite model.


### PR DESCRIPTION
For XGBoost models, raw inference time is minuscule compared to serving overheads. So to best utilize multi-core CPUs, it's actually better to allocate many worker processes, and give each process one thread. This is quite different from deep learning workloads, where we allocate 1 single worker and give it many threads.

* Make Treelite runtime aware of environment variable `OMP_NUM_THREADS`.
* Use different process X thread configurations for XGBoost and Deep Learning

Benchmark results

* Latency below is measured for each batch, where each batch contains 100 rows
* Model used : learning-to-rank with YAHOO dataset, 1600 trees, 6 max depth
* Latency was measured by running inference containers in C5.9xlarge machine; the client (Apache Bench) was co-located with the inference container, so as to eliminate network latency.

**Median (P50) Latency**

|# concurrent requests| Neo (current)| Neo (PROPOSED FIX)|
|---|---|---|
|1|63|55|
|2|124|56|
|5|311|57|
|10|622|58|
		
**Throughput (QPS)**

|# concurrent requests| Neo (current)| Neo (PROPOSED FIX)|
|---|---|---|
|1|15.81|18.16|
|2|16.09|35.45|
|5|16.08|86.37|
|10|16.07|168.22|

It is quite clear that for XGBoost, serving takes vast majority of time (> 90%), not raw inference. So it makes sense to allocate lots of worker processes, so that we can handle high number of concurrent requests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
