### PR TITLE
Remove nnvm from  android tvm_compiler/Dockerfile

### DIFF
--- a/examples/android/tvm_compiler/Dockerfile
+++ b/examples/android/tvm_compiler/Dockerfile
@@ -19,8 +19,6 @@ RUN cmake -DUSE_LLVM=ON -DUSE_ANTLR=ON .. && make -j$(nproc)
 
 WORKDIR /root/tvm/python
 RUN python3 setup.py install
-WORKDIR /root/tvm/nnvm/python
-RUN python3 setup.py install
 WORKDIR /root/tvm/topi/python
 RUN python3 setup.py install
 
@@ -29,9 +27,9 @@ RUN pip3 install tensorflow==1.15 keras keras-applications
 RUN pip3 install mxnet gluoncv
 
 WORKDIR /opt
-RUN wget https://dl.google.com/android/repository/android-ndk-r20-linux-x86_64.zip
-RUN unzip android-ndk-r20-linux-x86_64.zip && rm android-ndk-r20-linux-x86_64.zip
-RUN ln -s android-ndk-r20 android-ndk
+RUN wget https://dl.google.com/android/repository/android-ndk-r20b-linux-x86_64.zip
+RUN unzip android-ndk-r20b-linux-x86_64.zip && rm android-ndk-r20b-linux-x86_64.zip
+RUN ln -s android-ndk-r20b android-ndk
 
 WORKDIR /root/tvm_compiler
 COPY tvm_compiler_utils.py compile_keras.py compile_tensorflow.py compile_gluoncv.py ./

--- a/examples/android/tvm_compiler/tvm_compiler_utils.py
+++ b/examples/android/tvm_compiler/tvm_compiler_utils.py
@@ -22,7 +22,7 @@ def tvm_compile(func, params, arch, dlr_model_name):
     target = "llvm -model=x5-Z8350 -target=i686-linux-android -mattr=+ssse3"
     sysroot="/opt/android-ndk/toolchains/llvm/prebuilt/linux-x86_64/sysroot"
     toolchain="/opt/android-ndk/toolchains/x86-4.9/prebuilt/linux-x86_64"
-    os.environ['TVM_NDK_CC'] = "/opt/android-ndk-r20/toolchains/llvm/prebuilt/linux-x86_64/bin/i686-linux-android21-clang++"
+    os.environ['TVM_NDK_CC'] = "/opt/android-ndk/toolchains/llvm/prebuilt/linux-x86_64/bin/i686-linux-android21-clang++"
 
   ###arch arm64 aarch64
   elif arch == 'arm64-v8a':


### PR DESCRIPTION
Changes:
* Remove nnvm from  android tvm_compiler/Dockerfile (it was removed from TVM on Dec 23, 2019)
* Update to android-ndk-r20b
