### PR TITLE
Add tvm_compiler to compile models for Android examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ For instructions on using DLR, please refer to [Amazon SageMaker Neo – Train Y
 
 Also check out the [API documentation](https://neo-ai-dlr.readthedocs.io/en/latest/)
 
+## Examples
+We prepared several examples demonstrating how to use DLR API on different platforms
+
+* [Neo AI DLR image classification Android example application](examples/android/image_classification)
+
+
 ## License
 
 This library is licensed under the Apache License Version 2.0. 

--- a/examples/android/image_classification/README.md
+++ b/examples/android/image_classification/README.md
@@ -28,6 +28,8 @@ App Uses the following Neo pre-compiled models:
 * tf_mobilenet_v1_100
 
 
+Other models can be compiled by followng the instructions in [Compile Deep Learning Models for Android](../tvm_compiler)
+
 ## Requirements
 
 *   Android Studio 3.2 (installed on a Linux, Mac or Windows machine)

--- a/examples/android/image_classification/app/download.gradle
+++ b/examples/android/image_classification/app/download.gradle
@@ -1,6 +1,6 @@
 def targetFolder = "src/main/assets"
 def dlr_models_host = "https://dlc-models.s3.us-east-2.amazonaws.com/android-models/"
-// Set it to the architecture of target device
+// Set it to the architecture of target device arm64-v8a, armeabi-v7a, x86_64 or x86
 def arch = "arm64-v8a"
 def localCache = "build/intermediates"
 

--- a/examples/android/tvm_compiler/Dockerfile
+++ b/examples/android/tvm_compiler/Dockerfile
@@ -1,0 +1,37 @@
+FROM ubuntu:19.10
+
+RUN apt update
+
+RUN apt install -y build-essential
+RUN apt install -y llvm-9 clang-9
+RUN apt install -y cmake git wget curl vim zip
+RUN apt install -y python3 python3-dev
+RUN apt install -y libedit-dev libxml2-dev antlr4
+
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python3 get-pip.py && rm get-pip.py
+
+RUN pip3 install numpy decorator attrs antlr4-python3-runtime
+
+WORKDIR /root
+RUN git clone --recursive https://github.com/dmlc/tvm
+WORKDIR /root/tvm/build
+RUN cmake -DUSE_LLVM=ON -DUSE_ANTLR=ON .. && make -j$(nproc)
+
+WORKDIR /root/tvm/python
+RUN python3 setup.py install
+WORKDIR /root/tvm/nnvm/python
+RUN python3 setup.py install
+WORKDIR /root/tvm/topi/python
+RUN python3 setup.py install
+
+WORKDIR /root
+RUN pip3 install tensorflow==1.15 keras keras-applications
+RUN pip3 install mxnet gluoncv
+
+WORKDIR /opt
+RUN wget https://dl.google.com/android/repository/android-ndk-r20-linux-x86_64.zip
+RUN unzip android-ndk-r20-linux-x86_64.zip && rm android-ndk-r20-linux-x86_64.zip
+RUN ln -s android-ndk-r20 android-ndk
+
+WORKDIR /root/tvm_compiler
+COPY tvm_compiler_utils.py compile_keras.py compile_tensorflow.py compile_gluoncv.py ./

--- a/examples/android/tvm_compiler/README.md
+++ b/examples/android/tvm_compiler/README.md
@@ -1,0 +1,81 @@
+# Compile Deep Learning Models for Android
+
+## Overview
+This folder contain Dockerfile and scripts to compile different Deep Learning Models for Android platform.
+Currently we support the following Deep Learning Frameworks:
+* GluonCV
+* Keras
+* Tensorflow
+
+## Prepare Docker Container
+You can build `tvm_android_compiler` docker image yourself or pull pre-built image
+
+To build docker image yourself run the following
+```
+docker build -t tvm_android_compiler .
+
+docker run -ti tvm_android_compiler
+```
+
+To use pre-built Docker Image run
+```
+docker run -ti x4444/tvm_android_compiler
+```
+
+## Compile Deep Learning Models
+Once the Docker container is started you can compile Deep Learning Models for Android
+
+### Supported Android Architectures
+The compilation scripts support the following Android architectures:
+* arm64-v8a
+* armeabi-v7a
+* x86_64
+* x86
+
+The compilation scripts compile the models for all supported Android architectures.
+Output files fill be saved under folders `<arch>/<dlr_model_name>`.
+Each folder will have three files:
+* model.json
+* model.so
+* model.params
+
+Compiled models can be run using `neo-ai-dlr` API/lib.
+See [DLR Android examples](https://github.com/neo-ai/neo-ai-dlr/tree/master/examples/android)
+
+### GluonCV
+To compile GluonCV models use script `compile_gluoncv.py`.
+By default the script downloads pre-trained `mobilenetv2_0.75` model from GluonCV Model Zoo.
+Edit the script to change GluonCV Model Zoo model.
+
+To compile GluonCV model run the following:
+```
+./compile_gluoncv.py
+```
+
+### Keras
+To compile Keras models use script `compile_keras.py`.
+By default the script downloads pre-trained `MobileNet_v2` model from Keras applications.
+Edit the script to change Keras Application model.
+
+To compile Keras model run the following:
+```
+./compile_keras.py
+```
+
+### Tensorflow
+To compile Tensorflow models use script `compile_tensorflow.py`.
+By default the script compiles frozen model from [mobilenet_v1_1.0_224.tgz](http://download.tensorflow.org/models/mobilenet_v1_2018_02_22/mobilenet_v1_1.0_224.tgz).
+Download tgz file and extract it to some folder. Copy or link `mobilenet_v1_1.0_224_frozen.pb` file to `~/tvm_compiler` folder.
+
+To compile Tensorflow model run the following:
+```
+mkdir /tmp/mobilenet_v1_1.0_224
+cd /tmp/mobilenet_v1_1.0_224
+wget http://download.tensorflow.org/models/mobilenet_v1_2018_02_22/mobilenet_v1_1.0_224.tgz
+tar zxf mobilenet_v1_1.0_224.tgz
+rm mobilenet_v1_1.0_224.tgz
+cd ~/tvm_compiler
+ln -s /tmp/mobilenet_v1_1.0_224/mobilenet_v1_1.0_224_frozen.pb
+
+./compile_tensorflow.py
+```

--- a/examples/android/tvm_compiler/compile_gluoncv.py
+++ b/examples/android/tvm_compiler/compile_gluoncv.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+
+from tvm import relay
+from mxnet.gluon.model_zoo.vision import get_model
+from tvm_compiler_utils import tvm_compile
+
+model_name, dlr_model_name = "mobilenetv2_0.75", "dlr_gluoncv_mobilenet_v2_075"
+#model_name, dlr_model_name = "mobilenetv2_1.0", "dlr_gluoncv_mobilenet_v2_100"
+#model_name, dlr_model_name = "resnet18_v2", "dlr_gluoncv_resnet18_v2"
+#model_name, dlr_model_name = "resnet50_v2", "dlr_gluoncv_resnet50_v2"
+shape_dict = {'data': (1, 3, 224, 224)}
+dtype='float32'
+
+print("Model:", model_name, ", shape_dict:", shape_dict)
+block = get_model(model_name, pretrained=True)
+
+for arch in ["arm64-v8a", "armeabi-v7a", "x86_64", "x86"]:
+  sym, params = relay.frontend.from_mxnet(block, shape=shape_dict, dtype=dtype)
+  func = sym["main"]
+  func = relay.Function(func.params, relay.nn.softmax(func.body), None, func.type_params, func.attrs)
+  tvm_compile(func, params, arch, dlr_model_name)

--- a/examples/android/tvm_compiler/compile_keras.py
+++ b/examples/android/tvm_compiler/compile_keras.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+
+from tvm import relay
+from keras.applications import mobilenet_v2
+from tvm_compiler_utils import tvm_compile
+
+keras_model = mobilenet_v2.MobileNetV2()
+#keras_model.summary()
+shape_dict = {'input_1': (1, 3, 224, 224)}
+dlr_model_name = "dlr_keras_mobilenet_v2"
+
+print("Model:", keras_model.name, ", shape_dict:", shape_dict)
+
+for arch in ["arm64-v8a", "armeabi-v7a", "x86_64", "x86"]:
+  sym, params = relay.frontend.from_keras(keras_model, shape_dict)
+  func = sym["main"]
+  tvm_compile(func, params, arch, dlr_model_name)

--- a/examples/android/tvm_compiler/compile_tensorflow.py
+++ b/examples/android/tvm_compiler/compile_tensorflow.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+
+from tvm import relay
+import tensorflow as tf
+from tvm_compiler_utils import tvm_compile
+
+frozen_pb_file = "mobilenet_v1_1.0_224_frozen.pb"
+shape_dict = {'input': (1, 224, 224, 3)}
+dlr_model_name = "dlr_tf_mobilenet_v1_100"
+
+with tf.compat.v1.gfile.GFile(frozen_pb_file, 'rb') as f:
+  graph_def = tf.compat.v1.GraphDef()
+  graph_def.ParseFromString(f.read())
+
+print("Model:", frozen_pb_file, ", shape_dict:", shape_dict)
+
+for arch in ["arm64-v8a", "armeabi-v7a", "x86_64", "x86"]:
+  sym, params = relay.frontend.from_tensorflow(graph_def, layout='NCHW', shape=shape_dict)
+  func = sym["main"]
+  tvm_compile(func, params, arch, dlr_model_name)

--- a/examples/android/tvm_compiler/tvm_compiler_utils.py
+++ b/examples/android/tvm_compiler/tvm_compiler_utils.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import tvm
+from tvm import relay
+from tvm.contrib import ndk
+
+sys.setrecursionlimit(1031)
+print("sys.getrecursionlimit()", sys.getrecursionlimit())
+
+
+def tvm_compile(func, params, arch, dlr_model_name):
+  ###arch x86_64
+  if arch == 'x86_64':
+    target = "llvm -model=N3350 -target=x86_64-linux-android -mattr=+ssse3,+sse4.2"
+    sysroot="/opt/android-ndk/toolchains/llvm/prebuilt/linux-x86_64/sysroot"
+    toolchain="/opt/android-ndk/toolchains/x86_64-4.9/prebuilt/linux-x86_64"
+    os.environ['TVM_NDK_CC'] = "/opt/android-ndk/toolchains/llvm/prebuilt/linux-x86_64/bin/x86_64-linux-android28-clang++"
+  ###arch x86 i686
+  elif arch == 'x86':
+    target = "llvm -model=x5-Z8350 -target=i686-linux-android -mattr=+ssse3"
+    sysroot="/opt/android-ndk/toolchains/llvm/prebuilt/linux-x86_64/sysroot"
+    toolchain="/opt/android-ndk/toolchains/x86-4.9/prebuilt/linux-x86_64"
+    os.environ['TVM_NDK_CC'] = "/opt/android-ndk-r20/toolchains/llvm/prebuilt/linux-x86_64/bin/i686-linux-android21-clang++"
+
+  ###arch arm64 aarch64
+  elif arch == 'arm64-v8a':
+    target = "llvm -device=arm_cpu -model=SM8150 -target=aarch64-linux-android"
+    sysroot="/opt/android-ndk/toolchains/llvm/prebuilt/linux-x86_64/sysroot"
+    toolchain="/opt/android-ndk/toolchains/aarch64-linux-android-4.9/prebuilt/linux-x86_64"
+    os.environ['TVM_NDK_CC'] = "/opt/android-ndk/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android28-clang++"
+
+  ###arch armv7
+  ## More info on armv7 hard/soft abi for Android https://android.googlesource.com/platform/ndk/+/master/docs/HardFloatAbi.md
+  elif arch == 'armeabi-v7a':
+    target = "llvm -device=arm_cpu -model=MSM8940 -target=armv7a-linux-androideabi -mfloat-abi=soft -mattr=+neon,+thumb-mode"
+    sysroot="/opt/android-ndk/toolchains/llvm/prebuilt/linux-x86_64/sysroot"
+    toolchain="/opt/android-ndk/toolchains/arm-linux-androideabi-4.9/prebuilt/linux-x86_64"
+    os.environ['TVM_NDK_CC'] = "/opt/android-ndk/toolchains/llvm/prebuilt/linux-x86_64/bin/armv7a-linux-androideabi21-clang++"
+  else:
+    print("Valid arch: arm64-v8a, armeabi-v7a, x86_64, x86")
+    return
+
+  print('target:', target)
+  print("Compiling...")
+
+  with relay.build_config(opt_level=3):
+    graph, lib, params = relay.build(func, target, params=params)
+
+  print("Compilation done")
+  print("lib type_key: ", lib.type_key)
+
+  print("Saving files")
+  out_folder = arch + "/" + dlr_model_name + "/"
+  os.makedirs(out_folder, exist_ok=True)
+  # save the graph, lib and params into separate files
+  path_lib = out_folder + "model.so"
+  options=["-shared", "-fPIC", "--sysroot", sysroot, "--gcc-toolchain="+toolchain, "-static-libstdc++"]
+  lib.export_library(path_lib, ndk.create_shared, options=options)
+
+  print("export_library done")
+
+  with open(out_folder + "model.json", "w") as fo:
+    fo.write(graph)
+  with open(out_folder + "model.params", "wb") as fo:
+    fo.write(relay.save_param_dict(params))
+
+  print("Files saved to", out_folder)


### PR DESCRIPTION
This PR adds folder `examples/android/tvm_compiler` which contain python scripts to compile `GluonCV`, `Keras` and `Tensorflow` models for all Android architectures.
The folder also contains `Dockerfile` which can be used to create docker image with `TVM`, `Android NDK`, `MXNet`, `GluonCV`, `Tensorflow` and `Keras`. Plus the scripts to compile the models.

Performance optimization flags added to LLVM target
```
x86_64 :     -mattr=+ssse3,+sse4.2
X86:         -mattr=+ssse3
armeabi-v7a: -mattr=+neon,+thumb-mode
arm64-v8a:    <nothing>
```

See `README.md` for step by step instructions

To test the PR locally
```
git clone --recursive https://github.com/apivovarov/neo-ai-dlr.git
git checkout tvm_compiler
cd examples/android/tvm_compiler
docker build -t tvm_android_compiler .
...
```

See [README](https://github.com/apivovarov/neo-ai-dlr/tree/tvm_compiler/examples/android/tvm_compiler) for  details

### Testing
Tested resulting models on `ARMv8`, `ARMv7` and `x86` devices. Models work fast. `libc++_shared.so` is not needed.