### PR TITLE
Add TF C API adapter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -241,6 +241,12 @@ if(WITH_TENSORFLOW_LITE_LIB)
         list(APPEND DLR_LINKER_LIBS -Wl,--whole-archive ${WITH_TENSORFLOW_LITE_LIB} -Wl,--no-whole-archive -ldl)
     endif()
 endif()
+if(WITH_TENSORFLOW_LIB)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DDLR_TENSORFLOW")
+    include_directories("${WITH_TENSORFLOW_LIB}/include")
+    list(APPEND DLR_SRC "src/dlr_tensorflow/dlr_tensorflow.cc")
+    list(APPEND DLR_LINKER_LIBS -L${WITH_TENSORFLOW_LIB}/lib -ltensorflow_framework -ltensorflow)
+endif()
 if(AAR_BUILD)
     list(APPEND DLR_SRC "src/jni/dlr_jni.cc")
 endif()
@@ -312,6 +318,10 @@ if(NOT(ANDROID_BUILD OR AAR_BUILD))
     file(GLOB TFLITE_TEST_SRCS tests/cpp/dlr_tflite/*.cc)
     list(APPEND TEST_SRCS ${TFLITE_TEST_SRCS})
   endif()
+  if(WITH_TENSORFLOW_LIB)
+    file(GLOB TENSORFLOW_TEST_SRCS tests/cpp/dlr_tensorflow/*.cc)
+    list(APPEND TEST_SRCS ${TENSORFLOW_TEST_SRCS})
+  endif()
   foreach(__srcpath ${TEST_SRCS})
     get_filename_component(__srcname ${__srcpath} NAME)
     string(REPLACE ".cc" "" __execname ${__srcname})
@@ -338,6 +348,22 @@ if(NOT(ANDROID_BUILD OR AAR_BUILD))
         e35e82f3371bed37caa7ecece417f50876414077
       )
   endif() # WITH_TENSORFLOW_LITE_LIB
+  if(WITH_TENSORFLOW_LIB)
+      # Download Test Tensorflow model and input data
+      file(MAKE_DIRECTORY mobilenet_v1_1.0_224)
+      download_file(
+        https://neo-ai-dlr-test-artifacts.s3-us-west-2.amazonaws.com/tf-models/mobilenet_v1_1.0_224_frozen.pb
+        ./mobilenet_v1_1.0_224/mobilenet_v1_1.0_224_frozen.pb
+        SHA1
+        4df8525bcf2ec96296098ba7fec0fff1abe32fce
+      )
+      download_file(
+        https://neo-ai-dlr-test-artifacts.s3-us-west-2.amazonaws.com/tf-models/cat224-3.txt
+        ./cat224-3.txt
+        SHA1
+        e35e82f3371bed37caa7ecece417f50876414077
+      )
+  endif() # WITH_TENSORFLOW_LIB
 endif()
 
 # Group sources

--- a/include/dlr.h
+++ b/include/dlr.h
@@ -67,6 +67,27 @@ int CreateDLRModelFromTFLite(DLRModelHandle *handle,
                    int use_nnapi);
 #endif // DLR_TFLITE
 
+#ifdef DLR_TENSORFLOW
+/*!
+ \brief Creates a DLR model from Tensorflow frozen model .pb file
+ \param handle The pointer to save the model handle.
+ \param model_path Path to .pb file or to the top-level directory containing .pb file
+ \param inputs array of input names
+ \param input_size size of input array
+ \param outputs array of output names
+ \param output_size size of output array
+ \param batch_size set batch size for the case when the model has dynamic batch size
+ \param threads Number of threads to use (ignored if zero of less)
+ \return 0 for success, -1 for error. Call DLRGetLastError() to get the error message.
+ */
+int CreateDLRModelFromTensorflow(DLRModelHandle *handle,
+                   const char *model_path,
+                   const char* inputs[], int input_size,
+                   const char* outputs[], int output_size,
+                   const int batch_size,
+                   const int threads);
+#endif // DLR_TENSORFLOW
+
 /*!
  \brief Deletes a DLR model.
  \param handle The model handle returned from CreateDLRModel().

--- a/include/dlr_common.h
+++ b/include/dlr_common.h
@@ -57,7 +57,8 @@ inline bool EndsWith(const std::string& mainStr, const std::string& toMatch) {
 enum class DLRBackend {
   kTVM,
   kTREELITE,
-  kTFLITE
+  kTFLITE,
+  kTENSORFLOW
 };
 
 /*! \brief Get the backend based on the contents of the model folder.

--- a/include/dlr_tensorflow/dlr_tensorflow.h
+++ b/include/dlr_tensorflow/dlr_tensorflow.h
@@ -1,0 +1,64 @@
+#ifndef DLR_TENSORFLOW_H_
+#define DLR_TENSORFLOW_H_
+
+#include "dlr_common.h"
+#include "tensorflow/c/c_api.h"
+
+namespace dlr {
+
+/*! \brief Get the paths of the Tensorflow model files.
+ */
+std::string GetTensorflowFile(const std::string& dirname);
+
+/*! \brief free_buffer function used to cleanup memory after TF model is built.
+ */
+void FreeBuffer(void* data, size_t length);
+
+/*! \brief read tensorflow model file.
+ */
+TF_Buffer* ReadTFFile(const char* file);
+
+/*! \brief class TensorflowModel
+ */
+class TensorflowModel : public DLRModel {
+ private:
+  TF_Status* status_;
+  TF_Graph* graph_;
+  TF_Session* sess_;
+  // input_names_ are declared in base class
+  std::vector<std::string> output_names_;
+  std::vector<TF_Output> inputs_;
+  std::vector<TF_Output> outputs_;
+  std::vector<TF_Tensor*> input_tensors_;
+  std::vector<TF_Tensor*> output_tensors_;
+  void LoadFrozenModel(const char* pb_file);
+  void GenTensorSpec(bool is_input, const int batch_size);
+  int GetInputId(const char* name);
+
+ public:
+  /*! \brief Load model files from given folder path.
+   */
+  explicit TensorflowModel(const std::string& model_path, const DLContext& ctx,
+                           const std::vector<std::string>& inputs,
+                           const std::vector<std::string>& outputs,
+                           const int batch_size, const int threads);
+  ~TensorflowModel();
+
+  virtual const char* GetInputName(int index) const override;
+  virtual const char* GetWeightName(int index) const override;
+  virtual std::vector<std::string> GetWeightNames() const override;
+  virtual void GetInput(const char* name, float* input) override;
+  virtual void SetInput(const char* name, const int64_t* shape, float* input,
+                        int dim) override;
+  virtual void Run() override;
+  virtual void GetOutput(int index, float* out) override;
+  virtual void GetOutputShape(int index, int64_t* shape) const override;
+  virtual void GetOutputSizeDim(int index, int64_t* size, int* dim) override;
+  virtual const char* GetBackend() const override;
+  virtual void SetNumThreads(int threads) override;
+  virtual void UseCPUAffinity(bool use) override;
+};
+
+}  // namespace dlr
+
+#endif  // DLR_TENSORFLOW_H_

