### PR TITLE
[TF C API] Autodetect inputs and outputs

### DIFF
--- a/include/dlr_tensorflow/dlr_tensorflow.h
+++ b/include/dlr_tensorflow/dlr_tensorflow.h
@@ -34,6 +34,9 @@ class TensorflowModel : public DLRModel {
   std::vector<TF_Tensor*> output_tensors_;
   void LoadFrozenModel(const char* pb_file);
   TF_Output ParseTensorName(const std::string& t_name);
+  void DetectInputs();
+  void DetectOutputs();
+  void DetectInputShapes();
   void PrepInputs();
   void PrepOutputs();
   int GetInputId(const char* name);

--- a/src/dlr_common.cc
+++ b/src/dlr_common.cc
@@ -50,6 +50,9 @@ DLRBackend dlr::GetBackend(std::vector<std::string> dir_paths) {
   if (EndsWith(dir_paths[0], ".tflite")) {
     return DLRBackend::kTFLITE;
   }
+  if (EndsWith(dir_paths[0], ".pb")) {
+    return DLRBackend::kTENSORFLOW;
+  }
   // Scan Directory content to guess the backend.
   std::vector<std::string> paths;
   for (auto dir : dir_paths) {
@@ -60,6 +63,8 @@ DLRBackend dlr::GetBackend(std::vector<std::string> dir_paths) {
       return DLRBackend::kTVM;
     } else if (EndsWith(filename, ".tflite")) {
       return DLRBackend::kTFLITE;
+    } else if (EndsWith(filename, ".pb")) {
+      return DLRBackend::kTENSORFLOW;
     }
   }
   return DLRBackend::kTREELITE;

--- a/tests/cpp/dlr_tensorflow/dlr_tensorflow_test.cc
+++ b/tests/cpp/dlr_tensorflow/dlr_tensorflow_test.cc
@@ -214,6 +214,27 @@ TEST(Tensorflow, CreateDLRModelFromTensorflowDir) {
   DeleteDLRModel(&handle);
 }
 
+TEST(Tensorflow, AutodetectInputsAndOutputs) {
+  // Use generic CreateDLRModel
+  // input and output tensor names will be detected automatically.
+  const char* model_file =
+      "./mobilenet_v1_1.0_224/mobilenet_v1_1.0_224_frozen.pb";
+  const int batch_size = 1;
+  const int dev_type = 1;  // 1 - kDLCPU
+  const int dev_id = 0;
+
+  DLRModelHandle handle;
+  if (CreateDLRModel(&handle, model_file, dev_type, dev_id)) {
+    FAIL() << DLRGetLastError() << std::endl;
+  }
+  LOG(INFO) << "CreateDLRModel - OK";
+
+  CheckAllDLRMethods(handle, batch_size);
+
+  // DeleteDLRModel
+  DeleteDLRModel(&handle);
+}
+
 int main(int argc, char** argv) {
   testing::InitGoogleTest(&argc, argv);
 #ifndef _WIN32


### PR DESCRIPTION
Autodetect inputs and outputs in TF Frozen Graph (`.pb` file).

Now users can use Generic `CreateDLRModel` function to create DLR model from `.pb` file, e.g.
```
  const char* model_file =
      "./mobilenet_v1_1.0_224/mobilenet_v1_1.0_224_frozen.pb";
  const int dev_type = 1;  // 1 - kDLCPU
  const int dev_id = 0;

  DLRModelHandle handle;
  if (CreateDLRModel(&handle, model_file, dev_type, dev_id)) {
    FAIL() << DLRGetLastError() << std::endl;
  }
  LOG(INFO) << "CreateDLRModel - OK";
```

I experimented with different `.pb` files (some of them had lots of garbage tensors) to find the best approach to find "real" graph outputs. After all I decided to use the following algo to detect the outputs.

* If at least one output of operator "A" is used by other operators then ignore all outputs of operator "A"
* If all outputs of operator "A" do not have consumers then add all outputs of operator "A" to the list of outputs.
