### PR TITLE
Add UseDLRCPUAffinity to DLR C API

### DIFF
--- a/include/dlr.h
+++ b/include/dlr.h
@@ -208,6 +208,14 @@ int GetDLRVersion(const char** out);
  */
 int SetDLRNumThreads(DLRModelHandle* handle, int threads);
 
+/*!
+ \brief Enable or disable CPU Affinity
+ \param handle The model handle returned from CreateDLRModel().
+ \param use 0 to disable, 1 to enable
+ \return 0 for success, -1 for error. Call DLRGetLastError() to get the error message.
+ */
+int UseDLRCPUAffinity(DLRModelHandle* handle, int use);
+
 /*! \} */
 
 #ifdef __cplusplus

--- a/include/dlr_common.h
+++ b/include/dlr_common.h
@@ -94,6 +94,7 @@ class DLRModel {
   virtual void GetOutputSizeDim(int index, int64_t* size, int* dim) =0;
   virtual const char* GetBackend() const =0;
   virtual void SetNumThreads(int threads) =0;
+  virtual void UseCPUAffinity(bool use) =0;
 };
 
 } // namespace dlr

--- a/include/dlr_tflite/dlr_tflite.h
+++ b/include/dlr_tflite/dlr_tflite.h
@@ -49,6 +49,7 @@ class TFLiteModel: public DLRModel {
   virtual void GetOutputSizeDim(int index, int64_t* size, int* dim) override;
   virtual const char* GetBackend() const override;
   virtual void SetNumThreads(int threads) override;
+  virtual void UseCPUAffinity(bool use) override;
 };
 
 } // namespace dlr

--- a/include/dlr_treelite.h
+++ b/include/dlr_treelite.h
@@ -54,6 +54,7 @@ class TreeliteModel: public DLRModel {
   virtual void GetOutputSizeDim(int index, int64_t* size, int* dim) override;
   virtual const char* GetBackend() const override;
   virtual void SetNumThreads(int threads) override;
+  virtual void UseCPUAffinity(bool use) override;
 };
 
 } // namespace dlr

--- a/include/dlr_tvm.h
+++ b/include/dlr_tvm.h
@@ -38,6 +38,7 @@ class TVMModel: public DLRModel {
   virtual void GetOutputSizeDim(int index, int64_t* size, int* dim) override;
   virtual const char* GetBackend() const override;
   virtual void SetNumThreads(int threads) override;
+  virtual void UseCPUAffinity(bool use) override;
 };
 
 } // namespace dlr

--- a/src/dlr.cc
+++ b/src/dlr.cc
@@ -184,10 +184,10 @@ extern "C" int GetDLRBackend(DLRModelHandle* handle, const char** name) {
 extern "C" int GetDLRVersion(const char** out) {
   API_BEGIN();
   std::string version_str = std::to_string(DLR_MAJOR) + "." +
-                            std::to_string(DLR_MINOR) + "." + 
+                            std::to_string(DLR_MINOR) + "." +
                             std::to_string(DLR_PATCH);
   *out = version_str.c_str();
-  API_END();  
+  API_END();
 }
 
 extern "C" int SetDLRNumThreads(DLRModelHandle* handle, int threads) {
@@ -195,5 +195,13 @@ extern "C" int SetDLRNumThreads(DLRModelHandle* handle, int threads) {
   DLRModel* model = static_cast<DLRModel *>(*handle);
   CHECK(model != nullptr) << "model is nullptr, create it first";
   model->SetNumThreads(threads);
+  API_END();
+}
+
+extern "C" int UseDLRCPUAffinity(DLRModelHandle* handle, int use) {
+  API_BEGIN();
+  DLRModel* model = static_cast<DLRModel *>(*handle);
+  CHECK(model != nullptr) << "model is nullptr, create it first";
+  model->UseCPUAffinity(use);
   API_END();
 }

--- a/src/dlr_tflite/dlr_tflite.cc
+++ b/src/dlr_tflite/dlr_tflite.cc
@@ -194,3 +194,7 @@ void TFLiteModel::SetNumThreads(int threads) {
     LOG(INFO) << "Set Num Threads: " << threads;
   }
 }
+
+void TFLiteModel::UseCPUAffinity(bool use) {
+  LOG(FATAL) << "UseCPUAffinity is not supported by TFLite backend";
+}

--- a/src/dlr_treelite.cc
+++ b/src/dlr_treelite.cc
@@ -186,3 +186,7 @@ const char* TreeliteModel::GetBackend() const {
 void TreeliteModel::SetNumThreads(int threads) {
   LOG(FATAL) << "SetNumThreads is not supported by Treelite backend";
 }
+
+void TreeliteModel::UseCPUAffinity(bool use) {
+  LOG(FATAL) << "UseCPUAffinity is not supported by Treelite backend";
+}

--- a/src/dlr_tvm.cc
+++ b/src/dlr_tvm.cc
@@ -173,3 +173,13 @@ void TVMModel::SetNumThreads(int threads) {
     LOG(INFO) << "Set Num Threads: " << threads;
   }
 }
+
+void TVMModel::UseCPUAffinity(bool use) {
+  if (use) {
+    setenv("TVM_BIND_THREADS", "1", 1);
+    LOG(INFO) << "CPU Affinity is enabled";
+  } else {
+    setenv("TVM_BIND_THREADS", "0", 1);
+    LOG(INFO) << "CPU Affinity is disabled";
+  }
+}


### PR DESCRIPTION
`UseDLRCPUAffinity` method allows to control  whether to call `SetAffinity` or not in TVM backend
https://github.com/dmlc/tvm/blob/master/src/runtime/threading_backend.cc#L83
```
# to Disable CPU Affinity in TVM
export TVM_BIND_THREADS=0

# to Enable CPU Affinity in TVM
unset TVM_BIND_THREADS
```

If `CPUAffinity` is disabled then OS will decide what core the process should run on. It is useful when we want to run several DLR instances on one box.

The following screenshot shows three DLR instances running on one box. Each DRL instance uses particular core 100%. : https://www.dropbox.com/s/b3bfv5wylaftdt5/Screenshot%202019-10-17%2014.53.54.png?dl=0