### PR TITLE
Add TFLite C++ adapter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ build
 dist
 *.pyc
 lib
+3rdparty/tensorflow*
+3rdparty/flatbuffers*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,19 +68,12 @@ include_directories("${TREELITE_SRC}/include")
 include_directories("${TREELITE_SRC}/runtime/native/include")
 include_directories("${PROJECT_SOURCE_DIR}/include")
 
-FILE(GLOB_RECURSE DLR_SRC
+# Add only top level *.cc files (non-RECURSE)
+FILE(GLOB DLR_SRC
     "src/*.cc"
     ${TVM_SRC}/src/runtime/dso_module.cc
     ${TVM_SRC}/src/runtime/cpu_device_api.cc
     ${TVM_SRC}/src/contrib/sort/sort.cc
-)
-FILE(GLOB_RECURSE DLR_INC 
-    "src/*.h"
-    "include/*.h"
-    "${TVM_SRC}/src/*.h" 
-    "${TVM_SRC}/include/*.h"
-    "${TREELITE_SRC}/src/*.h" 
-    "${TREELITE_SRC}/include/*.h"
 )
 
 if(USE_OPENCL)
@@ -175,6 +168,47 @@ if(WITH_TENSORFLOW_LITE_LIB)
         message(FATAL_ERROR "WITH_TENSORFLOW_LITE_LIB should point to static library libtensorflow-lite.a")
     endif()
     message("Adding libtensorflow-lite.a to DLR shared library")
+
+    # Download Tensorflow and FlatBuffers source code
+    set(TENSORFLOW_VER "1.13.2")
+    set(TENSORFLOW_SHA1 "78bb81d1e78ac9c3b092dee65f6b6b3cee23b9ae")
+    set(FLATBUFFERS_VER "1.11.0")
+    set(FLATBUFFERS_SHA1 "2b2633902c57c6980b3a41b44d8ad933f214d71d")
+    set(TENSORFLOW_URL "https://github.com/tensorflow/tensorflow/archive/v${TENSORFLOW_VER}.tar.gz")
+    set(TENSORFLOW_TGZ "/tmp/tensorflow-${TENSORFLOW_VER}.tar.gz")
+    set(TENSORFLOW_SRC "${PROJECT_SOURCE_DIR}/3rdparty/tensorflow-${TENSORFLOW_VER}")
+    set(FLATBUFFERS_URL "https://github.com/google/flatbuffers/archive/v${FLATBUFFERS_VER}.tar.gz")
+    set(FLATBUFFERS_TGZ "/tmp/flatbuffers-${FLATBUFFERS_VER}.tar.gz")
+    set(FLATBUFFERS_SRC "${PROJECT_SOURCE_DIR}/3rdparty/flatbuffers-${FLATBUFFERS_VER}")
+
+    download_file(${TENSORFLOW_URL} ${TENSORFLOW_TGZ} SHA1 ${TENSORFLOW_SHA1})
+    download_file(${FLATBUFFERS_URL} ${FLATBUFFERS_TGZ} SHA1 ${FLATBUFFERS_SHA1})
+
+    # Extract Tensorflow and FlatBuffers source code
+    message(STATUS "Extracting " ${TENSORFLOW_TGZ} " ...")
+    execute_process(
+        COMMAND rm -rf ${PROJECT_SOURCE_DIR}/3rdparty/tensorflow*
+        COMMAND tar -C ${PROJECT_SOURCE_DIR}/3rdparty -zxf ${TENSORFLOW_TGZ}
+        RESULT_VARIABLE tf_ret
+    )
+    if(NOT tf_ret EQUAL "0")
+        message(FATAL_ERROR "Failed to extract " ${TENSORFLOW_TGZ})
+    endif()
+    message(STATUS "Extracting " ${FLATBUFFERS_TGZ} " ...")
+    execute_process(
+        COMMAND rm -rf ${PROJECT_SOURCE_DIR}/3rdparty/flatbuffers*
+        COMMAND tar -C ${PROJECT_SOURCE_DIR}/3rdparty -zxf ${FLATBUFFERS_TGZ}
+        RESULT_VARIABLE fb_ret
+    )
+    if(NOT fb_ret EQUAL "0")
+        message(FATAL_ERROR "Failed to extract " ${FLATBUFFERS_TGZ})
+    endif()
+
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -DDLR_TFLITE")
+    include_directories("${TENSORFLOW_SRC}")
+    include_directories("${FLATBUFFERS_SRC}/include")
+    list(APPEND DLR_SRC "src/dlr_tflite/dlr_tflite.cc")
+
     if(ANDROID_BUILD) # Android build needs additional library liblog
         list(APPEND TVM_RUNTIME_LINKER_LIBS -Wl,--whole-archive ${WITH_TENSORFLOW_LITE_LIB} -Wl,--no-whole-archive -llog)
     elseif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin") # Mac OS linker is different from Linux.
@@ -224,6 +258,10 @@ if(NOT ANDROID_BUILD)
   enable_testing()
 
   file(GLOB TEST_SRCS tests/cpp/*.cc)
+  if(WITH_TENSORFLOW_LITE_LIB)
+    file(GLOB TFLITE_TEST_SRCS tests/cpp/dlr_tflite/*.cc)
+    list(APPEND TEST_SRCS ${TFLITE_TEST_SRCS})
+  endif()
   foreach(__srcpath ${TEST_SRCS})
     get_filename_component(__srcname ${__srcpath} NAME)
     string(REPLACE ".cc" "" __execname ${__srcname})
@@ -232,6 +270,23 @@ if(NOT ANDROID_BUILD)
     add_test(NAME ${__execname} COMMAND ${__execname})
     message(STATUS "Added Test: " ${__execname})
   endforeach()
+
+  if(WITH_TENSORFLOW_LITE_LIB)
+      # Download Test TFLite model and input data
+      file(MAKE_DIRECTORY mobilenet_v2_0.75_224)
+      download_file(
+        https://neo-ai-dlr-test-artifacts.s3-us-west-2.amazonaws.com/tflite-models/mobilenet_v2_0.75_224.tflite
+        ./mobilenet_v2_0.75_224/mobilenet_v2_0.75_224.tflite
+        SHA1
+        c653a09facaf2dfb5e3910030b3f74ad04259e30
+      )
+      download_file(
+        https://neo-ai-dlr-test-artifacts.s3-us-west-2.amazonaws.com/tflite-models/cat224-3.txt
+        ./cat224-3.txt
+        SHA1
+        e35e82f3371bed37caa7ecece417f50876414077
+      )
+  endif() # WITH_TENSORFLOW_LITE_LIB
 endif()
 
 # Group sources

--- a/cmake/Utils.cmake
+++ b/cmake/Utils.cmake
@@ -40,3 +40,15 @@ function(set_output_directory target dir)
     ARCHIVE_OUTPUT_DIRECTORY_RELEASE ${dir}
   )
 endfunction(set_output_directory)
+
+# downloading and optionally verifying the checksum of files
+function(download_file url filename hash_type hash)
+  if(NOT EXISTS ${filename})
+    message(STATUS "Downloading: " ${url} " to " ${filename})
+    file(DOWNLOAD ${url} ${filename}
+         TIMEOUT 60  # seconds
+         EXPECTED_HASH ${hash_type}=${hash}
+         TLS_VERIFY ON
+    )
+  endif()
+endfunction(download_file)

--- a/include/dlr.h
+++ b/include/dlr.h
@@ -36,6 +36,21 @@ int CreateDLRModel(DLRModelHandle *handle,
                    int dev_type,
                    int dev_id);
 
+#ifdef DLR_TFLITE
+/*!
+ \brief Creates a DLR model from TFLite
+ \param handle The pointer to save the model handle.
+ \param model_path Path to tflite file or to the top-level directory containing tflite file
+ \param threads Number of threads to use.
+ \param use_nnapi Use NNAPI, 0 - false, 1 - true.
+ \return 0 for success, -1 for error. Call DLRGetLastError() to get the error message.
+ */
+int CreateDLRModelFromTFLite(DLRModelHandle *handle,
+                   const char *model_path,
+                   int threads,
+                   int use_nnapi);
+#endif // DLR_TFLITE
+
 /*!
  \brief Deletes a DLR model.
  \param handle The model handle returned from CreateDLRModel().
@@ -160,7 +175,7 @@ int GetDLROutputSizeDim(DLRModelHandle* handle,
 const char* DLRGetLastError();
 
 /*!
- \brief Gets the name of the backend ("tvm" / "treelite")
+ \brief Gets the name of the backend ("tvm", "treelite" or "tflite")
  \param handle The model handle returned from CreateDLRModel().
  \param name The pointer to save the null-terminated string containing the name.
  \return 0 for success, -1 for error. Call DLRGetLastError() to get the error message.

--- a/include/dlr_common.h
+++ b/include/dlr_common.h
@@ -54,7 +54,8 @@ inline bool EndsWith(const std::string& mainStr, const std::string& toMatch) {
 
 enum class DLRBackend {
   kTVM,
-  kTREELITE
+  kTREELITE,
+  kTFLITE
 };
 
 /*! \brief Get the backend based on the contents of the model folder.

--- a/include/dlr_tflite/dlr_tflite.h
+++ b/include/dlr_tflite/dlr_tflite.h
@@ -1,0 +1,56 @@
+#ifndef DLR_TFLITE_H_
+#define DLR_TFLITE_H_
+
+#include "tensorflow/lite/kernels/register.h"
+#include "dlr_common.h"
+
+namespace dlr {
+
+/*! \brief Get the paths of the TFLite model files.
+ */
+std::string GetTFLiteFile(const std::string& dirname);
+
+typedef struct {
+  int id;
+  std::string name;
+  TfLiteType type;
+  int dim;
+  std::vector<int> shape;
+  int64_t size;
+  size_t bytes;
+} TensorSpec;
+
+
+/*! \brief class TFLiteModel
+ */
+class TFLiteModel: public DLRModel {
+ private:
+  tflite::StderrReporter* error_reporter_;
+  std::unique_ptr<tflite::FlatBufferModel> model_;
+  std::unique_ptr<tflite::Interpreter> interpreter_;
+  std::vector<TensorSpec> input_tensors_spec_;
+  std::vector<TensorSpec> output_tensors_spec_;
+  void GenTensorSpec(bool isInput);
+  int GetInputId(const char* name);
+ public:
+  /*! \brief Load model files from given folder path.
+   */
+  explicit TFLiteModel(const std::string& model_path, const DLContext& ctx, const int threads, const bool use_nnapi);
+  ~TFLiteModel();
+
+  virtual const char* GetInputName(int index) const override;
+  virtual const char* GetWeightName(int index) const override;
+  virtual std::vector<std::string> GetWeightNames() const override;
+  virtual void GetInput(const char* name, float* input) override;
+  virtual void SetInput(const char* name, const int64_t* shape, float* input, int dim) override;
+  virtual void Run() override;
+  virtual void GetOutput(int index, float* out) override;
+  virtual void GetOutputShape(int index, int64_t* shape) const override;
+  virtual void GetOutputSizeDim(int index, int64_t* size, int* dim) override;
+  virtual const char* GetBackend() const override;
+};
+
+} // namespace dlr
+
+
+#endif  // DLR_TFLITE_H_

--- a/src/dlr_common.cc
+++ b/src/dlr_common.cc
@@ -46,14 +46,19 @@ void dlr::ListDir(const std::string& dirname, std::vector<std::string>& paths) {
 }
 
 DLRBackend dlr::GetBackend(const std::string& dirname) {
+  // Support the case where user provides full path to tflite file.
+  if (EndsWith(dirname, ".tflite")) {
+    return DLRBackend::kTFLITE;
+  }
+  // Scan Directory content to guess the backend.
   std::vector<std::string> paths;
   dlr::ListDir(dirname, paths);
-  DLRBackend backend = DLRBackend::kTREELITE;
   for (auto filename: paths) {
-    if (EndsWith(filename, ".params")){
-      backend = DLRBackend::kTVM;
-      break;
+    if (EndsWith(filename, ".params")) {
+      return DLRBackend::kTVM;
+    } else if (EndsWith(filename, ".tflite")) {
+      return DLRBackend::kTFLITE;
     }
   }
-  return backend;
+  return DLRBackend::kTREELITE;
 }

--- a/src/dlr_tflite/dlr_tflite.cc
+++ b/src/dlr_tflite/dlr_tflite.cc
@@ -1,0 +1,189 @@
+#include "dlr_tflite/dlr_tflite.h"
+#include <fstream>
+#include <numeric>
+
+
+using namespace dlr;
+
+std::string dlr::GetTFLiteFile(const std::string& dirname) {
+  // Support the case where user provides full path to tflite file.
+  if (EndsWith(dirname, ".tflite")) {
+    return dirname;
+  }
+  // Scan Dir to find tflite file and check that only one tflite file is provided.
+  std::string tflite_file;
+  std::vector<std::string> paths_vec;
+  ListDir(dirname, paths_vec);
+  for (auto filename : paths_vec) {
+    std::string basename = GetBasename(filename);
+    if (EndsWith(filename, ".tflite")) {
+      if (tflite_file.empty()) {
+        tflite_file = filename;
+      } else {
+        LOG(FATAL) << "Multiple .tflite files under the folder: " << dirname;
+      }
+    }
+  }
+  if (tflite_file.empty()) {
+    LOG(FATAL) << "No TFLite model file found under folder: " << dirname;
+  }
+  return tflite_file;
+}
+
+void TFLiteModel::GenTensorSpec(bool isInput) {
+  std::vector<int> t_ids = isInput ? interpreter_->inputs() : interpreter_->outputs();
+  size_t n = t_ids.size();
+  for (int i = 0; i < n; i++) {
+    auto t_id = t_ids[i];
+    TfLiteTensor* tensor = interpreter_->tensor(t_id);
+    TensorSpec t_spec;
+    t_spec.id = t_id;
+    t_spec.name = std::string(tensor->name);
+    t_spec.type = tensor->type;
+    t_spec.dim = tensor->dims->size;
+    // Use vector(first, last) to copy int* to vector. Do not keep pointers of internal TF data structures.
+    t_spec.shape = std::vector<int>(tensor->dims->data, tensor->dims->data + tensor->dims->size);
+    t_spec.bytes = tensor->bytes;
+    int64_t t_sz = 1;
+    for (int j = 0; j < t_spec.dim; j++) {
+      t_sz *= t_spec.shape[j];
+    }
+    t_spec.size = t_sz;
+    if (isInput) {
+      input_tensors_spec_.push_back(t_spec);
+      // Fill in input_names_ vector as well because it is defined in base class DLRModel
+      input_names_.push_back(t_spec.name);
+    } else {
+      output_tensors_spec_.push_back(t_spec);
+    }
+  }
+}
+
+int TFLiteModel::GetInputId(const char* name) {
+  // In most of the cases it will be just 1 element in the vector.
+  // Scan vector to find tensor by name.
+  for (int i = 0; i < num_inputs_; i++) {
+    if (input_tensors_spec_[i].name.compare(name) == 0) {
+      return i;
+    }
+  }
+  LOG(FATAL) << "Input Tensor not found, name: " << name;
+  return -1; // unreachable
+}
+
+// Constructor
+TFLiteModel::TFLiteModel(const std::string& model_path, const DLContext& ctx,
+                         const int threads, const bool use_nnapi): DLRModel(ctx, DLRBackend::kTFLITE) {
+  const char* tflite_file = GetTFLiteFile(model_path).c_str();
+
+  // ensure the model and error_reporter lifetime is at least as long as interpreter's lifetime
+  error_reporter_ = new tflite::StderrReporter();
+  model_ = tflite::FlatBufferModel::BuildFromFile(tflite_file, error_reporter_);
+  if (!model_) {
+    LOG(FATAL) << "Failed to load the model: " << tflite_file;
+    return; // unreachable
+  }
+  // op_resolver does not need to exist for the duration of interpreter objects.
+  tflite::ops::builtin::BuiltinOpResolver resolver;
+  tflite::InterpreterBuilder builder(*model_, resolver);
+  if (builder(&interpreter_) != kTfLiteOk) {
+    LOG(FATAL) << "Failed to build TFLite Interpreter";
+    return; // unreachable
+  }
+  interpreter_->UseNNAPI(use_nnapi);
+  LOG(INFO) << "Use NNAPI: " << (use_nnapi ? "true" : "false");
+  if (threads > 0) {
+    interpreter_->SetNumThreads(threads);
+    LOG(INFO) << "Set Num Threads: " << threads;
+  }
+
+  // AllocateTensors
+  if (interpreter_->AllocateTensors() != kTfLiteOk) {
+    LOG(FATAL) << "Failed to allocate tensors";
+    return; // unreachable
+  }
+  LOG(INFO) << "AllocateTensors - OK";
+
+  // Save the number of inputs
+  num_inputs_ = interpreter_->inputs().size();
+  GenTensorSpec(true);
+
+  // Save the number of outputs
+  num_outputs_ = interpreter_->outputs().size();
+  GenTensorSpec(false);
+
+  LOG(INFO) << "TFLiteModel was created";
+}
+
+// Destructor
+TFLiteModel::~TFLiteModel() {
+  interpreter_.reset();
+  model_.reset();
+  delete error_reporter_;
+  LOG(INFO) << "TFLiteModel was deleted";
+}
+
+std::vector<std::string> TFLiteModel::GetWeightNames() const {
+  LOG(FATAL) << "GetWeightNames is not supported by TFLite backend";
+  return std::vector<std::string>(); // unreachable
+}
+
+const char* TFLiteModel::GetInputName(int index) const {
+  CHECK_LT(index, num_inputs_) << "Input index is out of range.";
+  return input_names_[index].c_str();
+}
+
+const char* TFLiteModel::GetWeightName(int index) const {
+  LOG(FATAL) << "GetWeightName is not supported by TFLite backend";
+  return ""; // unreachable
+}
+
+void TFLiteModel::SetInput(const char* name, const int64_t* shape, float* input, int dim) {
+  int index = GetInputId(name);
+
+  // Check Size and Dim
+  CHECK_EQ(dim, input_tensors_spec_[index].dim) << "Incorrect input dim";
+  for (int i = 0; i < dim; i++) {
+    CHECK_EQ(shape[i], input_tensors_spec_[index].shape[i]) << "Incorrect input shape";
+  }
+
+  float* in_t_data = interpreter_->typed_input_tensor<float>(index);
+  std::memcpy(in_t_data, input, input_tensors_spec_[index].bytes);
+}
+
+void TFLiteModel::GetInput(const char* name, float* input) {
+  int index = GetInputId(name);
+  const float* in_t_data = interpreter_->typed_input_tensor<float>(index);
+  std::memcpy(input, in_t_data, input_tensors_spec_[index].bytes);
+}
+
+void TFLiteModel::GetOutputShape(int index, int64_t* shape) const {
+  CHECK_LT(index, num_outputs_) << "Output index is out of range.";
+  for (int i = 0; i < output_tensors_spec_[index].dim; i++) {
+    shape[i] = (int64_t) output_tensors_spec_[index].shape[i];
+  }
+}
+
+void TFLiteModel::GetOutput(int index, float* out) {
+  CHECK_LT(index, num_outputs_) << "Output index is out of range.";
+  const float* out_t_data = interpreter_->typed_output_tensor<float>(index);
+  std::memcpy(out, out_t_data, output_tensors_spec_[index].bytes);
+}
+
+void TFLiteModel::GetOutputSizeDim(int index, int64_t* size, int* dim) {
+  CHECK_LT(index, num_outputs_) << "Output index is out of range.";
+  *size = output_tensors_spec_[index].size;
+  *dim = output_tensors_spec_[index].dim;
+}
+
+void TFLiteModel::Run() {
+  // Invoke
+  if (interpreter_->Invoke() != kTfLiteOk) {
+    LOG(FATAL) << "Failed to invoke interpreter!";
+    return; // unreachable
+  }
+}
+
+const char* TFLiteModel::GetBackend() const {
+  return "tflite";
+}

--- a/tests/cpp/dlr_tflite/dlr_tflite_test.cc
+++ b/tests/cpp/dlr_tflite/dlr_tflite_test.cc
@@ -1,0 +1,192 @@
+#include <gtest/gtest.h>
+#include "dlr.h"
+#include <dmlc/logging.h>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+
+
+float* LoadImageAndPreprocess(const std::string& img_path, size_t size) {
+  std::string line;
+  std::ifstream fp(img_path);
+  float* img = new float[size];
+  size_t i = 0;
+  if (fp.is_open()) {
+    while (getline (fp, line) && i < size) {
+      int v = std::stoi(line);
+      float fv = 2.0f / 255.0f * v - 1.0f;
+      img[i++] = fv;
+    }
+    fp.close();
+  }
+
+  EXPECT_EQ(size, i);
+  LOG(INFO) << "Image read - OK, float[" << i << "]" ;
+  return img;
+}
+
+int ArgMax(float* data, int size) {
+  int idx = 0;
+  float v = 0.0f;
+  for (int i = 0; i < size; i++) {
+    float vi = data[i];
+    if (vi > v) {
+      idx = i;
+      v = vi;
+    }
+  }
+  return idx;
+}
+
+void CheckAllDLRMethods(DLRModelHandle& handle) {
+  // GetDLRBackend
+  const char* backend_name;
+  if (GetDLRBackend(&handle, &backend_name)) {
+    FAIL() << "GetDLRBackend failed";
+  }
+  LOG(INFO) << "GetDLRBackend: " << backend_name;
+  EXPECT_STREQ("tflite", backend_name);
+
+  // GetDLRNumInputs
+  int num_inputs;
+  if (GetDLRNumInputs(&handle, &num_inputs)) {
+    FAIL() << "GetDLRNumInputs failed";
+  }
+  LOG(INFO) << "GetDLRNumInputs: " << num_inputs;
+  EXPECT_EQ(1, num_inputs);
+
+  // GetDLRNumOutputs
+  int num_outputs;
+  if (GetDLRNumOutputs(&handle, &num_outputs)) {
+    FAIL() << "GetDLRNumOutputs failed";
+  }
+  LOG(INFO) << "GetDLRNumOutputs: " << num_outputs;
+  EXPECT_EQ(1, num_outputs);
+
+  // GetDLRNumWeights
+  int num_weights;
+  if (GetDLRNumWeights(&handle, &num_weights)) {
+    FAIL() << "GetDLRNumWeights failed";
+  }
+  LOG(INFO) << "GetDLRNumWeights: " << num_weights;
+  EXPECT_EQ(0, num_weights);
+
+  // GetDLRInputName
+  const char* input_name;
+  if (GetDLRInputName(&handle, 0, &input_name)) {
+    FAIL() << "GetDLRInputName failed";
+  }
+  LOG(INFO) << "DLRInputName: " << input_name;
+  EXPECT_STREQ("input", input_name);
+
+  // GetDLROutputSizeDim
+  int64_t out_size;
+  int out_dim;
+  if (GetDLROutputSizeDim(&handle, 0, &out_size, &out_dim)) {
+    FAIL() << "GetDLROutputSizeDim failed";
+  }
+  LOG(INFO) << "GetDLROutputSizeDim.size: " << out_size;
+  LOG(INFO) << "GetDLROutputSizeDim.dim: " << out_dim;
+  EXPECT_EQ(1001, out_size);
+  EXPECT_EQ(2, out_dim);
+
+  // GetDLROutputShape
+  int64_t shape[out_dim];
+  if (GetDLROutputShape(&handle, 0, shape)) {
+    FAIL() << "GetDLROutputShape failed";
+  }
+  std::stringstream ss;
+  ss << "GetDLROutputShape: (" << shape[0];
+  for (int i = 1; i < out_dim; i++) {
+    ss << "," << shape[i];
+  }
+  ss << ")";
+  LOG(INFO) << ss.str();
+  const int64_t exp_shape[2] = {1, 1001};
+  EXPECT_TRUE(std::equal(std::begin(exp_shape), std::end(exp_shape), shape));
+
+  // Load image
+  size_t img_size = 224*224*3;
+  float* img = LoadImageAndPreprocess("cat224-3.txt", img_size);
+  LOG(INFO) << "Input sample: " << img[0] << "," << img[1] << " ... " << img[img_size - 1];
+
+  // SetDLRInput
+  const int64_t in_shape[4] = {1,224,224,3};
+  if (SetDLRInput(&handle, input_name, in_shape, img, 4)) {
+    FAIL() << "SetDLRInput failed";
+  }
+  LOG(INFO) << "SetDLRInput - OK";
+
+  // GetDLRInput
+  float* input2 = new float[img_size];
+  if (GetDLRInput(&handle, input_name, input2)) {
+    FAIL() << "GetDLRInput failed";
+  }
+  EXPECT_TRUE(std::equal(img, img + img_size, input2));
+
+  // RunDLRModel
+  if (RunDLRModel(&handle)) {
+    FAIL() << "RunDLRModel failed";
+  }
+  LOG(INFO) << "RunDLRModel - OK";
+
+  // GetDLROutput
+  float* output = new float[out_size];
+  if (GetDLROutput(&handle, 0, output)) {
+    FAIL() << "GetDLROutput failed";
+  }
+  size_t max_id = ArgMax(output, out_size);
+  LOG(INFO) << "ArgMax: " << max_id << ", Prop: " << output[max_id];
+  // TFLite class range is 1-1000 (output size 1001)
+  // Imagenet1000 class range is 0-999 https://gist.github.com/yrevar/942d3a0ac09ec9e5eb3a
+  EXPECT_EQ(283, max_id); // TFLite 283 maps to Imagenet 282 - tiger cat
+  EXPECT_GE(output[max_id], 0.5f);
+  EXPECT_GE(output[282], 0.3f); // TFLite 282 maps to Imagenet 281 - tabby, tabby cat
+
+  // clean up
+  delete [] img;
+  delete [] input2;
+  delete [] output;
+}
+
+TEST(TFLite, CreateDLRModelFromTFLite) {
+  // CreateDLRModelFromTFLite (use tflite file)
+  const char* model_file = "./mobilenet_v2_0.75_224/mobilenet_v2_0.75_224.tflite";
+  int threads = 2;
+  int use_nn_api = 0;
+
+  DLRModelHandle handle;
+  if (CreateDLRModelFromTFLite(&handle, model_file, threads, use_nn_api)) {
+    FAIL() << "CreateDLRModelFromTFLite failed";
+  }
+  LOG(INFO) << "CreateDLRModelFromTFLite - OK";
+
+  CheckAllDLRMethods(handle);
+
+  // DeleteDLRModel
+  DeleteDLRModel(&handle);
+}
+
+TEST(TFLite, CreateDLRModel) {
+  // CreateDLRModel (use folder containing tflite file)
+  const char* model_dir = "./mobilenet_v2_0.75_224";
+  int dev_type = 1; // 1 - kDLCPU
+  int dev_id = 0;
+
+  DLRModelHandle handle;
+  if (CreateDLRModel(&handle, model_dir, dev_type, dev_id)) {
+    FAIL() << "CreateDLRModel failed";
+  }
+  LOG(INFO) << "CreateDLRModel - OK";
+
+  CheckAllDLRMethods(handle);
+
+  // DeleteDLRModel
+  DeleteDLRModel(&handle);
+}
+
+int main(int argc, char ** argv) {
+  testing::InitGoogleTest(&argc, argv);
+  testing::FLAGS_gtest_death_test_style = "threadsafe";
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Changes:
- Add TFLite C++ adapter - `dlr_tflite.cc` `TFLiteModel`
- Create additional `CreateDLRModel` function (`CreateDLRModelFromTFLite `) which supports `threads` and `use_nnapi` parameters. (added only for TFLite builds)
- Add C++ tests for TFLite Adapted. Tests work against real model `mobilenet_v2_0.75_224.tflite` (10MB)
- Add `download_file` function to `cmake/Utils.cmake` to download test model and input data.

To build DLR with TFLite:
```
mkdir build
cd build
export TFA_LIB=???/libtensorflow-lite.a
cmake -DWITH_TENSORFLOW_LITE_LIB=$TFA_LIB ..
make -j$(npoc)
make test

# Alternatively you can run TFLite test directly
./dlr_tflite_test

# libdlr.so size will be 3MB (it will fully include TFLite runtime)
```

Download `libtensorflow-lite.a`:
- [Mac OS 10.12](https://neo-ai-dlr-test-artifacts.s3-us-west-2.amazonaws.com/tensorflow-lite/mac-10.12/r1.13/libtensorflow-lite.a)
- [Ubuntu 18.04](https://neo-ai-dlr-test-artifacts.s3-us-west-2.amazonaws.com/tensorflow-lite/linux_x86_64/r1.13/libtensorflow-lite.a)

If `-DWITH_TENSORFLOW_LITE_LIB=...` is not set then 
- DLR build will not compile `dlr_tflite.cc` and `dlr_tflite.h` files
- `3rdparty/tensorflow` header files will not be included
- Compiler macro def `-DDLR_TFLITE` will not be set. 
- `dlr.cc` will not have lines related to TFLite
- `dlr_tflite_test.cc` will not be compiled

`dlr_tflite_test` output:
```
f45c8998e8eb:build pivovaa$ ./dlr_tflite_test 
[==========] Running 2 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 2 tests from TFLite
[ RUN      ] TFLite.CreateDLRModelFromTFLite
[19:25:27] /Users/pivovaa/workplace/neo-ai-dlr/src/dlr_tflite/dlr_tflite.cc:94: Use NNAPI: false
[19:25:27] /Users/pivovaa/workplace/neo-ai-dlr/src/dlr_tflite/dlr_tflite.cc:97: Set Num Threads: 2
[19:25:27] /Users/pivovaa/workplace/neo-ai-dlr/src/dlr_tflite/dlr_tflite.cc:105: AllocateTensors - OK
[19:25:27] /Users/pivovaa/workplace/neo-ai-dlr/src/dlr_tflite/dlr_tflite.cc:115: TFLiteModel was created
[19:25:27] /Users/pivovaa/workplace/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_test.cc:162: CreateDLRModelFromTFLite - OK
[19:25:27] /Users/pivovaa/workplace/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_test.cc:47: GetDLRBackend: tflite
[19:25:27] /Users/pivovaa/workplace/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_test.cc:55: GetDLRNumInputs: 1
[19:25:27] /Users/pivovaa/workplace/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_test.cc:63: GetDLRNumOutputs: 1
[19:25:27] /Users/pivovaa/workplace/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_test.cc:71: GetDLRNumWeights: 0
[19:25:27] /Users/pivovaa/workplace/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_test.cc:79: DLRInputName: input
[19:25:27] /Users/pivovaa/workplace/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_test.cc:88: GetDLROutputSizeDim.size: 1001
[19:25:27] /Users/pivovaa/workplace/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_test.cc:89: GetDLROutputSizeDim.dim: 2
[19:25:27] /Users/pivovaa/workplace/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_test.cc:104: GetDLROutputShape: (1,1001)
[19:25:27] /Users/pivovaa/workplace/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_test.cc:24: Image read - OK, float[150528]
[19:25:27] /Users/pivovaa/workplace/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_test.cc:111: Input sample: 0.521569,0.498039 ... -0.615686
[19:25:27] /Users/pivovaa/workplace/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_test.cc:118: SetDLRInput - OK
[19:25:27] /Users/pivovaa/workplace/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_test.cc:131: RunDLRModel - OK
[19:25:27] /Users/pivovaa/workplace/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_test.cc:139: ArgMax: 283, Prop: 0.529855
[19:25:27] /Users/pivovaa/workplace/neo-ai-dlr/src/dlr_tflite/dlr_tflite.cc:123: TFLiteModel was deleted
[       OK ] TFLite.CreateDLRModelFromTFLite (79 ms)
[ RUN      ] TFLite.CreateDLRModel
[19:25:27] /Users/pivovaa/workplace/neo-ai-dlr/src/dlr_tflite/dlr_tflite.cc:94: Use NNAPI: false
[19:25:27] /Users/pivovaa/workplace/neo-ai-dlr/src/dlr_tflite/dlr_tflite.cc:105: AllocateTensors - OK
[19:25:27] /Users/pivovaa/workplace/neo-ai-dlr/src/dlr_tflite/dlr_tflite.cc:115: TFLiteModel was created
[19:25:27] /Users/pivovaa/workplace/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_test.cc:180: CreateDLRModel - OK
[19:25:27] /Users/pivovaa/workplace/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_test.cc:47: GetDLRBackend: tflite
[19:25:27] /Users/pivovaa/workplace/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_test.cc:55: GetDLRNumInputs: 1
[19:25:27] /Users/pivovaa/workplace/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_test.cc:63: GetDLRNumOutputs: 1
[19:25:27] /Users/pivovaa/workplace/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_test.cc:71: GetDLRNumWeights: 0
[19:25:27] /Users/pivovaa/workplace/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_test.cc:79: DLRInputName: input
[19:25:27] /Users/pivovaa/workplace/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_test.cc:88: GetDLROutputSizeDim.size: 1001
[19:25:27] /Users/pivovaa/workplace/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_test.cc:89: GetDLROutputSizeDim.dim: 2
[19:25:27] /Users/pivovaa/workplace/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_test.cc:104: GetDLROutputShape: (1,1001)
[19:25:27] /Users/pivovaa/workplace/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_test.cc:24: Image read - OK, float[150528]
[19:25:27] /Users/pivovaa/workplace/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_test.cc:111: Input sample: 0.521569,0.498039 ... -0.615686
[19:25:27] /Users/pivovaa/workplace/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_test.cc:118: SetDLRInput - OK
[19:25:28] /Users/pivovaa/workplace/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_test.cc:131: RunDLRModel - OK
[19:25:28] /Users/pivovaa/workplace/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_test.cc:139: ArgMax: 283, Prop: 0.529855
[19:25:28] /Users/pivovaa/workplace/neo-ai-dlr/src/dlr_tflite/dlr_tflite.cc:123: TFLiteModel was deleted
[       OK ] TFLite.CreateDLRModel (67 ms)
[----------] 2 tests from TFLite (146 ms total)

[----------] Global test environment tear-down
[==========] 2 tests from 1 test case ran. (147 ms total)
[  PASSED  ] 2 tests.
```