### PR TITLE
Init DLRModelHandle with NULL

### DIFF
--- a/demo/cpp/model_peeker.cc
+++ b/demo/cpp/model_peeker.cc
@@ -89,7 +89,7 @@ int main(int argc, char** argv) {
     }
   }
 
-  DLRModelHandle model;
+  DLRModelHandle model = NULL;
   if (CreateDLRModel(&model, argv[1], device_type, 0) != 0) {
     LOG(INFO) << DLRGetLastError() << std::endl;
     throw std::runtime_error("Could not load DLR Model");

--- a/demo/cpp/run_resnet.cc
+++ b/demo/cpp/run_resnet.cc
@@ -112,7 +112,7 @@ int main(int argc, char** argv) {
   }
 
   std::cout << "Loading model... " << std::endl;
-  DLRModelHandle model;
+  DLRModelHandle model = NULL;
   if (CreateDLRModel(&model, argv[1], device_type, 0) != 0) {
     LOG(INFO) << DLRGetLastError() << std::endl;
     throw std::runtime_error("Could not load DLR Model");

--- a/src/dlr.cc
+++ b/src/dlr.cc
@@ -219,6 +219,7 @@ extern "C" int DeleteDLRModel(DLRModelHandle* handle) {
   API_BEGIN();
   DLRModel* model = static_cast<DLRModel*>(*handle);
   delete model;
+  *handle = NULL;
   API_END();
 }
 

--- a/tests/cpp/dlr_tensorflow/dlr_tensorflow_test.cc
+++ b/tests/cpp/dlr_tensorflow/dlr_tensorflow_test.cc
@@ -181,7 +181,7 @@ TEST(Tensorflow, CreateDLRModelFromTensorflow) {
   const DLR_TFTensorDesc inputs[1] = {{"input:0", dims, 4}};
   const char* outputs[1] = {"MobilenetV1/Predictions/Reshape_1:0"};
 
-  DLRModelHandle handle;
+  DLRModelHandle handle = NULL;
   if (CreateDLRModelFromTensorflow(&handle, model_file, inputs, 1, outputs, 1,
                                    tf_config)) {
     FAIL() << DLRGetLastError() << std::endl;
@@ -204,7 +204,7 @@ TEST(Tensorflow, CreateDLRModelFromTensorflowDir) {
   const DLR_TFTensorDesc inputs[1] = {{"input:0", dims, 4}};
   const char* outputs[1] = {"MobilenetV1/Predictions/Reshape_1:0"};
 
-  DLRModelHandle handle;
+  DLRModelHandle handle = NULL;
   if (CreateDLRModelFromTensorflow(&handle, model_dir, inputs, 1, outputs, 1,
                                    tf_config)) {
     FAIL() << DLRGetLastError() << std::endl;
@@ -226,7 +226,7 @@ TEST(Tensorflow, AutodetectInputsAndOutputs) {
   const int dev_type = 1;  // 1 - kDLCPU
   const int dev_id = 0;
 
-  DLRModelHandle handle;
+  DLRModelHandle handle = NULL;
   if (CreateDLRModel(&handle, model_file, dev_type, dev_id)) {
     FAIL() << DLRGetLastError() << std::endl;
   }
@@ -235,6 +235,10 @@ TEST(Tensorflow, AutodetectInputsAndOutputs) {
   CheckAllDLRMethods(handle, batch_size);
 
   // DeleteDLRModel
+  DeleteDLRModel(&handle);
+  ASSERT_EQ(nullptr, handle);
+  // Test that calling DeleteDLRModel again
+  // does not crash the program (no segmentation fault)
   DeleteDLRModel(&handle);
 }
 

--- a/tests/cpp/dlr_tflite/dlr_tflite_test.cc
+++ b/tests/cpp/dlr_tflite/dlr_tflite_test.cc
@@ -161,7 +161,7 @@ TEST(TFLite, CreateDLRModelFromTFLite) {
   int threads = 2;
   int use_nn_api = 0;
 
-  DLRModelHandle handle;
+  DLRModelHandle handle = NULL;
   if (CreateDLRModelFromTFLite(&handle, model_file, threads, use_nn_api)) {
     FAIL() << DLRGetLastError() << std::endl;
   }
@@ -179,7 +179,7 @@ TEST(TFLite, CreateDLRModel) {
   int dev_type = 1;  // 1 - kDLCPU
   int dev_id = 0;
 
-  DLRModelHandle handle;
+  DLRModelHandle handle = NULL;
   if (CreateDLRModel(&handle, model_dir, dev_type, dev_id)) {
     FAIL() << DLRGetLastError() << std::endl;
   }


### PR DESCRIPTION
Out test and demo code shows the following way to use DLR API
```
DLRModelHandle handle;
CreateDLRModelFromTensorflow(&handle, ...);
```

In real life some projects create `DLRModelHandle` on top level and then several levels below in stack they call `CreateDLRModelFromTensorflow`. 
`CreateDLRModelFromTensorflow` can be called multiple times.
To prevent memory leaks users call `DeleteDLRModel` before calling `CreateDLRModelFromTensorflow`.

`DeleteDLRModel` calls `delete handle` inside. It is totally fine to call `delete` for `nullptr` but it will segfault if `delete` is called for random undefined value.

This is why in our test and demo code we'd better init `DLRModelHandle handle` with `NULL`.
It will be good example on how to use DLR API properly.
```
DLRModelHandle handle = NULL;
CreateDLRModelFromTensorflow(&handle, ...)
```

Also, in some cases users call `DeleteDLRModel` twice - at the beginning and at the end of the loop. Lets set handler to `NULL` inside `DeleteDLRModel` to allow calling `DeleteDLRModel` multiple times.

```
DLRModelHandle handle = NULL;
while (true) {
  # 2 - Call DeleteDLRModel the second time
  DeleteDLRModel(&handle);
  CreateDLRModelFromTensorflow(&handle, ...);
  ....
  # 1 - Call DeleteDLRModel the first time
  DeleteDLRModel(&handle);
}
```