--- a/src/dlr.cc
+++ b/src/dlr.cc
@@ -6,6 +6,9 @@
 #ifdef DLR_TFLITE
 #include "dlr_tflite/dlr_tflite.h"
 #endif // DLR_TFLITE
+#ifdef DLR_TENSORFLOW
+#include "dlr_tensorflow/dlr_tensorflow.h"
+#endif // DLR_TENSORFLOW
 
 #include <locale>
 
@@ -128,6 +131,30 @@ int CreateDLRModelFromTFLite(DLRModelHandle *handle,
   API_END();
 }
 #endif // DLR_TFLITE
+
+#ifdef DLR_TENSORFLOW
+/*! \brief Translate c args from ctypes to std types for DLRModelFromTensorflow ctor.
+ */
+int CreateDLRModelFromTensorflow(DLRModelHandle *handle,
+                                 const char *model_path,
+                                 const char* inputs[], int input_size,
+                                 const char* outputs[], int output_size,
+                                 const int batch_size,
+                                 int threads) {
+  API_BEGIN();
+  const std::string model_path_string(model_path);
+  // TensorflowModel class does not use DLContext internally
+  DLContext ctx;
+  ctx.device_type = static_cast<DLDeviceType>(1); // 1 - kDLCPU
+  ctx.device_id = 0;
+  std::vector<std::string> v_inputs(inputs, inputs + input_size);
+  std::vector<std::string> v_outputs(outputs, outputs + output_size);
+  DLRModel* model = new TensorflowModel(
+      model_path_string, ctx, v_inputs, v_outputs, batch_size, threads);
+  *handle = model;
+  API_END();
+}
+#endif // DLR_TENSORFLOW
 
 /*! \brief Translate c args from ctypes to std types for DLRModel ctor.
  */

