### PR TITLE
Fix typo so that 400 error is thrown correctly

### DIFF
--- a/src/dlr_treelite.cc
+++ b/src/dlr_treelite.cc
@@ -113,7 +113,7 @@ void TreeliteModel::SetInput(const char* name, const int64_t* shape,
   // NOTE: If number of columns is less than num_feature, missing columns
   //       will be automatically padded with missing values
   CHECK_LE(static_cast<size_t>(shape[1]), treelite_num_feature_)
-      << "CilentError: Mismatch found in input shape at dimension 1. Value read: "
+      << "ClientError: Mismatch found in input shape at dimension 1. Value read: "
       << shape[1] << ", Expected: " << treelite_num_feature_ << " or less";
 
   const size_t batch_size = static_cast<size_t>(shape[0]);


### PR DESCRIPTION
This commit by Philip had a typo due to which error was still showing Internal Server Error 

https://github.com/neo-ai/neo-ai-dlr/commit/2895a6747f48dd7a420f0a0ac227236272af246b

Testing
- Batch Transform now shows ClientError: See job logs for more information

