### PR TITLE
Add tests/cpp placeholders

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -214,22 +214,24 @@ add_custom_target(combined_lib
         )
 
 # Tests
-set(TEST_EXECS "")
-file(GLOB TEST_SRCS test/cpp/*.cc)
-find_library(GTEST_LIB NAMES libgtest.a gtest)
+if(NOT ANDROID_BUILD)
+  include(cmake/googletest.cmake)
+  fetch_googletest(
+    ${PROJECT_SOURCE_DIR}/cmake
+    ${PROJECT_BINARY_DIR}/googletest
+    )
 
-if(GTEST_LIB)
+  enable_testing()
+
+  file(GLOB TEST_SRCS tests/cpp/*.cc)
   foreach(__srcpath ${TEST_SRCS})
     get_filename_component(__srcname ${__srcpath} NAME)
     string(REPLACE ".cc" "" __execname ${__srcname})
     add_executable(${__execname} ${__srcpath})
-    list(APPEND TEST_EXECS ${__execname})
-    target_link_libraries(${__execname}
-      dlr ${GTEST_LIB} pthread)
-    set_target_properties(${__execname} PROPERTIES EXCLUDE_FROM_ALL 1)
-    set_target_properties(${__execname} PROPERTIES EXCLUDE_FROM_DEFAULT_BUILD 1)
+    target_link_libraries(${__execname} dlr gtest_main)
+    add_test(NAME ${__execname} COMMAND ${__execname})
+    message(STATUS "Added Test: " ${__execname})
   endforeach()
-  add_custom_target(dlrtest DEPENDS ${TEST_EXECS})
 endif()
 
 # Group sources

--- a/cmake/googletest-download.cmake
+++ b/cmake/googletest-download.cmake
@@ -1,0 +1,20 @@
+# code copied from https://crascit.com/2015/07/25/cmake-gtest/
+cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
+
+project(googletest-download NONE)
+
+include(ExternalProject)
+
+ExternalProject_Add(
+  googletest
+  SOURCE_DIR "@GOOGLETEST_DOWNLOAD_ROOT@/googletest-src"
+  BINARY_DIR "@GOOGLETEST_DOWNLOAD_ROOT@/googletest-build"
+  GIT_REPOSITORY
+    https://github.com/google/googletest.git
+  GIT_TAG
+    release-1.8.0
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND ""
+  INSTALL_COMMAND ""
+  TEST_COMMAND ""
+  )

--- a/cmake/googletest.cmake
+++ b/cmake/googletest.cmake
@@ -1,0 +1,32 @@
+# the following code to fetch googletest
+# is inspired by and adapted after https://crascit.com/2015/07/25/cmake-gtest/
+# download and unpack googletest at configure time
+
+macro(fetch_googletest _download_module_path _download_root)
+    set(GOOGLETEST_DOWNLOAD_ROOT ${_download_root})
+    configure_file(
+        ${_download_module_path}/googletest-download.cmake
+        ${_download_root}/CMakeLists.txt
+        @ONLY
+        )
+    unset(GOOGLETEST_DOWNLOAD_ROOT)
+
+    execute_process(
+        COMMAND
+            "${CMAKE_COMMAND}" -G "${CMAKE_GENERATOR}" .
+        WORKING_DIRECTORY
+            ${_download_root}
+        )
+    execute_process(
+        COMMAND
+            "${CMAKE_COMMAND}" --build .
+        WORKING_DIRECTORY
+            ${_download_root}
+        )
+
+    # adds the targers: gtest, gtest_main, gmock, gmock_main
+    add_subdirectory(
+        ${_download_root}/googletest-src
+        ${_download_root}/googletest-build
+        )
+endmacro()

--- a/tests/cpp/dlr_treelite_test.cc
+++ b/tests/cpp/dlr_treelite_test.cc
@@ -1,0 +1,13 @@
+#include <gtest/gtest.h>
+#include "dlr.h"
+
+
+TEST(Treelite, Test1) {
+  EXPECT_EQ(1, 1);
+}
+
+int main(int argc, char ** argv) {
+  testing::InitGoogleTest(&argc, argv);
+  testing::FLAGS_gtest_death_test_style = "threadsafe";
+  return RUN_ALL_TESTS();
+}

--- a/tests/cpp/dlr_tvm_test.cc
+++ b/tests/cpp/dlr_tvm_test.cc
@@ -1,0 +1,13 @@
+#include <gtest/gtest.h>
+#include "dlr.h"
+
+
+TEST(TVM, Test1) {
+  EXPECT_EQ(1, 1);
+}
+
+int main(int argc, char ** argv) {
+  testing::InitGoogleTest(&argc, argv);
+  testing::FLAGS_gtest_death_test_style = "threadsafe";
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
- Add placeholder for TVM and Treelite C++ modules.
- Enable GTest (for non Android builds)
- Automatically download and build GTest lib during `cmake ..`

To run the test:
```
# use make test
make test

# or run the tests directly
./dlr_tvm_test
./dlr_treelite_test
```

`make test` output:
```
Scanning dependencies of target dlr
[ 94%] Linking CXX shared library ../lib/libdlr.dylib
[ 94%] Built target dlr
Scanning dependencies of target dlr_tvm_test
Scanning dependencies of target dlr_treelite_test
[ 94%] Building CXX object CMakeFiles/dlr_treelite_test.dir/tests/cpp/dlr_treelite_test.cc.o
[ 94%] Building CXX object CMakeFiles/dlr_tvm_test.dir/tests/cpp/dlr_tvm_test.cc.o
[100%] Linking CXX executable dlr_tvm_test
[100%] Built target dlr_tvm_test
[100%] Linking CXX executable dlr_treelite_test
[100%] Built target dlr_treelite_test


f45c8998e8eb:build pivovaa$ make test
Running tests...
Test project /Users/pivovaa/workplace/neo-ai-dlr/build
    Start 1: dlr_treelite_test
1/2 Test #1: dlr_treelite_test ................   Passed    0.01 sec
    Start 2: dlr_tvm_test
2/2 Test #2: dlr_tvm_test .....................   Passed    0.01 sec

100% tests passed, 0 tests failed out of 2

Total Test time (real) =   0.02 sec
```

Direct run output:
```
f45c8998e8eb:build pivovaa$ ./dlr_tvm_test 
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from TVM
[ RUN      ] TVM.Test1
[       OK ] TVM.Test1 (0 ms)
[----------] 1 test from TVM (0 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (0 ms total)
[  PASSED  ] 1 test.


f45c8998e8eb:build pivovaa$ ./dlr_treelite_test 
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from Treelite
[ RUN      ] Treelite.Test1
[       OK ] Treelite.Test1 (0 ms)
[----------] 1 test from Treelite (0 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (0 ms total)
[  PASSED  ] 1 test.
```