### PR TITLE
add GetRuntimeEnabled()

### DIFF
--- a/include/dlr.h
+++ b/include/dlr.h
@@ -216,6 +216,15 @@ int SetDLRNumThreads(DLRModelHandle* handle, int threads);
  */
 int UseDLRCPUAffinity(DLRModelHandle* handle, int use);
 
+/*!
+ \brief Check if a particular compute device is enabled for the runtime
+ \param handle The model handle returned from CreateDLRModel().
+ \param device The compute device type 
+ \param enabled Pointer to save bool result
+ \return 0 for success, -1 for error. Call DLRGetLastError() to get the error message.
+ */
+int GetDLRRuntimeEnabled(DLRModelHandle* handle, const char* device, bool* enabled);
+
 /*! \} */
 
 #ifdef __cplusplus

--- a/include/dlr_common.h
+++ b/include/dlr_common.h
@@ -95,6 +95,7 @@ class DLRModel {
   virtual const char* GetBackend() const =0;
   virtual void SetNumThreads(int threads) =0;
   virtual void UseCPUAffinity(bool use) =0;
+  virtual void GetRuntimeEnabled(const char* device, bool* enabled) =0;
 };
 
 } // namespace dlr

--- a/include/dlr_tflite/dlr_tflite.h
+++ b/include/dlr_tflite/dlr_tflite.h
@@ -50,6 +50,7 @@ class TFLiteModel: public DLRModel {
   virtual const char* GetBackend() const override;
   virtual void SetNumThreads(int threads) override;
   virtual void UseCPUAffinity(bool use) override;
+  virtual void GetRuntimeEnabled(const char* device, bool* enabled) override;
 };
 
 } // namespace dlr

--- a/include/dlr_treelite.h
+++ b/include/dlr_treelite.h
@@ -55,6 +55,7 @@ class TreeliteModel: public DLRModel {
   virtual const char* GetBackend() const override;
   virtual void SetNumThreads(int threads) override;
   virtual void UseCPUAffinity(bool use) override;
+  virtual void GetRuntimeEnabled(const char* device, bool* enabled) override;
 };
 
 } // namespace dlr

--- a/include/dlr_tvm.h
+++ b/include/dlr_tvm.h
@@ -2,6 +2,7 @@
 #define DLR_TVM_H_
 
 #include <graph/graph_runtime.h>
+#include <tvm/runtime/registry.h>
 #include "dlr_common.h"
 
 namespace dlr {
@@ -19,6 +20,7 @@ class TVMModel: public DLRModel {
   std::shared_ptr<tvm::runtime::Module> tvm_module_;
   std::vector<const DLTensor *> outputs_;
   std::vector<std::string> weight_names_;
+  std::unordered_map<std::string, bool> device_enabled_;
   void SetupTVMModule(const std::string& model_path);
  public:
   /*! \brief Load model files from given folder path.
@@ -39,6 +41,7 @@ class TVMModel: public DLRModel {
   virtual const char* GetBackend() const override;
   virtual void SetNumThreads(int threads) override;
   virtual void UseCPUAffinity(bool use) override;
+  virtual void GetRuntimeEnabled(const char* device, bool* enabled) override;
 };
 
 } // namespace dlr

--- a/python/dlr/api.py
+++ b/python/dlr/api.py
@@ -28,6 +28,10 @@ class IDLRModel:
         raise NotImplementedError
 
     @abc.abstractmethod
+    def get_enabled_devices(self):
+        raise NotImplementedError
+
+    @abc.abstractmethod
     def run(self, input_data):
         raise NotImplementedError
 
@@ -87,3 +91,6 @@ class DLRModel(IDLRModel):
 
     def get_version(self):
         return self._impl.get_version()
+    
+    def get_enabled_devices(self):
+        return self._impl.get_enabled_devices()        

--- a/src/dlr.cc
+++ b/src/dlr.cc
@@ -110,8 +110,8 @@ extern "C" int GetDLRNumOutputs(DLRModelHandle* handle,
 #ifdef DLR_TFLITE
 /*! \brief Translate c args from ctypes to std types for DLRModelFromTFLite ctor.
  */
-int CreateDLRModelFromTFLite(DLRModelHandle *handle,
-                   const char *model_path,
+int CreateDLRModelFromTFLite(DLRModelHandle* handle,
+                   const char* model_path,
                    int threads,
                    int use_nnapi) {
   API_BEGIN();
@@ -204,4 +204,12 @@ extern "C" int UseDLRCPUAffinity(DLRModelHandle* handle, int use) {
   CHECK(model != nullptr) << "model is nullptr, create it first";
   model->UseCPUAffinity(use);
   API_END();
+}
+
+extern "C" int GetDLRRuntimeEnabled(DLRModelHandle* handle, const char* device, bool* enabled) {
+  API_BEGIN();
+  DLRModel* model = static_cast<DLRModel *>(*handle);
+  CHECK(model != nullptr) << "model is nullptr, create it first";
+  model->GetRuntimeEnabled(device, enabled);
+  API_END();  
 }

--- a/src/dlr_tflite/dlr_tflite.cc
+++ b/src/dlr_tflite/dlr_tflite.cc
@@ -198,3 +198,7 @@ void TFLiteModel::SetNumThreads(int threads) {
 void TFLiteModel::UseCPUAffinity(bool use) {
   LOG(FATAL) << "UseCPUAffinity is not supported by TFLite backend";
 }
+
+void TFLiteModel::GetRuntimeEnabled(const char* device, bool* enabled) {
+  LOG(FATAL) << "GetRuntimeEnabled is not supported by TFLite backend";
+}

--- a/src/dlr_treelite.cc
+++ b/src/dlr_treelite.cc
@@ -190,3 +190,7 @@ void TreeliteModel::SetNumThreads(int threads) {
 void TreeliteModel::UseCPUAffinity(bool use) {
   LOG(FATAL) << "UseCPUAffinity is not supported by Treelite backend";
 }
+
+void TreeliteModel::GetRuntimeEnabled(const char* device, bool* enabled) {
+  LOG(FATAL) << "GetRuntimeEnabled is not supported by Treelite backend";
+}

--- a/src/dlr_tvm.cc
+++ b/src/dlr_tvm.cc
@@ -183,3 +183,10 @@ void TVMModel::UseCPUAffinity(bool use) {
     LOG(INFO) << "CPU Affinity is disabled";
   }
 }
+
+void TVMModel::GetRuntimeEnabled(const char* device, bool* enabled) {
+  if ( device_enabled_.find(device) == device_enabled_.end()) {
+    device_enabled_[device] = (*tvm::runtime::Registry::Get("module._Enabled"))(device);
+  }
+  *enabled = device_enabled_[device];
+}


### PR DESCRIPTION
Adds get_enabled_devices() --> List in python API and GetDLRRuntimeEnabled() --> bool in C API. 

These functions queries underlying TVM runtime to determine compute devices turned-on for currently build. This is needed for correct error-handling when DLR parses metadata from Neo service. 