### PR TITLE
Defaulting to android-21 if ANDROID_PLATFORM not set

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,9 +8,10 @@ option(AAR_BUILD "Build Android Archive (AAR)" OFF)
 
 if(ANDROID_BUILD)
     set(ANDROID_SYSROOT "${NDK_ROOT}/sysroot")
-    set(CMAKE_ANDROID_API 21)
-    set(ANDROID_PLATFORM android-21)
-    set(ANDROID_DEPRECATED_HEADERS ON)
+    if(NOT ANDROID_PLATFORM AND NOT ANDROID_NATIVE_API_LEVEL)
+        set(ANDROID_PLATFORM "android-21")
+        message(STATUS "ANDROID_PLATFORM not set. Defaulting to android-21")
+    endif()
 endif(ANDROID_BUILD)
 
 project(dlr)

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -186,8 +186,14 @@ Once done with above steps, invoke cmake with following commands to build Androi
 
 .. code-block:: bash
 
-  cmake .. -DANDROID_BUILD=ON -DNDK_ROOT=/path/to/your/ndk/folder -DCMAKE_TOOLCHAIN_FILE=/path/to/your/ndk/folder/build/cmake/android.toolchain.cmake 
+  cmake .. -DANDROID_BUILD=ON \
+    -DNDK_ROOT=/path/to/your/ndk/folder \
+    -DCMAKE_TOOLCHAIN_FILE=/path/to/your/ndk/folder/build/cmake/android.toolchain.cmake \
+    -DANDROID_PLATFORM=android-21
+
   make -j4
+
+``ANDROID_PLATFORM`` should correspond to ``minSdkVersion`` of your project. If ``ANDROID_PLATFORM`` is not set it will default to ``android-21``.
 
 For arm64 targets, add 
 


### PR DESCRIPTION
`ANDROID_PLATFORM` (or its alias `ANDROID_NATIVE_API_LEVEL`) Specifies the minimum API level supported by the application or library. This value corresponds to the application's `minSdkVersion`. https://developer.android.com/ndk/guides/cmake#android_platform

Currently DLR cmake file hardcores `ANDROID_PLATFORM` to `android-21`.
This PR gives user the ability to select `ANDROID_PLATFORM`.
If user does not specify `ANDROID_PLATFORM` (or `ANDROID_NATIVE_API_LEVEL`)  DLR will use `android-21`

cmake command example where user selects `ANDROID_PLATFORM=android-28`:
```
cmake .. \
-DANDROID_BUILD=ON \
-DANDROID_NATIVE_API_LEVEL=android-28 \
-DNDK_ROOT=/opt/android-ndk-r20 \
-DCMAKE_TOOLCHAIN_FILE=/opt/android-ndk-r20/build/cmake/android.toolchain.cmake
```

Documentation update: https://github.com/apivovarov/neo-ai-dlr/blob/ANDROID_PLATFORM_LEVEL/doc/install.rst#building-for-android-on-arm