--- a/src/dlr_tensorflow/dlr_tensorflow.cc
+++ b/src/dlr_tensorflow/dlr_tensorflow.cc
@@ -1,0 +1,304 @@
+#include "dlr_tensorflow/dlr_tensorflow.h"
+
+#include <cstring>
+#include <fstream>
+#include <numeric>
+#include <regex>
+
+using namespace dlr;
+
+std::string dlr::GetTensorflowFile(const std::string& dirname) {
+  // Support the case where user provides full path to .pb file.
+  if (EndsWith(dirname, ".pb")) {
+    return dirname;
+  }
+  // Scan Dir to find .pb file and check that only one .pb file is provided.
+  std::string pb_file;
+  std::vector<std::string> paths_vec;
+  ListDir(dirname, paths_vec);
+  for (auto filename : paths_vec) {
+    std::string basename = GetBasename(filename);
+    if (EndsWith(filename, ".pb")) {
+      if (pb_file.empty()) {
+        pb_file = filename;
+      } else {
+        LOG(FATAL) << "Multiple .pb files under the folder: " << dirname;
+      }
+    }
+  }
+  if (pb_file.empty()) {
+    LOG(FATAL) << "No Tensorflow frozen model file found under folder: "
+               << dirname;
+  }
+  return pb_file;
+}
+
+void dlr::FreeBuffer(void* data, size_t length) { free(data); }
+
+TF_Buffer* dlr::ReadTFFile(const char* file) {
+  FILE* f = fopen(file, "rb");
+  fseek(f, 0L, SEEK_END);
+  long fsize = ftell(f);
+  fseek(f, 0L, SEEK_SET);  // same as rewind(f);
+
+  void* data = malloc(fsize);
+  if (fread(data, fsize, 1, f) != 1) {
+    printf("File read error....\n");
+  }
+  fclose(f);
+
+  TF_Buffer* buf = TF_NewBuffer();
+  buf->data = data;
+  buf->length = fsize;
+  buf->data_deallocator = FreeBuffer;
+  return buf;
+}
+
+void TensorflowModel::LoadFrozenModel(const char* pb_file) {
+  const char* op_prefix = "";
+  TF_ImportGraphDefOptions* opts = TF_NewImportGraphDefOptions();
+  TF_ImportGraphDefOptionsSetPrefix(opts, op_prefix);
+
+  TF_Buffer* graph_def = ReadTFFile(pb_file);
+  TF_GraphImportGraphDef(graph_, graph_def, opts, status_);
+  if (TF_GetCode(status_) != TF_OK) {
+    LOG(FATAL) << "ERROR: Unable to import graph " << TF_Message(status_);
+    return;  // unreachable
+  }
+  LOG(INFO) << "Successfully imported graph";
+  TF_DeleteImportGraphDefOptions(opts);
+  TF_DeleteBuffer(graph_def);
+}
+
+void TensorflowModel::GenTensorSpec(bool is_input, const int batch_size) {
+  std::vector<std::string> tensor_names =
+      is_input ? input_names_ : output_names_;
+  std::regex r("^(.+):(\\d+)$");
+  for (std::string t_name : tensor_names) {
+    std::smatch match;
+    std::string op_name;
+    int op_out_id;
+    if (std::regex_search(t_name, match, r)) {
+      op_name = match.str(1);
+      op_out_id = std::stoi(match.str(2));
+    } else {
+      LOG(FATAL) << "ERROR: failed to parse tensor name " << t_name;
+      return;  // unreachable
+    }
+
+    TF_Operation* op = TF_GraphOperationByName(graph_, op_name.c_str());
+    if (op == NULL) {
+      LOG(FATAL)
+          << "ERROR: inputOp TF_GraphOperationByName failed for operation "
+          << op_name;
+      return;  // unreachable
+    }
+    TF_Output oper_out = {op, op_out_id};
+    const int n_dim = TF_GraphGetTensorNumDims(graph_, oper_out, status_);
+    if (TF_GetCode(status_) != TF_OK) {
+      LOG(FATAL) << "ERROR: TF_GraphGetTensorNumDims failed "
+                 << TF_Message(status_);
+      return;  // unreachable
+    }
+    int64_t dims[n_dim];
+    TF_GraphGetTensorShape(graph_, oper_out, dims, n_dim, status_);
+    if (TF_GetCode(status_) != TF_OK) {
+      LOG(FATAL) << "ERROR: TF_GraphGetTensorShape failed "
+                 << TF_Message(status_);
+      return;  // unreachable
+    }
+    // Set fixed batch size if batch size is dynamic
+    if (dims[0] == -1) {
+      dims[0] = batch_size > 0 ? batch_size : 1;
+      TF_GraphSetTensorShape(graph_, oper_out, dims, n_dim, status_);
+      if (TF_GetCode(status_) != TF_OK) {
+        LOG(FATAL) << "ERROR: TF_GraphSetTensorShape failed "
+                   << TF_Message(status_);
+        return;  // unreachable
+      }
+    }
+    size_t num_elements = 1;
+    for (int z = 0; z < n_dim; z++) {
+      if (dims[z] == -1) {
+        LOG(FATAL) << "ERROR: dynamic tensor shape is not supported";
+        return;  // unreachable
+      }
+      num_elements *= dims[z];
+    }
+    TF_DataType t_type = TF_OperationOutputType(oper_out);
+    size_t num_bytes = TF_DataTypeSize(t_type) * num_elements;
+
+    TF_Tensor* tensor = TF_AllocateTensor(t_type, dims, n_dim, num_bytes);
+
+    if (is_input) {
+      inputs_.push_back(oper_out);
+      input_tensors_.push_back(tensor);
+    } else {
+      outputs_.push_back(oper_out);
+      output_tensors_.push_back(tensor);
+    }
+  }
+}
+
+int TensorflowModel::GetInputId(const char* name) {
+  // In most of the cases it will be just 1 element in the vector.
+  // Scan vector to find tensor by name.
+  for (int i = 0; i < num_inputs_; i++) {
+    if (input_names_[i].compare(name) == 0) {
+      return i;
+    }
+  }
+  LOG(FATAL) << "Input Tensor not found, name: " << name;
+  return -1;  // unreachable
+}
+
+// Constructor
+TensorflowModel::TensorflowModel(const std::string& model_path,
+                                 const DLContext& ctx,
+                                 const std::vector<std::string>& inputs,
+                                 const std::vector<std::string>& outputs,
+                                 const int batch_size, const int threads)
+    : DLRModel(ctx, DLRBackend::kTENSORFLOW) {
+  const std::string pb_file = GetTensorflowFile(model_path);
+
+  status_ = TF_NewStatus();
+  graph_ = TF_NewGraph();
+
+  LoadFrozenModel(pb_file.c_str());
+
+  // Using assignment operator to copy one vector to other
+  input_names_ = inputs;
+  output_names_ = outputs;
+  num_inputs_ = inputs.size();
+  num_outputs_ = outputs.size();
+
+  GenTensorSpec(/*is_input=*/true, batch_size);
+  GenTensorSpec(/*is_input=*/false, batch_size);
+
+  LOG(INFO) << "Tensorflow Model was created";
+
+  TF_SessionOptions* opts = TF_NewSessionOptions();
+  if (threads > 0 && threads < 256) {
+    // More info https://github.com/tensorflow/tensorflow/issues/13853
+    std::array<std::uint8_t, 4> config = {
+        {0x10, (std::uint8_t)threads, 0x28, (std::uint8_t)threads}};
+    TF_SetConfig(opts, config.data(), config.size(), status_);
+
+    if (TF_GetCode(status_) != TF_OK) {
+      TF_DeleteSessionOptions(opts);
+      LOG(FATAL) << "ERROR: TF_SetConfig failed " << TF_Message(status_);
+      return;  // unreachable
+    }
+    LOG(INFO) << "Set number of threads to " << threads;
+  }
+
+  sess_ = TF_NewSession(graph_, opts, status_);
+  if (TF_GetCode(status_) != TF_OK) {
+    LOG(FATAL) << "ERROR: Unable to create Session " << TF_Message(status_);
+    return;  // unreachable
+  }
+  TF_DeleteSessionOptions(opts);
+  LOG(INFO) << "Tensorflow Session was created";
+}
+
+// Destructor
+TensorflowModel::~TensorflowModel() {
+  for (TF_Tensor* tensor : input_tensors_) {
+    TF_DeleteTensor(tensor);
+  }
+  for (TF_Tensor* tensor : output_tensors_) {
+    TF_DeleteTensor(tensor);
+  }
+  TF_CloseSession(sess_, status_);
+  // Result of close is ignored, delete anyway.
+  TF_DeleteSession(sess_, status_);
+  TF_DeleteGraph(graph_);
+  TF_DeleteStatus(status_);
+
+  LOG(INFO) << "TensorflowModel was deleted";
+}
+
+std::vector<std::string> TensorflowModel::GetWeightNames() const {
+  LOG(FATAL) << "GetWeightNames is not supported by Tensorflow backend";
+  return std::vector<std::string>();  // unreachable
+}
+
+const char* TensorflowModel::GetInputName(int index) const {
+  CHECK_LT(index, num_inputs_) << "Input index is out of range.";
+  return input_names_[index].c_str();
+}
+
+const char* TensorflowModel::GetWeightName(int index) const {
+  LOG(FATAL) << "GetWeightName is not supported by Tensorflow backend";
+  return "";  // unreachable
+}
+
+void TensorflowModel::SetInput(const char* name, const int64_t* shape,
+                               float* input, int dim) {
+  int index = GetInputId(name);
+  TF_Tensor* tensor = input_tensors_[index];
+  CHECK_EQ(dim, TF_NumDims(tensor)) << "Incorrect input dim";
+  for (int i = 0; i < dim; i++) {
+    CHECK_EQ(shape[i], TF_Dim(tensor, i)) << "Incorrect input shape";
+  }
+  size_t num_bytes = TF_TensorByteSize(tensor);
+  float* in_t_data = (float*)TF_TensorData(tensor);
+  std::memcpy(in_t_data, input, num_bytes);
+}
+
+void TensorflowModel::GetInput(const char* name, float* input) {
+  int index = GetInputId(name);
+  TF_Tensor* tensor = input_tensors_[index];
+  size_t num_bytes = TF_TensorByteSize(tensor);
+  float* in_t_data = (float*)TF_TensorData(tensor);
+  std::memcpy(input, in_t_data, num_bytes);
+}
+
+void TensorflowModel::GetOutputShape(int index, int64_t* shape) const {
+  CHECK_LT(index, num_outputs_) << "Output index is out of range.";
+  TF_Tensor* tensor = output_tensors_[index];
+  int n_dim = TF_NumDims(tensor);
+  for (int i = 0; i < n_dim; i++) {
+    shape[i] = TF_Dim(tensor, i);
+  }
+}
+
+void TensorflowModel::GetOutput(int index, float* output) {
+  CHECK_LT(index, num_outputs_) << "Output index is out of range.";
+  TF_Tensor* tensor = output_tensors_[index];
+  size_t num_bytes = TF_TensorByteSize(tensor);
+  float* out_t_data = (float*)TF_TensorData(tensor);
+  std::memcpy(output, out_t_data, num_bytes);
+}
+
+void TensorflowModel::GetOutputSizeDim(int index, int64_t* size, int* dim) {
+  CHECK_LT(index, num_outputs_) << "Output index is out of range.";
+  TF_Tensor* tensor = output_tensors_[index];
+  *size = TF_TensorElementCount(tensor);
+  *dim = TF_NumDims(tensor);
+}
+
+void TensorflowModel::Run() {
+  TF_SessionRun(sess_,
+                NULL,  // Run options.
+                inputs_.data(), input_tensors_.data(), num_inputs_,
+                outputs_.data(), output_tensors_.data(), num_outputs_, NULL,
+                0,       // Target operations, number of targets.
+                NULL,    // Run metadata.
+                status_  // Output status.
+  );
+  if (TF_GetCode(status_) != TF_OK) {
+    LOG(FATAL) << "ERROR: Session run error: " << TF_Message(status_);
+    return;  // unreachable
+  }
+}
+
+const char* TensorflowModel::GetBackend() const { return "tensorflow"; }
+
+void TensorflowModel::SetNumThreads(int threads) {
+  LOG(FATAL) << "SetNumThreads is not supported by Tensorflow backend";
+}
+
+void TensorflowModel::UseCPUAffinity(bool use) {
+  LOG(FATAL) << "UseCPUAffinity is not supported by Tensorflow backend";
+}

