### PR TITLE
Support Windows platform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,11 +2,6 @@ cmake_minimum_required (VERSION 3.6)
 include(cmake/Utils.cmake)
 include(3rdparty/tvm/cmake/util/FindCUDA.cmake)
 
-set_default_configuration_release()
-msvc_use_static_runtime()
-
-message(STATUS "CMAKE_BUILD_TYPE: " ${CMAKE_BUILD_TYPE})
-
 # Option for Android on Arm --- has to come before project() function
 option(ANDROID_BUILD "Build for Android target" OFF)
 option(AAR_BUILD "Build Android Archive (AAR)" OFF)
@@ -19,6 +14,12 @@ if(ANDROID_BUILD)
 endif(ANDROID_BUILD)
 
 project(dlr)
+
+# The following lines should be after project()
+set_default_configuration_release()
+msvc_use_static_runtime()
+message(STATUS "CMAKE_BUILD_TYPE: " ${CMAKE_BUILD_TYPE})
+set(CMAKE_LOCAL "${PROJECT_SOURCE_DIR}/cmake")
 
 # CMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES stuff should go after project() function
 if(ANDROID_BUILD)
@@ -310,6 +311,7 @@ if(NOT(ANDROID_BUILD OR AAR_BUILD))
     string(REPLACE ".cc" "" __execname ${__srcname})
     add_executable(${__execname} ${__srcpath})
     target_link_libraries(${__execname} dlr gtest_main)
+    set_output_directory(${__execname} ${CMAKE_BINARY_DIR})
     add_test(NAME ${__execname} COMMAND ${__execname})
     message(STATUS "Added Test: " ${__execname})
   endforeach()

