### PR TITLE
Try to fix install & test CI failure

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -129,7 +129,9 @@ def CloudInstallAndTest(cloudTarget) {
     sh """
     ls -lh python/dist/*.whl
     pip3 install python/dist/*.whl
+    pip3 install setuptools
     """
+    // setuptools must be installed before absl-py-0.9.0 (tensorflow dependency)
     if (cloudTarget == "p2" || cloudTarget == "p3") {
       sh """
       sudo pip3 install --upgrade --force-reinstall tensorflow_gpu

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -129,7 +129,7 @@ def CloudInstallAndTest(cloudTarget) {
     sh """
     ls -lh python/dist/*.whl
     pip3 install python/dist/*.whl
-    pip3 install setuptools
+    pip3 install wrapt --upgrade --ignore-installed
     """
     // setuptools must be installed before absl-py-0.9.0 (tensorflow dependency)
     if (cloudTarget == "p2" || cloudTarget == "p3") {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -129,7 +129,7 @@ def CloudInstallAndTest(cloudTarget) {
     sh """
     ls -lh python/dist/*.whl
     pip3 install python/dist/*.whl
-    pip3 install wrapt --upgrade --ignore-installed
+    sudo apt-get install python3-setuptools
     """
     // setuptools must be installed before absl-py-0.9.0 (tensorflow dependency)
     if (cloudTarget == "p2" || cloudTarget == "p3") {


### PR DESCRIPTION
CI is failing to install TF:
```
unning setup.py install for absl-py: started

[2020-02-11T21:31:04.172Z]     Running setup.py install for absl-py: finished with status 'error'

[2020-02-11T21:31:04.172Z]     Complete output from command /usr/bin/python3 -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-vbi86_qq/absl-py/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" install --record /tmp/pip-2rbcu6iz-record/install-record.txt --single-version-externally-managed --compile:

[2020-02-11T21:31:04.172Z]     Traceback (most recent call last):

[2020-02-11T21:31:04.172Z]       File "<string>", line 1, in <module>

[2020-02-11T21:31:04.172Z]       File "/usr/local/lib/python3.6/dist-packages/setuptools/__init__.py", line 18, in <module>

[2020-02-11T21:31:04.172Z]     ModuleNotFoundError: No module named 'setuptools.extension'

[2020-02-11T21:31:04.172Z]     

[2020-02-11T21:31:04.172Z]     ----------------------------------------

[2020-02-11T21:31:04.172Z]   Rolling back uninstall of absl-py

[2020-02-11T21:31:05.005Z] Command "/usr/bin/python3 -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-vbi86_qq/absl-py/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" install --record /tmp/pip-2rbcu6iz-record/install-record.txt --single-version-externally-managed --compile" failed with error code 1 in /tmp/pip-build-vbi86_qq/absl-py/

script returned exit code 1
```
