### PR TITLE
[Tensorflow] Add DLR_TFConfig

### DIFF
--- a/include/dlr.h
+++ b/include/dlr.h
@@ -65,8 +65,26 @@ int CreateDLRModelFromTFLite(DLRModelHandle* handle, const char* model_path,
 #endif  // DLR_TFLITE
 
 #ifdef DLR_TENSORFLOW
+
 /*!
- \brief Input Tensor Description structure for CreateDLRModelFromTensorflow.
+ \brief Tensorflow GPU Options structure for Tensorflow Config structure.
+ */
+typedef struct DLR_TFGPUOptions {
+  int allow_growth;
+  double per_process_gpu_memory_fraction;
+} DLR_TFGPUOptions;
+
+/*!
+ \brief Tensorflow Config structure for CreateDLRModelFromTensorflow.
+ */
+typedef struct DLR_TFConfig {
+  int intra_op_parallelism_threads;
+  int inter_op_parallelism_threads;
+  DLR_TFGPUOptions gpu_options;
+} DLR_TFConfig;
+
+/*!
+ \brief Tensor Description structure for CreateDLRModelFromTensorflow.
  */
 typedef struct DLR_TFTensorDesc {
   const char* name;
@@ -88,7 +106,7 @@ typedef struct DLR_TFTensorDesc {
 int CreateDLRModelFromTensorflow(DLRModelHandle* handle, const char* model_path,
                                  const DLR_TFTensorDesc* inputs, int input_size,
                                  const char* outputs[], int output_size,
-                                 const int threads);
+                                 const DLR_TFConfig tf_config);
 #endif  // DLR_TENSORFLOW
 
 /*!

--- a/include/dlr_tensorflow/dlr_tensorflow.h
+++ b/include/dlr_tensorflow/dlr_tensorflow.h
@@ -1,6 +1,7 @@
 #ifndef DLR_TENSORFLOW_H_
 #define DLR_TENSORFLOW_H_
 
+#include "dlr.h"
 #include "dlr_common.h"
 #include "tensorflow/c/c_api.h"
 
@@ -17,6 +18,11 @@ void FreeBuffer(void* data, size_t length);
 /*! \brief read tensorflow model file.
  */
 TF_Buffer* ReadTFFile(const char* file);
+
+/*! \brief convert DLR_TFConfig to protobuf vector of bytes
+ */
+void PrepareTFConfigProto(const DLR_TFConfig& tf_config,
+                          std::vector<std::uint8_t>& config);
 
 /*! \brief class TensorflowModel
  */
@@ -48,7 +54,7 @@ class TensorflowModel : public DLRModel {
       const std::string& model_path, const DLContext& ctx,
       const std::vector<std::string>& inputs,
       const std::vector<std::vector<int64_t>>& input_shapes,
-      const std::vector<std::string>& outputs, const int threads);
+      const std::vector<std::string>& outputs, const DLR_TFConfig& tf_config);
   ~TensorflowModel();
 
   virtual const char* GetInputName(int index) const override;

--- a/src/dlr.cc
+++ b/src/dlr.cc
@@ -128,7 +128,7 @@ int CreateDLRModelFromTFLite(DLRModelHandle* handle, const char* model_path,
 int CreateDLRModelFromTensorflow(DLRModelHandle* handle, const char* model_path,
                                  const DLR_TFTensorDesc* inputs, int input_size,
                                  const char* outputs[], int output_size,
-                                 const int threads) {
+                                 const DLR_TFConfig tf_config) {
   API_BEGIN();
   const std::string model_path_string(model_path);
   // TensorflowModel class does not use DLContext internally
@@ -147,7 +147,7 @@ int CreateDLRModelFromTensorflow(DLRModelHandle* handle, const char* model_path,
     v_outputs[i] = outputs[i];
   }
   DLRModel* model = new TensorflowModel(model_path_string, ctx, v_inputs,
-                                        v_input_shapes, v_outputs, threads);
+                                        v_input_shapes, v_outputs, tf_config);
   *handle = model;
   API_END();
 }
@@ -193,9 +193,17 @@ extern "C" int CreateDLRModel(DLRModelHandle* handle, const char* model_path,
   } else if (backend == DLRBackend::kTENSORFLOW) {
     // input and output tensor names will be detected automatically.
     // use undefined number of threads - threads=0
+    // GPUOptions.allow_growth is True
+    // GPUOptions.per_process_gpu_memory_fraction=10%. It allows effectively share GPU memory.
+    // No Performance degradation was detected.
     DLRModelHandle tf_handle;
+    DLR_TFConfig tf_config = {};
+    tf_config.inter_op_parallelism_threads = 0;
+    tf_config.intra_op_parallelism_threads = 0;
+    tf_config.gpu_options.allow_growth = 1;
+    tf_config.gpu_options.per_process_gpu_memory_fraction = 0.1;
     int errC = CreateDLRModelFromTensorflow(&tf_handle, model_path, NULL, 0,
-                                            NULL, 0, 0);
+                                            NULL, 0, tf_config);
     if (errC != 0) return errC;
     model = static_cast<DLRModel*>(tf_handle);
 #endif  // DLR_TENSORFLOW

--- a/tests/cpp/dlr_tensorflow/dlr_tensorflow_internal_test.cc
+++ b/tests/cpp/dlr_tensorflow/dlr_tensorflow_internal_test.cc
@@ -1,0 +1,54 @@
+#include <dmlc/logging.h>
+#include <gtest/gtest.h>
+
+#include "dlr_tensorflow/dlr_tensorflow.h"
+
+using namespace dlr;
+
+TEST(PrepareTFConfigProto1, test1) {
+  DLR_TFConfig tf_config = {};
+  tf_config.intra_op_parallelism_threads = 2;
+  tf_config.inter_op_parallelism_threads = 3;
+  tf_config.gpu_options.per_process_gpu_memory_fraction = 0.33;
+  tf_config.gpu_options.allow_growth = 1;
+  std::vector<std::uint8_t> config;
+  PrepareTFConfigProto(tf_config, config);
+  std::uint8_t exp[] = {0x10,0x2,0x28,0x3,0x32,0xb,0x9,0x1f,0x85,0xeb,0x51,0xb8,0x1e,0xd5,0x3f,0x20,0x1};
+  EXPECT_TRUE(std::equal(std::begin(exp), std::end(exp), config.begin()));
+}
+
+TEST(PrepareTFConfigProto1, test2) {
+  DLR_TFConfig tf_config = {};
+  tf_config.intra_op_parallelism_threads = 2;
+  tf_config.inter_op_parallelism_threads = 3;
+  tf_config.gpu_options.allow_growth = 1;
+  std::vector<std::uint8_t> config;
+  PrepareTFConfigProto(tf_config, config);
+  std::uint8_t exp[] = {0x10,0x2,0x28,0x3,0x32,0x2,0x20,0x1};
+  EXPECT_TRUE(std::equal(std::begin(exp), std::end(exp), config.begin()));
+}
+
+TEST(PrepareTFConfigProto1, test3) {
+  DLR_TFConfig tf_config = {};
+  tf_config.intra_op_parallelism_threads = 2;
+  tf_config.inter_op_parallelism_threads = 3;
+  std::vector<std::uint8_t> config;
+  PrepareTFConfigProto(tf_config, config);
+  std::uint8_t exp[] = {0x10,0x2,0x28,0x3};
+  EXPECT_TRUE(std::equal(std::begin(exp), std::end(exp), config.begin()));
+}
+
+TEST(PrepareTFConfigProto1, test4) {
+  DLR_TFConfig tf_config = {};
+  std::vector<std::uint8_t> config;
+  PrepareTFConfigProto(tf_config, config);
+  EXPECT_TRUE(config.empty());
+}
+
+int main(int argc, char** argv) {
+  testing::InitGoogleTest(&argc, argv);
+#ifndef _WIN32
+  testing::FLAGS_gtest_death_test_style = "threadsafe";
+#endif  // _WIN32
+  return RUN_ALL_TESTS();
+}

--- a/tests/cpp/dlr_tensorflow/dlr_tensorflow_test.cc
+++ b/tests/cpp/dlr_tensorflow/dlr_tensorflow_test.cc
@@ -173,7 +173,9 @@ TEST(Tensorflow, CreateDLRModelFromTensorflow) {
   // CreateDLRModelFromTensorflow (use .pb file)
   const char* model_file =
       "./mobilenet_v1_1.0_224/mobilenet_v1_1.0_224_frozen.pb";
-  int threads = 2;
+  DLR_TFConfig tf_config = {};
+  tf_config.inter_op_parallelism_threads = 2;
+  tf_config.intra_op_parallelism_threads = 2;
   int batch_size = 1;
   const int64_t dims[4] = {batch_size, 224, 224, 3};
   const DLR_TFTensorDesc inputs[1] = {{"input:0", dims, 4}};
@@ -181,7 +183,7 @@ TEST(Tensorflow, CreateDLRModelFromTensorflow) {
 
   DLRModelHandle handle;
   if (CreateDLRModelFromTensorflow(&handle, model_file, inputs, 1, outputs, 1,
-                                   threads)) {
+                                   tf_config)) {
     FAIL() << DLRGetLastError() << std::endl;
   }
   LOG(INFO) << "CreateDLRModelFromTensorflow - OK";
@@ -195,7 +197,8 @@ TEST(Tensorflow, CreateDLRModelFromTensorflow) {
 TEST(Tensorflow, CreateDLRModelFromTensorflowDir) {
   // CreateDLRModelFromTensorflow (use folder containing .pb file)
   const char* model_dir = "./mobilenet_v1_1.0_224";
-  int threads = 0;  // undefined
+  // Use undefined number of threads
+  DLR_TFConfig tf_config = {};
   int batch_size = 8;
   const int64_t dims[4] = {batch_size, 224, 224, 3};
   const DLR_TFTensorDesc inputs[1] = {{"input:0", dims, 4}};
@@ -203,7 +206,7 @@ TEST(Tensorflow, CreateDLRModelFromTensorflowDir) {
 
   DLRModelHandle handle;
   if (CreateDLRModelFromTensorflow(&handle, model_dir, inputs, 1, outputs, 1,
-                                   threads)) {
+                                   tf_config)) {
     FAIL() << DLRGetLastError() << std::endl;
   }
   LOG(INFO) << "CreateDLRModelFromTensorflow - OK";


### PR DESCRIPTION
Tensorflow adapter changes / fixes:
1. Fix GPU memory leak in case `RunDLRModel` (TF backend) is invoked multiple times in loop.
2. Allows users to set Tensorflow `GPUOptions` such as `allow_growth` and `per_process_gpu_memory_fraction`. User needs to use `CreateDLRModelFromTensorflow` function to provide custom `DLR_TFConfig`.
3. If user uses generic `CreateDLRModel` then we set `allow_growth=True` and `per_process_gpu_memory_fraction=10%`. It allows effectively share GPU memory and run several DLR/TF_Session instances on one GPU. 

I tested Tensorflow models With and Without (`per_process_gpu_memory_fraction=10%` `allow_growth=True`) - No performance degradation was noticed in case we run one model on GPU.

If I run multiple models on GPU in parallel I observed gradual performance drop as the number of models increases, e.g.
```
# number of models  - avg inference time
1 - 8ms
2 - 13ms
4 - 22ms
...
14 - 84ms
```
Without that settings we can not run multiple models on GPU simultaneously because the first model allocates all GPU memory. As a result the second model initialization fails with `CUDA_ERROR_OUT_OF_MEMORY`