--- a/cmake/googletest-download.cmake
+++ b/cmake/googletest-download.cmake
@@ -12,7 +12,7 @@ ExternalProject_Add(
   GIT_REPOSITORY
     https://github.com/google/googletest.git
   GIT_TAG
-    release-1.8.0
+    release-1.8.1
   CONFIGURE_COMMAND ""
   BUILD_COMMAND ""
   INSTALL_COMMAND ""

--- a/include/dlr.h
+++ b/include/dlr.h
@@ -5,12 +5,14 @@
 
 /* special symbols for DLL library on Windows */
 #ifdef __cplusplus
-#if defined(_MSC_VER) || defined(_WIN32)
-extern "C" __declspec(dllexport) { // Open extern "C" block on Windows
-#else
 extern "C" { // Open extern "C" block
-#endif
 #endif // __cplusplus
+
+#if defined(_MSC_VER) || defined(_WIN32)
+#define DLR_DLL __declspec(dllexport)
+#else
+#define DLR_DLL
+#endif  // defined(_MSC_VER) || defined(_WIN32)
 
 /*! \brief major version */
 #define DLR_MAJOR 1
@@ -42,6 +44,7 @@ typedef void* DLRModelHandle;
  \param dev_id Device ID.
  \return 0 for success, -1 for error. Call DLRGetLastError() to get the error message.
  */
+DLR_DLL
 int CreateDLRModel(DLRModelHandle *handle,
                    const char *model_path,
                    int dev_type,
@@ -56,6 +59,7 @@ int CreateDLRModel(DLRModelHandle *handle,
  \param use_nnapi Use NNAPI, 0 - false, 1 - true.
  \return 0 for success, -1 for error. Call DLRGetLastError() to get the error message.
  */
+DLR_DLL
 int CreateDLRModelFromTFLite(DLRModelHandle *handle,
                    const char *model_path,
                    int threads,
@@ -67,6 +71,7 @@ int CreateDLRModelFromTFLite(DLRModelHandle *handle,
  \param handle The model handle returned from CreateDLRModel().
  \return 0 for success, -1 for error. Call DLRGetLastError() to get the error message.
  */
+DLR_DLL
 int DeleteDLRModel(DLRModelHandle* handle);
 
 /*!
@@ -74,6 +79,7 @@ int DeleteDLRModel(DLRModelHandle* handle);
  \param handle The model handle returned from CreateDLRModel().
  \return 0 for success, -1 for error. Call DLRGetLastError() to get the error message.
  */
+DLR_DLL
 int RunDLRModel(DLRModelHandle *handle);
 
 /*!
@@ -82,6 +88,7 @@ int RunDLRModel(DLRModelHandle *handle);
  \param num_inputs The pointer to save the number of inputs.
  \return 0 for success, -1 for error. Call DLRGetLastError() to get the error message.
  */
+DLR_DLL
 int GetDLRNumInputs(DLRModelHandle* handle, int* num_inputs);
 
 /*!
@@ -90,6 +97,7 @@ int GetDLRNumInputs(DLRModelHandle* handle, int* num_inputs);
  \param num_weights The pointer to save the number of weights.
  \return 0 for success, -1 for error. Call DLRGetLastError() to get the error message.
  */
+DLR_DLL
 int GetDLRNumWeights(DLRModelHandle* handle, int* num_weights);
 
 /*!
@@ -99,6 +107,7 @@ int GetDLRNumWeights(DLRModelHandle* handle, int* num_weights);
  \param input_name The pointer to save the name of the index-th input.
  \return 0 for success, -1 for error. Call DLRGetLastError() to get the error message.
  */
+DLR_DLL
 int GetDLRInputName(DLRModelHandle* handle,
                     int index,
                     const char** input_name);
@@ -110,6 +119,7 @@ int GetDLRInputName(DLRModelHandle* handle,
  \param input_name The pointer to save the name of the index-th weight.
  \return 0 for success, -1 for error. Call DLRGetLastError() to get the error message.
  */
+DLR_DLL
 int GetDLRWeightName(DLRModelHandle* handle,
                      int index,
                      const char** weight_name);
@@ -123,6 +133,7 @@ int GetDLRWeightName(DLRModelHandle* handle,
  \param dim The dimension of the input data.
  \return 0 for success, -1 for error. Call DLRGetLastError() to get the error message.
  */
+DLR_DLL
 int SetDLRInput(DLRModelHandle* handle,
                 const char* name,
                 const int64_t* shape,
@@ -135,6 +146,7 @@ int SetDLRInput(DLRModelHandle* handle,
  \param input The current value of the input will be copied to this buffer.
  \return 0 for success, -1 for error. Call DLRGetLastError() to get the error message.
  */
+DLR_DLL
 int GetDLRInput(DLRModelHandle* handle,
                 const char* name,
                 float* input);
@@ -145,6 +157,7 @@ int GetDLRInput(DLRModelHandle* handle,
  \param shape The pointer to save the shape of index-th output. This should be a pointer to an array of size "dim" from GetDLROutputSizeDim().
  \return 0 for success, -1 for error. Call DLRGetLastError() to get the error message.
  */
+DLR_DLL
 int GetDLROutputShape(DLRModelHandle* handle,
                       int index,
                       int64_t* shape);
@@ -156,6 +169,7 @@ int GetDLROutputShape(DLRModelHandle* handle,
  \param out The pointer to save the output data. This should be a pointer to an array of size "size" from GetDLROutputSizeDim().
  \return 0 for success, -1 for error. Call DLRGetLastError() to get the error message.
  */
+DLR_DLL
 int GetDLROutput(DLRModelHandle* handle,
                  int index,
                  float* out);
@@ -165,6 +179,7 @@ int GetDLROutput(DLRModelHandle* handle,
  \param num_outputs The pointer to save the number of outputs.
  \return 0 for success, -1 for error. Call DLRGetLastError() to get the error message.
  */
+DLR_DLL
 int GetDLRNumOutputs(DLRModelHandle* handle, int* num_outputs);
 
 /*!
@@ -175,6 +190,7 @@ int GetDLRNumOutputs(DLRModelHandle* handle, int* num_outputs);
  \param dim The pointer to save the dimension of the index-th output.
  \return 0 for success, -1 for error. Call DLRGetLastError() to get the error message.
  */
+DLR_DLL
 int GetDLROutputSizeDim(DLRModelHandle* handle,
                         int index,
                         int64_t* size,
@@ -183,6 +199,7 @@ int GetDLROutputSizeDim(DLRModelHandle* handle,
  \brief Gets the last error message.
  \return Null-terminated string containing the error message.
  */
+DLR_DLL
 const char* DLRGetLastError();
 
 /*!
@@ -191,6 +208,7 @@ const char* DLRGetLastError();
  \param name The pointer to save the null-terminated string containing the name.
  \return 0 for success, -1 for error. Call DLRGetLastError() to get the error message.
  */
+DLR_DLL
 int GetDLRBackend(DLRModelHandle* handle, const char** name);
 
 /*!
@@ -198,6 +216,7 @@ int GetDLRBackend(DLRModelHandle* handle, const char** name);
  \param out The pointer to save the null-terminated string containing the version.
  \return 0 for success, -1 for error. Call DLRGetLastError() to get the error message.
  */
+DLR_DLL
 int GetDLRVersion(const char** out);
 
 /*!
@@ -206,6 +225,7 @@ int GetDLRVersion(const char** out);
  \param threads number of threads
  \return 0 for success, -1 for error. Call DLRGetLastError() to get the error message.
  */
+DLR_DLL
 int SetDLRNumThreads(DLRModelHandle* handle, int threads);
 
 /*!
@@ -214,6 +234,7 @@ int SetDLRNumThreads(DLRModelHandle* handle, int threads);
  \param use 0 to disable, 1 to enable
  \return 0 for success, -1 for error. Call DLRGetLastError() to get the error message.
  */
+DLR_DLL
 int UseDLRCPUAffinity(DLRModelHandle* handle, int use);
 
 /*! \} */

--- a/src/dlr_tvm.cc
+++ b/src/dlr_tvm.cc
@@ -186,7 +186,7 @@ static inline int SetEnv(const char* key, const char* value) {
 
 void TVMModel::SetNumThreads(int threads) {
   if (threads > 0) {
-	SetEnv("TVM_NUM_THREADS", std::to_string(threads).c_str());
+    SetEnv("TVM_NUM_THREADS", std::to_string(threads).c_str());
     LOG(INFO) << "Set Num Threads: " << threads;
   }
 }

--- a/src/dlr_tvm.cc
+++ b/src/dlr_tvm.cc
@@ -44,7 +44,7 @@ void TVMModel::SetupTVMModule(const std::string& model_path) {
   std::ifstream jstream(paths.model_json);
   std::stringstream json_blob;
   json_blob << jstream.rdbuf();
-  std::ifstream pstream(paths.params);
+  std::ifstream pstream(paths.params, std::ios::in | std::ios::binary);
   std::stringstream param_blob;
   param_blob << pstream.rdbuf();
 

--- a/src/dlr_tvm.cc
+++ b/src/dlr_tvm.cc
@@ -1,6 +1,7 @@
 #include "dlr_tvm.h"
 #include <fstream>
 #include <numeric>
+#include <iterator>
 #include <stdlib.h>
 
 
@@ -167,19 +168,27 @@ const char* TVMModel::GetBackend() const {
   return "tvm";
 }
 
+static inline int SetEnv(const char* key, const char* value) {
+#ifdef _WIN32
+  return static_cast<int>(_putenv_s(key, value));
+#else
+  return setenv(key, value, 1);
+#endif  // _WIN32
+}
+
 void TVMModel::SetNumThreads(int threads) {
   if (threads > 0) {
-    setenv("TVM_NUM_THREADS", std::to_string(threads).c_str(), 1);
+	SetEnv("TVM_NUM_THREADS", std::to_string(threads).c_str());
     LOG(INFO) << "Set Num Threads: " << threads;
   }
 }
 
 void TVMModel::UseCPUAffinity(bool use) {
   if (use) {
-    setenv("TVM_BIND_THREADS", "1", 1);
+    SetEnv("TVM_BIND_THREADS", "1");
     LOG(INFO) << "CPU Affinity is enabled";
   } else {
-    setenv("TVM_BIND_THREADS", "0", 1);
+    SetEnv("TVM_BIND_THREADS", "0");
     LOG(INFO) << "CPU Affinity is disabled";
   }
 }

--- a/tests/cpp/dlr_tflite/dlr_tflite_test.cc
+++ b/tests/cpp/dlr_tflite/dlr_tflite_test.cc
@@ -187,6 +187,8 @@ TEST(TFLite, CreateDLRModel) {
 
 int main(int argc, char ** argv) {
   testing::InitGoogleTest(&argc, argv);
+#ifndef _WIN32
   testing::FLAGS_gtest_death_test_style = "threadsafe";
+#endif  // _WIN32
   return RUN_ALL_TESTS();
 }

--- a/tests/cpp/dlr_treelite_test.cc
+++ b/tests/cpp/dlr_treelite_test.cc
@@ -8,6 +8,8 @@ TEST(Treelite, Test1) {
 
 int main(int argc, char ** argv) {
   testing::InitGoogleTest(&argc, argv);
+#ifndef _WIN32
   testing::FLAGS_gtest_death_test_style = "threadsafe";
+#endif  // _WIN32
   return RUN_ALL_TESTS();
 }

--- a/tests/cpp/dlr_tvm_test.cc
+++ b/tests/cpp/dlr_tvm_test.cc
@@ -8,6 +8,8 @@ TEST(TVM, Test1) {
 
 int main(int argc, char ** argv) {
   testing::InitGoogleTest(&argc, argv);
+#ifndef _WIN32
   testing::FLAGS_gtest_death_test_style = "threadsafe";
+#endif  // _WIN32
   return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
* Use `_putenv_s()` to set environment variables, since `setenv()` is only available on Linux.
* Do not set `FLAGS_gtest_death_test_style` variable in unit tests, since doing so causes compilation failure on Windows.
* The `__declspec(dllexport)` specifier needs to attach every single symbol.
* Move `msvc_use_static_runtime()` after `project()` directive.
* Use Google Test 1.8.1, as 1.8.0 uses `std::tr1`. (MSVC 2019 dropped support for TR1.)
* Specify `std::ios::binary` when opening the `*.params` file (DL model only). This is because Windows makes distinction between "text files" and "binary files." (Unix does not make this distinction.) Opening the `params` file as text results in an undefined behavior.

TODO: #104 