### PR TITLE
Ask input shape in TF C API

### DIFF
--- a/include/dlr.h
+++ b/include/dlr.h
@@ -66,6 +66,15 @@ int CreateDLRModelFromTFLite(DLRModelHandle* handle, const char* model_path,
 
 #ifdef DLR_TENSORFLOW
 /*!
+ \brief Input Tensor Description structure for CreateDLRModelFromTensorflow.
+ */
+typedef struct DLR_TFTensorDesc {
+  const char* name;
+  const int64_t* dims;
+  const int num_dims;
+} DLR_TFTensorDesc;
+
+/*!
  \brief Creates a DLR model from Tensorflow frozen model .pb file
  \param handle The pointer to save the model handle.
  \param model_path Path to .pb file or to the top-level directory containing .pb
@@ -77,9 +86,9 @@ int CreateDLRModelFromTFLite(DLRModelHandle* handle, const char* model_path,
  0 for success, -1 for error. Call DLRGetLastError() to get the error message.
  */
 int CreateDLRModelFromTensorflow(DLRModelHandle* handle, const char* model_path,
-                                 const char* inputs[], int input_size,
+                                 const DLR_TFTensorDesc* inputs, int input_size,
                                  const char* outputs[], int output_size,
-                                 const int batch_size, const int threads);
+                                 const int threads);
 #endif  // DLR_TENSORFLOW
 
 /*!

--- a/include/dlr_tensorflow/dlr_tensorflow.h
+++ b/include/dlr_tensorflow/dlr_tensorflow.h
@@ -26,22 +26,26 @@ class TensorflowModel : public DLRModel {
   TF_Graph* graph_;
   TF_Session* sess_;
   // input_names_ are declared in base class
+  std::vector<std::vector<int64_t>> input_shapes_;
   std::vector<std::string> output_names_;
   std::vector<TF_Output> inputs_;
   std::vector<TF_Output> outputs_;
   std::vector<TF_Tensor*> input_tensors_;
   std::vector<TF_Tensor*> output_tensors_;
   void LoadFrozenModel(const char* pb_file);
-  void GenTensorSpec(bool is_input, const int batch_size);
+  TF_Output ParseTensorName(const std::string& t_name);
+  void PrepInputs();
+  void PrepOutputs();
   int GetInputId(const char* name);
 
  public:
   /*! \brief Load model files from given folder path.
    */
-  explicit TensorflowModel(const std::string& model_path, const DLContext& ctx,
-                           const std::vector<std::string>& inputs,
-                           const std::vector<std::string>& outputs,
-                           const int batch_size, const int threads);
+  explicit TensorflowModel(
+      const std::string& model_path, const DLContext& ctx,
+      const std::vector<std::string>& inputs,
+      const std::vector<std::vector<int64_t>>& input_shapes,
+      const std::vector<std::string>& outputs, const int threads);
   ~TensorflowModel();
 
   virtual const char* GetInputName(int index) const override;

--- a/src/dlr.cc
+++ b/src/dlr.cc
@@ -126,19 +126,25 @@ int CreateDLRModelFromTFLite(DLRModelHandle* handle, const char* model_path,
  * ctor.
  */
 int CreateDLRModelFromTensorflow(DLRModelHandle* handle, const char* model_path,
-                                 const char* inputs[], int input_size,
+                                 const DLR_TFTensorDesc* inputs, int input_size,
                                  const char* outputs[], int output_size,
-                                 const int batch_size, int threads) {
+                                 const int threads) {
   API_BEGIN();
   const std::string model_path_string(model_path);
   // TensorflowModel class does not use DLContext internally
   DLContext ctx;
   ctx.device_type = static_cast<DLDeviceType>(1);  // 1 - kDLCPU
   ctx.device_id = 0;
-  std::vector<std::string> v_inputs(inputs, inputs + input_size);
+  std::vector<std::string> v_inputs(input_size);
+  std::vector<std::vector<int64_t>> v_input_shapes(input_size);
+  for (int i = 0; i < input_size; i++) {
+    DLR_TFTensorDesc v = inputs[i];
+    v_inputs[i] = v.name;
+    v_input_shapes[i] = std::vector<int64_t>(v.dims, v.dims + v.num_dims);
+  }
   std::vector<std::string> v_outputs(outputs, outputs + output_size);
   DLRModel* model = new TensorflowModel(model_path_string, ctx, v_inputs,
-                                        v_outputs, batch_size, threads);
+                                        v_input_shapes, v_outputs, threads);
   *handle = model;
   API_END();
 }

--- a/tests/cpp/dlr_tensorflow/dlr_tensorflow_test.cc
+++ b/tests/cpp/dlr_tensorflow/dlr_tensorflow_test.cc
@@ -175,12 +175,13 @@ TEST(Tensorflow, CreateDLRModelFromTensorflow) {
       "./mobilenet_v1_1.0_224/mobilenet_v1_1.0_224_frozen.pb";
   int threads = 2;
   int batch_size = 1;
-  const char* inputs[1] = {"input:0"};
+  const int64_t dims[4] = {batch_size, 224, 224, 3};
+  const DLR_TFTensorDesc inputs[1] = {{"input:0", dims, 4}};
   const char* outputs[1] = {"MobilenetV1/Predictions/Reshape_1:0"};
 
   DLRModelHandle handle;
   if (CreateDLRModelFromTensorflow(&handle, model_file, inputs, 1, outputs, 1,
-                                   batch_size, threads)) {
+                                   threads)) {
     FAIL() << "CreateDLRModelFromTensorflow failed";
   }
   LOG(INFO) << "CreateDLRModelFromTensorflow - OK";
@@ -191,17 +192,18 @@ TEST(Tensorflow, CreateDLRModelFromTensorflow) {
   DeleteDLRModel(&handle);
 }
 
-TEST(Tensorflow2, CreateDLRModelFromTensorflowDir) {
+TEST(Tensorflow, CreateDLRModelFromTensorflowDir) {
   // CreateDLRModelFromTensorflow (use folder containing .pb file)
   const char* model_dir = "./mobilenet_v1_1.0_224";
   int threads = 0;  // undefined
   int batch_size = 8;
-  const char* inputs[1] = {"input:0"};
+  const int64_t dims[4] = {batch_size, 224, 224, 3};
+  const DLR_TFTensorDesc inputs[1] = {{"input:0", dims, 4}};
   const char* outputs[1] = {"MobilenetV1/Predictions/Reshape_1:0"};
 
   DLRModelHandle handle;
   if (CreateDLRModelFromTensorflow(&handle, model_dir, inputs, 1, outputs, 1,
-                                   batch_size, threads)) {
+                                   threads)) {
     FAIL() << "CreateDLRModelFromTensorflow failed";
   }
   LOG(INFO) << "CreateDLRModelFromTensorflow - OK";


### PR DESCRIPTION
TF models might have dynamic H and W.
In DLR we allocate input tensor once and reuse it for entire model life.
To make dynamic shape models work in DLR we should ask about input shape at the construction time.

Example:
```
const int64_t dims[4] = {batch_size, 224, 224, 3};
const DLR_TFTensorDesc inputs[1] = {{"input:0", dims, 4}};
const char* outputs[1] = {"MobilenetV1/Predictions/Reshape_1:0"};
const int threads = -1; // undefined

CreateDLRModelFromTensorflow(&handle, "model.pb", inputs, 1, outputs, 1, threads);
```
