### PR TITLE
Fix GetTFLiteFile bug and linux build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,7 +215,7 @@ if(WITH_TENSORFLOW_LITE_LIB)
         # Use -force_load instead of --whole-archive
         list(APPEND TVM_RUNTIME_LINKER_LIBS -Wl,-force_load,${WITH_TENSORFLOW_LITE_LIB})
     else() # Regulal Linux Build
-        list(APPEND TVM_RUNTIME_LINKER_LIBS -Wl,--whole-archive ${WITH_TENSORFLOW_LITE_LIB} -Wl,--no-whole-archive)
+        list(APPEND TVM_RUNTIME_LINKER_LIBS -Wl,--whole-archive ${WITH_TENSORFLOW_LITE_LIB} -Wl,--no-whole-archive -ldl)
     endif()
 endif()
 

--- a/src/dlr_tflite/dlr_tflite.cc
+++ b/src/dlr_tflite/dlr_tflite.cc
@@ -74,11 +74,11 @@ int TFLiteModel::GetInputId(const char* name) {
 // Constructor
 TFLiteModel::TFLiteModel(const std::string& model_path, const DLContext& ctx,
                          const int threads, const bool use_nnapi): DLRModel(ctx, DLRBackend::kTFLITE) {
-  const char* tflite_file = GetTFLiteFile(model_path).c_str();
+  const std::string tflite_file = GetTFLiteFile(model_path);
 
   // ensure the model and error_reporter lifetime is at least as long as interpreter's lifetime
   error_reporter_ = new tflite::StderrReporter();
-  model_ = tflite::FlatBufferModel::BuildFromFile(tflite_file, error_reporter_);
+  model_ = tflite::FlatBufferModel::BuildFromFile(tflite_file.c_str(), error_reporter_);
   if (!model_) {
     LOG(FATAL) << "Failed to load the model: " << tflite_file;
     return; // unreachable


### PR DESCRIPTION
Fix the following situation:
```
# Bug
const char *cfff = GetTFLiteFile(model_path).c_str();
std::cerr << "cfff3: [" << cfff3 << "]" << std::endl;
cfff3: [???]

# Fixed
std::string fff = GetTFLiteFile(model_path);
std::cerr << "fff.c_str(): [" << fff.c_str() << "]" << std::endl;
fff.c_str(): [./mobilenet_v2_0.75_224/mobilenet_v2_0.75_224.tflite]
```
