### PR TITLE
add versioning API

### DIFF
--- a/include/dlr.h
+++ b/include/dlr.h
@@ -18,7 +18,7 @@ extern "C" { // Open extern "C" block
 #define DLR_MINOR 0
 /*! \brief patch version */
 #define DLR_PATCH 0
-/*! \brief mxnet version */
+/*! \brief DLR version */
 #define DLR_VERSION (DLR_MAJOR*10000 + DLR_MINOR*100 + DLR_PATCH)
 /*! \brief helper for making version number */
 #define DLR_MAKE_VERSION(major, minor, patch) ((major)*10000 + (minor)*100 + patch)

--- a/include/dlr.h
+++ b/include/dlr.h
@@ -12,6 +12,17 @@ extern "C" { // Open extern "C" block
 #endif
 #endif // __cplusplus
 
+/*! \brief major version */
+#define DLR_MAJOR 1
+/*! \brief minor version */
+#define DLR_MINOR 0
+/*! \brief patch version */
+#define DLR_PATCH 0
+/*! \brief mxnet version */
+#define DLR_VERSION (DLR_MAJOR*10000 + DLR_MINOR*100 + DLR_PATCH)
+/*! \brief helper for making version number */
+#define DLR_MAKE_VERSION(major, minor, patch) ((major)*10000 + (minor)*100 + patch)
+
 /*!
  * \defgroup c_api
  * C API of DLR
@@ -181,6 +192,8 @@ const char* DLRGetLastError();
  \return 0 for success, -1 for error. Call DLRGetLastError() to get the error message.
  */
 int GetDLRBackend(DLRModelHandle* handle, const char** name);
+
+int GetDLRVersion(int *out);
 
 /*! \} */
 

--- a/include/dlr.h
+++ b/include/dlr.h
@@ -193,7 +193,7 @@ const char* DLRGetLastError();
  */
 int GetDLRBackend(DLRModelHandle* handle, const char** name);
 
-int GetDLRVersion(int *out);
+int GetDLRVersion(const char** out);
 
 /*! \} */
 

--- a/python/dlr/api.py
+++ b/python/dlr/api.py
@@ -24,9 +24,12 @@ class IDLRModel:
         raise NotImplementedError
 
     @abc.abstractmethod
-    def run(self, input_data):
+    def get_version(self):
         raise NotImplementedError
 
+    @abc.abstractmethod
+    def run(self, input_data):
+        raise NotImplementedError
 
 def _find_model_file(model_path, ext):
     if os.path.isfile(model_path) and model_path.endswith(ext):
@@ -81,3 +84,6 @@ class DLRModel(IDLRModel):
 
     def get_output_names(self):
         return self._impl.get_output_names()
+
+    def get_version(self):
+        return self._impl.get_version()

--- a/python/dlr/dlr_model.py
+++ b/python/dlr/dlr_model.py
@@ -90,6 +90,11 @@ class DLRModelImpl(IDLRModel):
                                        byref(backend)))
         return backend.value.decode('ascii')
 
+    def _get_version(self):
+        version = c_int()
+        _check_call(_LIB.GetDLRVersion(byref(version)))
+        return version.value
+
     def __init__(self, model_path, dev_type='cpu', dev_id=0):
         if not os.path.exists(model_path):
             raise ValueError("model_path %s doesn't exist" % model_path)
@@ -107,6 +112,7 @@ class DLRModelImpl(IDLRModel):
                                         c_int(dev_id)))
 
         self.backend = self._parse_backend()
+        self.version = self._get_version()
 
         self.num_inputs = self._get_num_inputs()
         self.num_weights = self._get_num_weights()
@@ -160,6 +166,16 @@ class DLRModelImpl(IDLRModel):
         out : list of :py:class:`str`
         """
         raise NotImplementedError
+
+    def get_version(self):
+        """
+        Get DLR version
+
+        Returns
+        -------
+        out : py:class:`int`
+        """
+        return self.version
 
     def _get_input_name(self, index):
         name = ctypes.c_char_p()

--- a/python/dlr/dlr_model.py
+++ b/python/dlr/dlr_model.py
@@ -91,9 +91,9 @@ class DLRModelImpl(IDLRModel):
         return backend.value.decode('ascii')
 
     def _get_version(self):
-        version = c_int()
+        version = c_char_p()
         _check_call(_LIB.GetDLRVersion(byref(version)))
-        return version.value
+        return version.value.decode('ascii')
 
     def __init__(self, model_path, dev_type='cpu', dev_id=0):
         if not os.path.exists(model_path):

--- a/src/dlr.cc
+++ b/src/dlr.cc
@@ -180,3 +180,9 @@ extern "C" int GetDLRBackend(DLRModelHandle* handle, const char** name) {
   *name = static_cast<DLRModel *>(*handle)->GetBackend();
   API_END();
 }
+
+extern "C" int GetDLRVersion(int *out) {
+  API_BEGIN();
+  *out = static_cast<int>(DLR_VERSION);
+  API_END();  
+}

--- a/src/dlr.cc
+++ b/src/dlr.cc
@@ -181,8 +181,11 @@ extern "C" int GetDLRBackend(DLRModelHandle* handle, const char** name) {
   API_END();
 }
 
-extern "C" int GetDLRVersion(int *out) {
+extern "C" int GetDLRVersion(const char** out) {
   API_BEGIN();
-  *out = static_cast<int>(DLR_VERSION);
+  std::string version_str = std::to_string(DLR_MAJOR) + "." +
+                            std::to_string(DLR_MINOR) + "." + 
+                            std::to_string(DLR_PATCH);
+  *out = version_str.c_str();
   API_END();  
 }

--- a/version.json
+++ b/version.json
@@ -1,0 +1,7 @@
+{
+  "dlc_version": "1.0.0",
+  "commit_ids": {
+    "tvm": "44779571412930681eef9e8b9d32aa845b8cc5ad", 
+    "treelite": "0972ce97687b4a1fb1262fad56232e7cc61116eb"
+  } 
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This implementation of get_version() API is designed on the assumption that TVM/Treelite portion of DLR package is the only part that needs explicit versioning, on top of the underlying TVM/Treelite runtime libs, since these libs are built into libdlr. 

Other executors like TFLite and 3rd party vendor runtime libs will each implement their own version API and hook it to python level get_version(), or leave it as Not Implemented. Therefore this API is expected to be used together with get_backend() to provide the whole picture.

Open to suggestions.