### PR TITLE
Disable debugging info for Release build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,11 +22,12 @@ project(dlr)
 
 # CMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES stuff should go after project() function
 if(ANDROID_BUILD)
-    # Use RELEASE flags for Release build. It will reduce libdlr.so size by a factor of 3.
+    # Disable debugging info for Release build by setting -g level to 0. It will reduce libdlr.so size by a factor of 3.
+    # NDK Issue https://github.com/android/ndk/issues/243
     if (CMAKE_BUILD_TYPE STREQUAL "Release")
-        set(CMAKE_C_FLAGS ${CMAKE_C_FLAGS_RELEASE})
-        set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS_RELEASE})
-        set(CMAKE_ASM_FLAGS ${CMAKE_ASM_FLAGS_RELEASE})
+        string(REPLACE "-g " "-g0 " CMAKE_C_FLAGS ${CMAKE_C_FLAGS})
+        string(REPLACE "-g " "-g0 " CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
+        string(REPLACE "-g " "-g0 " CMAKE_ASM_FLAGS ${CMAKE_ASM_FLAGS})
     endif()
   # Add ARCH specific header folder to CMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES
     if (ANDROID_ABI STREQUAL "x86_64")


### PR DESCRIPTION
This PR tries to solve the issue with "-g" debugging info flag added by `android.toolchain.cmake` to `CMAKE_CXX_FLAGS` and `CMAKE_C_FLAGS`.

Previous approach to this problem was to use RELEASE flags instead of Regular flags. The problem with that solution is that lots of other option are added only to Regular flags. E.g. `-DANDROID_ARM_NEON=TRUE` adds `-mfpu=neon` to `CMAKE_CXX_FLAGS` but not to `CMAKE_CXX_FLAGS_RELEASE`.
In Fact Release build combines Regular flags with RELEASE flags. So, we can not just replace regular flags with RELEASE flags.

One of the solution to remove "-g" flag in Release build is to add "-g0" flag to `CMAKE_CXX_FLAGS_RELEASE`. Default debugging info level 2 will be overwritten with level 0 - disabled.
```
cmake -DANDROID_BUILD=ON \
-DCMAKE_C_FLAGS_RELEASE="-g0" \
-DCMAKE_CXX_FLAGS_RELEASE="-g0" \
```

That works but requires users to explicitly run cmake with `-DCMAKE_CXX_FLAGS_RELEASE="-g0"`

I tried to `(set CMAKE_CXX_FLAGS_RELEASE "-g0")` inside our `CMakeLists.txt` before and after `project(dlr)` line -  it did not help. It only works if `CMAKE_CXX_FLAGS_RELEASE` is set in cmake command via `-D`

Another solution to the problem is to fix `CMAKE_CXX_FLAGS` string directly inside our `CMakeLists.txt` after `project(dlr)` line -  that works.
I decided to replace `-g` with `-g0` in `CMAKE_CXX_FLAGS` to set debug level to 0 explicitly. (Replacement is done only for Release build)

# Testing
cmake with NEON
```
cmake -DANDROID_BUILD=ON \
-DANDROID_ARM_NEON=TRUE \
-DNDK_ROOT=/opt/android-ndk-r20 \
-DCMAKE_TOOLCHAIN_FILE=/opt/android-ndk-r20/build/cmake/android.toolchain.cmake \
-DANDROID_ABI="armeabi-v7a" \
..
```

make output has `-g0` and `-mfpu=neon`
```
[ 93%] Building CXX object CMakeFiles/model_peeker.dir/demo/cpp/model_peeker.cc.o

/opt/android-ndk-r20/toolchains/llvm/prebuilt/linux-x86_64/bin/clang++ 
--target=armv7-none-linux-androideabi21 
--gcc-toolchain=/opt/android-ndk-r20/toolchains/llvm/prebuilt/linux-x86_64 
--sysroot=/opt/android-ndk-r20/toolchains/llvm/prebuilt/linux-x86_64/sysroot   
-I/home/dlc/workplace/neo-ai-dlr/3rdparty/tvm/include 
-I/home/dlc/workplace/neo-ai-dlr/3rdparty/tvm/src/runtime 
-I/home/dlc/workplace/neo-ai-dlr/3rdparty/tvm/3rdparty/dlpack/include 
-I/home/dlc/workplace/neo-ai-dlr/3rdparty/tvm/3rdparty/dmlc-core/include 
-I/home/dlc/workplace/neo-ai-dlr/3rdparty/treelite/include 
-I/home/dlc/workplace/neo-ai-dlr/3rdparty/treelite/runtime/native/include 
-I/home/dlc/workplace/neo-ai-dlr/include 
-isystem /opt/android-ndk-r20/sysroot/usr/include/arm-linux-androideabi  
-g0 -DANDROID -fdata-sections -ffunction-sections -funwind-tables 
-fstack-protector-strong -no-canonical-prefixes -fno-addrsig -march=armv7-a 
-mthumb -mfpu=neon -Wa,--noexecstack -Wformat -Werror=format-security   
-funroll-loops -Oz -DNDEBUG  -fPIE   -std=gnu++11 
-o CMakeFiles/model_peeker.dir/demo/cpp/model_peeker.cc.o 
-c /home/dlc/workplace/neo-ai-dlr/demo/cpp/model_peeker.cc
```

lib and demo file sizes are small.
```
-rwxrwxr-x 1 dlc dlc 4.2M Oct 31 17:31 libdlr.so
-rw-rw-r-- 1 dlc dlc 875K Oct 31 17:31 libdlr_static.a
-rwxrwxr-x 1 dlc dlc 3.5M Oct 31 17:31 model_peeker
-rwxrwxr-x 1 dlc dlc 3.5M Oct 31 17:31 run_resnet
```