### PR TITLE
TVM Python Support and Xilinx FPGA APIs (#1)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,9 +92,6 @@ include_directories("${PROJECT_SOURCE_DIR}/include")
 # Add only top level *.cc files (non-RECURSE)
 FILE(GLOB DLR_SRC
     "src/*.cc"
-    ${TVM_SRC}/src/runtime/dso_module.cc
-    ${TVM_SRC}/src/runtime/cpu_device_api.cc
-    ${TVM_SRC}/src/contrib/sort/sort.cc
 )
 
 if(USE_OPENCL)
@@ -257,7 +254,7 @@ add_library(dlr SHARED $<TARGET_OBJECTS:objdlr>)
 set_output_directory(dlr ${CMAKE_BINARY_DIR}/lib)
 set_target_properties(dlr PROPERTIES LINKER_LANGUAGE CXX)
 message(STATUS "DLR_LINKER_LIBS: " ${DLR_LINKER_LIBS})
-target_link_libraries(dlr treelite_runtime_static tvm_runtime_static ${DLR_LINKER_LIBS})
+target_link_libraries(dlr treelite_runtime_static tvm_runtime ${DLR_LINKER_LIBS})
 
 add_library(dlr_static STATIC $<TARGET_OBJECTS:objdlr>)
 set_output_directory(dlr_static ${CMAKE_BINARY_DIR}/lib)
@@ -281,9 +278,9 @@ foreach(__srcpath ${DEMO_SRCS})
   list(APPEND DEMO_EXECS ${__execname})
   add_executable(${__execname} ${__srcpath} $<TARGET_OBJECTS:objdlr>)
   if (ANDROID_BUILD)
-    target_link_libraries(${__execname} PRIVATE treelite_runtime_static tvm_runtime_static ${DLR_LINKER_LIBS} -fuse-ld=gold)
+    target_link_libraries(${__execname} PRIVATE treelite_runtime_static tvm_runtime ${DLR_LINKER_LIBS} -fuse-ld=gold)
   else (ANDROID_BUILD)
-    target_link_libraries(${__execname} PRIVATE treelite_runtime_static tvm_runtime_static ${DLR_LINKER_LIBS} -lpthread)     
+    target_link_libraries(${__execname} PRIVATE treelite_runtime_static tvm_runtime ${DLR_LINKER_LIBS} -lpthread)     
   endif ()
   set_output_directory(${__execname} ${CMAKE_BINARY_DIR}/bin)
   set_target_properties(${__execname} PROPERTIES EXCLUDE_FROM_ALL 1)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ For installation of DLR on non-x86 edge devices, or building DLR from source, pl
 ## Installation of TVM Runtime
 Required if using python TVM extern with @tvm.register_func
 
-cd 3rdparty/tvm/python && TVM_LIBRARY_PATH=../../../build/3rdparty/tvm && python3 setup.py install --user
+cd python && TVM_LIBRARY_PATH=../build/3rdparty/tvm && python setup.py install --user
 
 ## Documentation
 For instructions on using DLR, please refer to [Amazon SageMaker Neo – Train Your Machine Learning Models Once, Run Them Anywhere](https://aws.amazon.com/blogs/aws/amazon-sagemaker-neo-train-your-machine-learning-models-once-run-them-anywhere/)

--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ On X86_64 targets running Linux, you can install latest release of DLR package v
 
 For installation of DLR on non-x86 edge devices, or building DLR from source, please refer to [Installing DLR](https://neo-ai-dlr.readthedocs.io/en/latest/install.html)
 
+## Installation of TVM Runtime
+Required if using python TVM extern with @tvm.register_func
+
+cd 3rdparty/tvm/python && TVM_LIBRARY_PATH=../../../build/3rdparty/tvm && python3 setup.py install --user
+
 ## Documentation
 For instructions on using DLR, please refer to [Amazon SageMaker Neo – Train Your Machine Learning Models Once, Run Them Anywhere](https://aws.amazon.com/blogs/aws/amazon-sagemaker-neo-train-your-machine-learning-models-once-run-them-anywhere/)
 

--- a/python/dlr/contrib/xilinx_vai.py
+++ b/python/dlr/contrib/xilinx_vai.py
@@ -1,0 +1,82 @@
+"""
+All userspace code authored by Xilinx is released under the following license:
+Copyright (C) 2019 Xilinx, Inc
+Licensed under the Apache License, Version 2.0 (the "License"). You may
+not use this file except in compliance with the License. A copy of the
+License is located at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations
+under the License.
+"""
+
+"""
+Registration of Xilinx Vitis-AI fused acceleration operation for aceleration of 
+convolutional neural networks
+
+
+This Vitis-AI acceleration exploits DPU hardware accelerator built for 
+following evaluation boards:
+- Ultra96: https://www.xilinx.com/products/boards-and-kits/1-vad4rl.html
+- ZCU104: https://www.xilinx.com/products/boards-and-kits/zcu104.html
+- ZCU102: https://www.xilinx.com/products/boards-and-kits/ek-u1-zcu102-g.html
+- Zedboard: https://www.xilinx.com/products/boards-and-kits/1-8dyf-11.html
+
+More information about DPU and DNNDK can be found in the user guides:
+https://www.xilinx.com/support/documentation/ip_documentation/dpu/v3_0/pg338-dpu.pdf
+https://www.xilinx.com/support/documentation/sw_manuals/ai_inference/v1_6/ug1327-dnndk-user-guide.pdf
+"""
+
+import tvm
+import warnings
+import numpy as np
+
+try:
+    from dnndk import n2cube
+except:
+    warnings.warn("Could not import dnndk n2cube")
+
+
+@tvm.register_func("tvm.accel.accel_fused")
+def accel_fused(kernel_name, input_name, output_name, 
+    layout, out, *ins):
+
+    # Attach to DPU driver and prepare for running
+    n2cube.dpuOpen()
+    
+    # Create DPU Kernels
+    kernel = n2cube.dpuLoadKernel(kernel_name)
+
+    # Create DPU Tasks for kernel
+    task = n2cube.dpuCreateTask(kernel, 0)
+
+    # Load image to DPU
+    X = ins[0].asnumpy().reshape((-1))
+    n2cube.dpuSetInputTensorInHWCFP32(task, input_name, X, len(X))
+
+    # Model run on DPU """
+    n2cube.dpuRunTask(task)
+    
+    # Get the output tensor size 
+    size = n2cube.dpuGetOutputTensorSize(task, output_name)
+    address = n2cube.dpuGetOutputTensorAddress(task, output_name)
+
+    value = [0 for i in range(size)]
+
+    # Get the output tensor data 
+    n2cube.dpuGetTensorData(address, value, size)
+    scale = n2cube.dpuGetOutputTensorScale(task, output_name, idx=0)
+    
+    value = np.array(value).astype(np.float32) * float(scale)
+    
+    value_shape = tuple(out.shape) if layout == 'NHWC' else  \
+        (out.shape[0], out.shape[2], out.shape[3], out.shape[1])
+    value = np.reshape(value, value_shape)
+
+    # DPU output is in NHWC
+    if layout == 'NCHW':
+        value = np.transpose(value,(0,3,1,2))
+    
+    tvm.nd.array(value).copyto(out)

--- a/python/dlr/contrib/xilinx_vai.py
+++ b/python/dlr/contrib/xilinx_vai.py
@@ -51,9 +51,16 @@ def accel_fused(kernel_name, input_name, output_name,
 
     # Create DPU Tasks for kernel
     task = n2cube.dpuCreateTask(kernel, 0)
-
+    
     # Load image to DPU
-    X = ins[0].asnumpy().reshape((-1))
+    X = ins[0].asnumpy()
+
+    # Possibly transpose input if layout is NCHW
+    if layout == 'NCHW':
+        X = np.transpose(X, (0,2,3,1)) # NCHW --> NHWC
+
+    X = X.reshape((-1))
+    
     n2cube.dpuSetInputTensorInHWCFP32(task, input_name, X, len(X))
 
     # Model run on DPU """


### PR DESCRIPTION
Changes TVM library to dynamic for python support
Adds Xilinx FPGA APIs as contrib

Note requires change to Jenkins build to install TVM python from 3rdparty/tvm/python (python setup.py ...)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