--- a/tests/cpp/dlr_tensorflow/dlr_tensorflow_test.cc
+++ b/tests/cpp/dlr_tensorflow/dlr_tensorflow_test.cc
@@ -1,0 +1,221 @@
+#include <dmlc/logging.h>
+#include <gtest/gtest.h>
+
+#include <cstring>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+
+#include "dlr.h"
+
+float* LoadImageAndPreprocess(const std::string& img_path, size_t size,
+                              int batch_size) {
+  std::string line;
+  std::ifstream fp(img_path);
+  float* img = new float[size * batch_size];
+  size_t i = 0;
+  if (fp.is_open()) {
+    while (getline(fp, line) && i < size) {
+      int v = std::stoi(line);
+      float fv = 2.0f / 255.0f * v - 1.0f;
+      img[i++] = fv;
+    }
+    fp.close();
+  }
+
+  EXPECT_EQ(size, i);
+  LOG(INFO) << "Image read - OK, float[" << i << "]";
+
+  for (int j = 1; j < batch_size; j++) {
+    std::memcpy(img + j * size, img, size * sizeof(float));
+  }
+  return img;
+}
+
+int ArgMax(float* data, int start, int size) {
+  int idx = 0;
+  float v = 0.0f;
+  for (int i = start; i < start + size; i++) {
+    float vi = data[i];
+    if (vi > v) {
+      idx = i;
+      v = vi;
+    }
+  }
+  return idx;
+}
+
+void CheckAllDLRMethods(DLRModelHandle& handle, const int batch_size) {
+  // GetDLRBackend
+  const char* backend_name;
+  if (GetDLRBackend(&handle, &backend_name)) {
+    FAIL() << "GetDLRBackend failed";
+  }
+  LOG(INFO) << "GetDLRBackend: " << backend_name;
+  EXPECT_STREQ("tensorflow", backend_name);
+
+  // GetDLRNumInputs
+  int num_inputs;
+  if (GetDLRNumInputs(&handle, &num_inputs)) {
+    FAIL() << "GetDLRNumInputs failed";
+  }
+  LOG(INFO) << "GetDLRNumInputs: " << num_inputs;
+  EXPECT_EQ(1, num_inputs);
+
+  // GetDLRNumOutputs
+  int num_outputs;
+  if (GetDLRNumOutputs(&handle, &num_outputs)) {
+    FAIL() << "GetDLRNumOutputs failed";
+  }
+  LOG(INFO) << "GetDLRNumOutputs: " << num_outputs;
+  EXPECT_EQ(1, num_outputs);
+
+  // GetDLRNumWeights
+  int num_weights;
+  if (GetDLRNumWeights(&handle, &num_weights)) {
+    FAIL() << "GetDLRNumWeights failed";
+  }
+  LOG(INFO) << "GetDLRNumWeights: " << num_weights;
+  EXPECT_EQ(0, num_weights);
+
+  // GetDLRInputName
+  const char* input_name;
+  if (GetDLRInputName(&handle, 0, &input_name)) {
+    FAIL() << "GetDLRInputName failed";
+  }
+  LOG(INFO) << "DLRInputName: " << input_name;
+  EXPECT_STREQ("input:0", input_name);
+
+  // GetDLROutputSizeDim
+  int64_t out_size;
+  int out_dim;
+  if (GetDLROutputSizeDim(&handle, 0, &out_size, &out_dim)) {
+    FAIL() << "GetDLROutputSizeDim failed";
+  }
+  LOG(INFO) << "GetDLROutputSizeDim.size: " << out_size;
+  LOG(INFO) << "GetDLROutputSizeDim.dim: " << out_dim;
+  EXPECT_EQ(1001 * batch_size, out_size);
+  EXPECT_EQ(2, out_dim);
+
+  // GetDLROutputShape
+  int64_t shape[out_dim];
+  if (GetDLROutputShape(&handle, 0, shape)) {
+    FAIL() << "GetDLROutputShape failed";
+  }
+  std::stringstream ss;
+  ss << "GetDLROutputShape: (" << shape[0];
+  for (int i = 1; i < out_dim; i++) {
+    ss << "," << shape[i];
+  }
+  ss << ")";
+  LOG(INFO) << ss.str();
+  const int64_t exp_shape[2] = {batch_size, 1001};
+  EXPECT_TRUE(std::equal(std::begin(exp_shape), std::end(exp_shape), shape));
+
+  // Load image
+  size_t img_size = 224 * 224 * 3;
+  float* img = LoadImageAndPreprocess("cat224-3.txt", img_size, batch_size);
+  LOG(INFO) << "Input sample: [" << img[0] << "," << img[1] << "..."
+            << img[img_size - 1] << "]...[" << img[img_size * (batch_size - 1)]
+            << "," << img[img_size * (batch_size - 1) + 1] << "..."
+            << img[img_size * batch_size - 1] << "]";
+  img_size *= batch_size;
+
+  // SetDLRInput
+  const int64_t in_shape[4] = {batch_size, 224, 224, 3};
+  if (SetDLRInput(&handle, input_name, in_shape, img, 4)) {
+    FAIL() << "SetDLRInput failed";
+  }
+  LOG(INFO) << "SetDLRInput - OK";
+
+  // GetDLRInput
+  float* input2 = new float[img_size];
+  if (GetDLRInput(&handle, input_name, input2)) {
+    FAIL() << "GetDLRInput failed";
+  }
+  EXPECT_TRUE(std::equal(img, img + img_size, input2));
+  LOG(INFO) << "GetDLRInput - OK";
+
+  // RunDLRModel
+  if (RunDLRModel(&handle)) {
+    FAIL() << "RunDLRModel failed";
+  }
+  LOG(INFO) << "RunDLRModel - OK";
+
+  // GetDLROutput (the first and the last item in the batch)
+  float* output = new float[out_size];
+  if (GetDLROutput(&handle, 0, output)) {
+    FAIL() << "GetDLROutput failed";
+  }
+  LOG(INFO) << "GetDLROutput - OK";
+  size_t out_size0 = out_size / batch_size;
+  for (int i = 0; i < batch_size; i++) {
+    size_t out_offset = i * out_size0;
+    size_t max_id = ArgMax(output, out_offset, out_size0);
+    LOG(INFO) << "ArgMax: " << max_id << ", Prop: " << output[max_id];
+    // Tensorflow class range is 1-1000 (output size 1001)
+    // Imagenet1000 class range is 0-999
+    // https://gist.github.com/yrevar/942d3a0ac09ec9e5eb3a
+    // Tensorflow 283 maps to Imagenet 282 - tiger cat
+    EXPECT_EQ(out_offset + 283, max_id);
+    EXPECT_GE(output[max_id], 0.5f);
+    // Tensorflow 282 maps to Imagenet 281 - tabby, tabby cat
+    EXPECT_GE(output[out_offset + 282], 0.3f);
+  }
+
+  // clean up
+  delete[] img;
+  delete[] input2;
+  delete[] output;
+}
+
+TEST(Tensorflow, CreateDLRModelFromTensorflow) {
+  // CreateDLRModelFromTensorflow (use .pb file)
+  const char* model_file =
+      "./mobilenet_v1_1.0_224/mobilenet_v1_1.0_224_frozen.pb";
+  int threads = 2;
+  int batch_size = 1;
+  const char* inputs[1] = {"input:0"};
+  const char* outputs[1] = {"MobilenetV1/Predictions/Reshape_1:0"};
+
+  DLRModelHandle handle;
+  if (CreateDLRModelFromTensorflow(&handle, model_file, inputs, 1, outputs, 1,
+                                   batch_size, threads)) {
+    FAIL() << "CreateDLRModelFromTensorflow failed";
+  }
+  LOG(INFO) << "CreateDLRModelFromTensorflow - OK";
+
+  CheckAllDLRMethods(handle, batch_size);
+
+  // DeleteDLRModel
+  DeleteDLRModel(&handle);
+}
+
+TEST(Tensorflow2, CreateDLRModelFromTensorflowDir) {
+  // CreateDLRModelFromTensorflow (use folder containing .pb file)
+  const char* model_dir = "./mobilenet_v1_1.0_224";
+  int threads = 0;  // undefined
+  int batch_size = 8;
+  const char* inputs[1] = {"input:0"};
+  const char* outputs[1] = {"MobilenetV1/Predictions/Reshape_1:0"};
+
+  DLRModelHandle handle;
+  if (CreateDLRModelFromTensorflow(&handle, model_dir, inputs, 1, outputs, 1,
+                                   batch_size, threads)) {
+    FAIL() << "CreateDLRModelFromTensorflow failed";
+  }
+  LOG(INFO) << "CreateDLRModelFromTensorflow - OK";
+
+  CheckAllDLRMethods(handle, batch_size);
+
+  // DeleteDLRModel
+  DeleteDLRModel(&handle);
+}
+
+int main(int argc, char** argv) {
+  testing::InitGoogleTest(&argc, argv);
+#ifndef _WIN32
+  testing::FLAGS_gtest_death_test_style = "threadsafe";
+#endif  // _WIN32
+  return RUN_ALL_TESTS();
+}

