### PR TITLE
[ec2 container] Make lambda to use mcpu ivybridge

### DIFF
--- a/container/ec2_compilation_container/tvm_ec2_compiler_utils.py
+++ b/container/ec2_compilation_container/tvm_ec2_compiler_utils.py
@@ -24,9 +24,9 @@ def tvm_compile(func, params, arch, dlr_model_name):
   elif arch in ['p2', 'ml_p2']:
     target = "cuda"
     gpu_code = "sm_37"
-  ###arch lambda ssse3,sse4.2
+  ###arch lambda ssse3,sse4.2,avx
   elif arch == 'lambda':
-    target = "llvm -mattr=+ssse3,+sse4.2"
+    target = "llvm -mcpu=ivybridge"
   else:
     print("Valid arch: c4, m4, c5, m5, lambda")
     return


### PR DESCRIPTION
I checked /proc/cpuinfo hw info by running Lambda functions with different amount of memory (128-3096MB) - in all cases I got hardware which has SSSE3, SSE4.2, AVX instructions. To enable these instruction for LLVM we can use -mcpu=ivybridge.

https://gcc.gnu.org/onlinedocs/gcc/x86-Options.html

Ivy Bridge march was introduced in 2012

https://en.wikipedia.org/wiki/Ivy_Bridge_(microarchitecture)

Xeon CPUs on Ivy Bridge:

https://en.wikipedia.org/wiki/Xeon#Sandy_Bridge%E2%80%93_and_Ivy_Bridge%E2%80%93based_Xeon

Testing
I tested the performance
```
resnet50 on Lambda 2048MB
- llvm : 482ms
- llvm -mcpu=ivybridge : 260ms (2x faster)
```