### PR TITLE
Add special handling logic for Windows drive letter

### DIFF
--- a/src/dlr.cc
+++ b/src/dlr.cc
@@ -7,6 +7,8 @@
 #include "dlr_tflite/dlr_tflite.h"
 #endif // DLR_TFLITE
 
+#include <locale>
+
 
 using namespace dlr;
 
@@ -137,7 +139,18 @@ extern "C" int CreateDLRModel(DLRModelHandle* handle,
   ctx.device_type = static_cast<DLDeviceType>(dev_type);
   ctx.device_id = dev_id;
 
-  std::vector<std::string> path_vec = dmlc::Split(model_path, ':');
+  /* Logic to handle Windows drive letter */
+  std::string model_path_string{model_path};
+  std::string special_prefix{""};
+  if (model_path_string.length() >= 2 && model_path_string[1] == ':' &&
+    std::isalpha(model_path_string[0], std::locale("C"))) {
+    // Handle drive letter
+    special_prefix = model_path_string.substr(0, 2);
+    model_path_string = model_path_string.substr(2);
+  }
+
+  std::vector<std::string> path_vec = dmlc::Split(model_path_string, ':');
+  path_vec[0] = special_prefix + path_vec[0];
 
   DLRBackend backend = dlr::GetBackend(path_vec);
   DLRModel* model;


### PR DESCRIPTION
DLR currently uses colon (:) as the delimiter in the model path, so that we can specify multiple artifacts in the same model path, e.g. `metadata/model.json:lib/model.so:metadata/model.params`. See #98. Colon is fine for most cases, since it does not appear in any file paths. Except in one place: Windows drive letter (e.g. `C:\mydata`). This PR adds a special handling logic to remove the drive letter prior to splitting the model path with the delimiter `:`. Note: Windows paths never contain colon, except for the drive letter.