--- a/tests/cpp/dlr_tflite/dlr_tflite_test.cc
+++ b/tests/cpp/dlr_tflite/dlr_tflite_test.cc
@@ -123,6 +123,7 @@ void CheckAllDLRMethods(DLRModelHandle& handle) {
     FAIL() << "GetDLRInput failed";
   }
   EXPECT_TRUE(std::equal(img, img + img_size, input2));
+  LOG(INFO) << "GetDLRInput - OK";
 
   // RunDLRModel
   if (RunDLRModel(&handle)) {


### PR DESCRIPTION
TF C API adapter allows DLR to run .pb files directly using Native Tensorflow C API (libtensorflow.so).

This is needed for 
* Alexa team to run .pb files on p3 instances in their C++ based product (gstreamer).
* Autodesk to run .pb file on aws lambda (unpacked lambda function size limit is 250 GB, libtensorflow.so is abut 200MB).

Pre-built Tensorflow for CPU and GPU can be found here https://www.tensorflow.org/install/lang_c

Better to build TF lib from source as described here https://github.com/tensorflow/tensorflow/blob/r1.15/tensorflow/tools/lib_package/README.md

TF lib for aws lambda: https://pivovaa-us-west-1.s3-us-west-1.amazonaws.com/libtensorflow-ivybridge.tar.gz

TF lib for p3 cuda 10.0 / cudnn 7.6.5: https://pivovaa-us-west-1.s3-us-west-1.amazonaws.com/libtensorflow-gpu-10-0.tar.gz

Command to build Tensorflow 1.15.0:
```
git clone https://github.com/tensorflow/tensorflow.git
cd tensorflow
git checkout r.1.15

./configure

bazel build -s \
--explain /tmp/build.log \
--verbose_explanations \
--config opt \
--config=v1 \
--verbose_failures \
--config=noaws \
--config=nogcp \
--config=nohdfs \
--config=noignite \
--config=nokafka \
--config=nonccl \
//tensorflow/tools/lib_package:libtensorflow
```
This command will produce `libtensorflow.tar.gz`.
Extract it to some folder and export TF_LIB to point to the folder.

Command to build DLR:
```
cmake -DWITH_TENSORFLOW_LIB=$TF_LIB -DCMAKE_BUILD_TYPE=Release ..

make -j$(nproc)
```

Command to run DLR/TF test `dlr_tensorflow_test`
```
LD_LIBRARY_PATH=$TF_LIB/lib ./dlr_tensorflow_test
```