### PR TITLE
Change TVM runtime to dynamic link.  Add Xilinx Vitis-AI APIs in contrib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,9 +92,6 @@ include_directories("${PROJECT_SOURCE_DIR}/include")
 # Add only top level *.cc files (non-RECURSE)
 FILE(GLOB DLR_SRC
     "src/*.cc"
-    ${TVM_SRC}/src/runtime/dso_module.cc
-    ${TVM_SRC}/src/runtime/cpu_device_api.cc
-    ${TVM_SRC}/src/contrib/sort/sort.cc
 )
 
 if(USE_OPENCL)
@@ -257,7 +254,7 @@ add_library(dlr SHARED $<TARGET_OBJECTS:objdlr>)
 set_output_directory(dlr ${CMAKE_BINARY_DIR}/lib)
 set_target_properties(dlr PROPERTIES LINKER_LANGUAGE CXX)
 message(STATUS "DLR_LINKER_LIBS: " ${DLR_LINKER_LIBS})
-target_link_libraries(dlr treelite_runtime_static tvm_runtime_static ${DLR_LINKER_LIBS})
+target_link_libraries(dlr treelite_runtime_static tvm_runtime ${DLR_LINKER_LIBS})
 
 add_library(dlr_static STATIC $<TARGET_OBJECTS:objdlr>)
 set_output_directory(dlr_static ${CMAKE_BINARY_DIR}/lib)
@@ -281,9 +278,9 @@ foreach(__srcpath ${DEMO_SRCS})
   list(APPEND DEMO_EXECS ${__execname})
   add_executable(${__execname} ${__srcpath} $<TARGET_OBJECTS:objdlr>)
   if (ANDROID_BUILD)
-    target_link_libraries(${__execname} PRIVATE treelite_runtime_static tvm_runtime_static ${DLR_LINKER_LIBS} -fuse-ld=gold)
+    target_link_libraries(${__execname} PRIVATE treelite_runtime_static tvm_runtime ${DLR_LINKER_LIBS} -fuse-ld=gold)
   else (ANDROID_BUILD)
-    target_link_libraries(${__execname} PRIVATE treelite_runtime_static tvm_runtime_static ${DLR_LINKER_LIBS} -lpthread)     
+    target_link_libraries(${__execname} PRIVATE treelite_runtime_static tvm_runtime ${DLR_LINKER_LIBS} -lpthread)     
   endif ()
   set_output_directory(${__execname} ${CMAKE_BINARY_DIR}/bin)
   set_target_properties(${__execname} PROPERTIES EXCLUDE_FROM_ALL 1)

