### PR TITLE
Fix include dir issue for android build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,18 +13,24 @@ if(ANDROID_BUILD)
     set(CMAKE_ANDROID_API 21)
     set(ANDROID_PLATFORM android-21)
     set(ANDROID_DEPRECATED_HEADERS ON)
-    if (${ANDROID_ABI} STREQUAL "x86_64")
-        include_directories(${ANDROID_SYSROOT}/usr/include/x86_64-linux-android)
-    elseif (${ANDROID_ABI} STREQUAL "x86")
-        include_directories(${ANDROID_SYSROOT}/usr/include/i686-linux-android)
-    elseif (${ANDROID_ABI} STREQUAL "arm64-v8a")
-        include_directories(${ANDROID_SYSROOT}/usr/include/aarch64-linux-android)
-    else() # Default to armv7a which matches NDK toolchain.cmake behavior
-        include_directories(${ANDROID_SYSROOT}/usr/include/arm-linux-androideabi)
-    endif()
 endif(ANDROID_BUILD)
 
 project(dlr)
+
+# CMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES stuff should go after project() function
+if(ANDROID_BUILD)
+    if (ANDROID_ABI STREQUAL "x86_64")
+        list(APPEND CMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES ${ANDROID_SYSROOT}/usr/include/x86_64-linux-android)
+    elseif (ANDROID_ABI STREQUAL "x86")
+        list(APPEND CMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES ${ANDROID_SYSROOT}/usr/include/i686-linux-android)
+    elseif (ANDROID_ABI STREQUAL "arm64-v8a")
+        list(APPEND CMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES ${ANDROID_SYSROOT}/usr/include/aarch64-linux-android)
+    else() # Default to armv7a which matches NDK toolchain.cmake behavior
+        list(APPEND CMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES ${ANDROID_SYSROOT}/usr/include/arm-linux-androideabi)
+    endif()
+    message(STATUS "CMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES: ${CMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES}")
+endif(ANDROID_BUILD)
+
 # Options
 option(USE_OPENCL  "Build with OpenCL" OFF)
 option(USE_CUDA  "Build with CUDA" OFF)


### PR DESCRIPTION
dmlc-core compilation needs `asm/type.h` file which is not explicitly added to `<sysroot>/usr/include`. This file is located in ARCH specific folders:
```
/opt/android-ndk-r18b/sysroot/usr/include/aarch64-linux-android/asm/types.h
/opt/android-ndk-r18b/sysroot/usr/include/asm-generic/types.h
/opt/android-ndk-r18b/sysroot/usr/include/x86_64-linux-android/asm/types.h
/opt/android-ndk-r18b/sysroot/usr/include/arm-linux-androideabi/asm/types.h
/opt/android-ndk-r18b/sysroot/usr/include/i686-linux-android/asm/types.h
```

I noticed that `CMakeLists.txt` had "if block" to include one of these ARCH specific folders using `include_directory` command. But, it only works for this particular cmake file targets, but not for `dmlc-core` cmake targets.
To include ARCH specific folder globally for all targets we need to add this folder to `CMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES` list which is defined in `android.toolchain.cmake` file.

I also noticed that Standalone NDK has `asm/types.h` under `<sysroot>/usr/include`. That explains why the compilation worked on some boxes before. They used Standalone NDK.

Now we can use just regular NDK.

cmake output:
```
dlc@dlc-HP-EliteDesk-800-G4-SFF:~/workplace/neo-ai-dlr/build$ cmake .. -DANDROID_BUILD=ON -DNDK_ROOT=/opt/android-ndk-r18b -DCMAKE_TOOLCHAIN_FILE=/opt/android-ndk-r18b/build/cmake/android.toolchain.cmake -DANDROID_ABI=x86
-- Setting build type to 'Release' as none was specified.
-- Check for working C compiler: /opt/android-ndk-r18b/toolchains/llvm/prebuilt/linux-x86_64/bin/clang
-- Check for working C compiler: /opt/android-ndk-r18b/toolchains/llvm/prebuilt/linux-x86_64/bin/clang -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /opt/android-ndk-r18b/toolchains/llvm/prebuilt/linux-x86_64/bin/clang++
-- Check for working CXX compiler: /opt/android-ndk-r18b/toolchains/llvm/prebuilt/linux-x86_64/bin/clang++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- CMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES: /opt/android-ndk-r18b/sources/cxx-stl/llvm-libc++/include;/opt/android-ndk-r18b/sources/cxx-stl/llvm-libc++abi/include;/opt/android-ndk-r18b/sysroot/usr/include/i686-linux-android
-- Performing Test SUPPORT_CXX11
-- Performing Test SUPPORT_CXX11 - Success
-- Build with RPC support...
-- Build with Graph runtime support...
-- Build VTA runtime with target: sim
-- Found OpenMP_C: -fopenmp=libomp (found version "3.1") 
-- Found OpenMP_CXX: -fopenmp=libomp (found version "3.1") 
-- Found OpenMP: TRUE (found version "3.1")  
-- CMake version: 3.15.3
```

As you can see `CMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES` has ARCH specific folder now `/opt/android-ndk-r18b/sysroot/usr/include/i686-linux-android`