--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@ On X86_64 targets running Linux, you can install latest release of DLR package v
 
 For installation of DLR on non-x86 edge devices, or building DLR from source, please refer to [Installing DLR](https://neo-ai-dlr.readthedocs.io/en/latest/install.html)
 
+## Installation of TVM Runtime
+Required if using python TVM extern with @tvm.register_func
+
+cd 3rdparty/tvm/python
+TVM_LIBRARY_PATH=../../../build/3rdparty/tvm python3 setup.py install --user
+
 ## Documentation
 For instructions on using DLR, please refer to [Amazon SageMaker Neo – Train Your Machine Learning Models Once, Run Them Anywhere](https://aws.amazon.com/blogs/aws/amazon-sagemaker-neo-train-your-machine-learning-models-once-run-them-anywhere/)
 

--- a/python/dlr/contrib/xilinx_vai.py
+++ b/python/dlr/contrib/xilinx_vai.py
@@ -1,0 +1,131 @@
+"""
+All userspace code authored by Xilinx is released under the following license:
+
+Copyright (C) 2019 Xilinx, Inc
+
+Licensed under the Apache License, Version 2.0 (the "License"). You may
+not use this file except in compliance with the License. A copy of the
+License is located at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations
+under the License.
+"""
+
+""" Registration of Xilinx Vitis-AI fused acceleration operation """
+
+import os
+import tvm
+import warnings
+import numpy as np
+
+try:
+    import xfdnn.rt.xdnn as xdnn
+    import xfdnn.rt.xdnn_io as xdnn_io
+    from xfdnn.rt import xdnn, xdnn_io
+except:
+    warnings.warn("Xilinx xfdnn python module not found.")
+
+try:
+    from dnndk import n2cube, dputils
+except:
+    warnings.warn("Xilinx dnndk python module not found.")
+
+
+@tvm.register_func("tvm.accel.accel_fused")
+def accel_fused(path, kernel_name, input_name, output_name, 
+    output_layout, platform, out, *ins):
+
+    #print(kernel_name, input_name, output_name)
+
+    if platform == "DPU":
+
+        # Attach to DPU driver and prepare for running
+        n2cube.dpuOpen()
+        
+        # Create DPU Kernels
+        kernel = n2cube.dpuLoadKernel(kernel_name)
+
+        # Create DPU Tasks for kernel
+        task = n2cube.dpuCreateTask(kernel, 0)
+
+        # Load image to DPU
+        X = ins[0].asnumpy().reshape((-1))
+        n2cube.dpuSetInputTensorInHWCFP32(task, input_name, X, len(X))
+
+        # Model run on DPU """
+        n2cube.dpuRunTask(task)
+        
+        # Get the output tensor size 
+        size = n2cube.dpuGetOutputTensorSize(task, output_name)
+        address = n2cube.dpuGetOutputTensorAddress(task, output_name)
+
+        value = [0 for i in range(size)]
+
+        n2cube.dpuGetTensorData (address, value, size)
+        scale = n2cube.dpuGetOutputTensorScale(task, output_name, idx=0)
+        value = np.array(value).astype(np.float32)/scale
+
+        # DPU output is in NHWC
+        if output_layout == 'NCHW':
+            value = np.transpose(value,(0,3,1,2))
+
+        
+    elif platform == 'XDNN':
+        # CREATE A HANDLE FOR FPGA COMMUNICATION
+        platform = os.environ.get('MLSUITE_PLATFORM')#"alveo-u200"
+        xclbin = "/workspace/MLsuite/overlaybins/" + platform.lower() + "/overlay_4.xclbin"
+
+
+        layout = output_layout 
+        
+        args_dict = {
+            'xclbin'     : xclbin,
+            'netcfg'     : str(path  + "/_compiler.json" ),
+            'quantizecfg': str(path  + "/_quantizer.json"),
+            'weights'    : str(path  + "/_weights.h5"    ), 
+            'scaleA'     : 1,
+            'scaleB'     : 1,
+            'PE'         : 0,
+            'batch_sz'   : ins[0].shape[0],
+            'inshape'    : tuple(ins[0].shape[1:])
+        }
+
+          
+        ret, handles = xdnn.createHandle(xclbin)
+     
+        if ret != 0:
+            raise ValueError("ERROR: Unable to create handle to FPGA")
+        
+        args = xdnn_io.make_dict_args(args_dict)
+     
+        fpgaRT = xdnn.XDNNFPGAOp(handles,args)
+     
+        fpgaInput = fpgaRT.getInputs()
+        fpgaOutput = fpgaRT.getOutputs()
+     
+        batch_array = np.empty(((ins[0].shape[0],) + tuple(ins[0].shape[1:])), dtype=np.float32, order='C')
+        data_paths = [ins[0].asnumpy()]
+     
+        for i in range(0, len(data_paths), ins[0].shape[0]):
+            for j, d in enumerate(data_paths[i:i + ins[0].shape[0]]):
+                batch_array[j, ...] = d
+        
+        fpgaInput[list(fpgaInput.keys())[0]] = batch_array
+     
+        # Execute xdnn
+        fpgaRT.execute(fpgaInput, fpgaOutput)
+
+        key, value  = fpgaOutput.popitem()
+     
+        # xDNN output is in NCHW format
+        if str(layout) == 'NHWC':
+            value = np.transpose(value,(0,2,3,1))
+    else:
+        raise ValueError("Unknown platform: {}".format(platform))
+        
+    tvm.nd.array(value).copyto(out)


### PR DESCRIPTION
* Changes TVM runtime to dynamic to support python TVM runtime functions
* Add Xilinx Vitis-AI APIs for subgraph execution

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.