### PR TITLE
[Docs] Improve install DLR steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 DLR is a compact, common runtime for deep learning models and decision tree models compiled by [AWS SageMaker Neo](https://aws.amazon.com/sagemaker/neo/), [TVM](https://tvm.ai/), or [Treelite](https://treelite.readthedocs.io/en/latest/install.html). DLR uses the TVM runtime, Treelite runtime, NVIDIA TensorRT™, and can include other hardware-specific runtimes. DLR provides unified Python/C++ APIs for loading and running compiled models on various devices. DLR currently supports platforms from Intel, NVIDIA, and ARM, with support for Xilinx, Cadence, and Qualcomm coming soon.
 
 ## Installation
-On X86_64 targets running Linux, you can install latest release of DLR package via 
+On X86_64 CPU targets running Linux, you can install latest release of DLR package via 
 
 `pip install dlr`
 
-For installation of DLR on non-x86 edge devices, or building DLR from source, please refer to [Installing DLR](https://neo-ai-dlr.readthedocs.io/en/latest/install.html)
+For installation of DLR on GPU targets, non-x86 edge devices, or building DLR from source, please refer to [Installing DLR](https://neo-ai-dlr.readthedocs.io/en/latest/install.html)
 
 ## Documentation
 For instructions on using DLR, please refer to [Amazon SageMaker Neo – Train Your Machine Learning Models Once, Run Them Anywhere](https://aws.amazon.com/blogs/aws/amazon-sagemaker-neo-train-your-machine-learning-models-once-run-them-anywhere/)

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -95,13 +95,12 @@ To build, create a subdirectory ``build``:
   cd build
   
 Building for CPU
+  Invoke CMake to generate a Makefile and then run GNU Make to compile:
 
-Invoke CMake to generate a Makefile and then run GNU Make to compile:
+  .. code-block:: bash
 
-.. code-block:: bash
-
-  cmake ..
-  make -j4         # Use 4 cores to compile sources in parallel
+    cmake ..
+    make -j4         # Use 4 cores to compile sources in parallel
 
 Building for GPU
   By default, DLR will be built with CPU support only. To enable support for NVIDIA GPUs, enable CUDA, CUDNN, and TensorRT by calling CMake with these extra options.
@@ -112,23 +111,21 @@ Building for GPU
     cmake .. -DUSE_CUDA=ON -DUSE_CUDNN=ON -DUSE_TENSORRT=ON
     make -j4
 
-If you do not have a system install of TensorRT and have downloaded it via tar file or zip, provide the path to the extracted TensorRT directory via `-DUSE_TENSORRT=/path/to/TensorRT/`.
+  If you do not have a system install of TensorRT and have downloaded it via tar file or zip, provide the path to the extracted TensorRT directory via `-DUSE_TENSORRT=/path/to/TensorRT/`.
 
-.. code-block:: bash
+  .. code-block:: bash
 
-  cmake .. -DUSE_CUDA=ON -DUSE_CUDNN=ON -DUSE_TENSORRT=/path/to/TensorRT/ 
-  make -j4
+    cmake .. -DUSE_CUDA=ON -DUSE_CUDNN=ON -DUSE_TENSORRT=/path/to/TensorRT/ 
+    make -j4
 
-You will need to install NVIDIA CUDA and TensorRT toolkits and drivers beforehand.
+  You will need to install NVIDIA CUDA and TensorRT toolkits and drivers beforehand.
 
 Building for OpenCL Devices
----------------------------
+  Similarly, to enable support for OpenCL devices, run CMake with:
 
-Similarly, to enable support for OpenCL devices, run CMake with:
-
-.. code-block:: bash
-  cmake .. -DUSE_OPENCL=ON 
-  make -j4
+  .. code-block:: bash
+    cmake .. -DUSE_OPENCL=ON 
+    make -j4
 
 Install Python package
 ----------------------

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -75,6 +75,7 @@ Building DLR consists of two steps:
   .. code-block:: bash
 
     git clone --recursive https://github.com/neo-ai/neo-ai-dlr
+    cd neo-ai-dlr
 
 Building on Linux
 -----------------
@@ -86,42 +87,55 @@ Ensure that all necessary software packages are installed: GCC (or Clang), CMake
   sudo apt-get update
   sudo apt-get install -y python3 python3-pip gcc build-essential cmake
   
-To build, create a subdirectory ``build`` and invoke CMake:
+To build, create a subdirectory ``build``:
 
 .. code-block:: bash
 
   mkdir build
   cd build
-  cmake ..
+  
+## Building for CPU
 
-Once CMake is done generating a Makefile, run GNU Make to compile:
+Invoke CMake to generate a Makefile and then run GNU Make to compile:
 
 .. code-block:: bash
-
+  cmake ..
   make -j4         # Use 4 cores to compile sources in parallel
 
-By default, DLR will be built with CPU support only. To enable support for NVIDIA GPUs, enable CUDA, CUDNN, and TensorRT by calling CMake with extra options:
+## Building for GPU
+
+By default, DLR will be built with CPU support only. To enable support for NVIDIA GPUs, enable CUDA, CUDNN, and TensorRT by calling CMake with these extra options.
+
+If you have a system install of TensorRT via Deb or RPM package, or if you are on a Jetson device, use `-DUSE_TENSORRT=ON`.
 
 .. code-block:: bash
+  cmake .. -DUSE_CUDA=ON -DUSE_CUDNN=ON -DUSE_TENSORRT=ON
+  make -j4
 
+If you do not have a system install of TensorRT and have downloaded it via tar file or zip, provide the path to the extracted TensorRT directory via `-DUSE_TENSORRT=/path/to/TensorRT/`.
+
+.. code-block:: bash
   cmake .. -DUSE_CUDA=ON -DUSE_CUDNN=ON -DUSE_TENSORRT=/path/to/TensorRT/ 
   make -j4
 
 You will need to install NVIDIA CUDA and TensorRT toolkits and drivers beforehand.
 
+## Building for OpenCL Devices
+
 Similarly, to enable support for OpenCL devices, run CMake with:
 
 .. code-block:: bash
-
   cmake .. -DUSE_OPENCL=ON 
   make -j4
+
+## After compiling, install Python package
 
 Once the compilation is completed, install the Python package by running ``setup.py``:
 
 .. code-block:: bash
 
   cd ../python
-  python3 setup.py install --user
+  python3 setup.py install --user --force
 
 Building on Mac OS X
 --------------------

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -80,7 +80,7 @@ Building DLR consists of two steps:
 Building on Linux
 -----------------
 
-Ensure that all necessary software packages are installed: GCC (or Clang), CMake, and Python. For example, in Ubuntu, you can run
+1. Ensure that all necessary software packages are installed: GCC (or Clang), CMake, and Python. For example, in Ubuntu, you can run
 
 .. code-block:: bash
 
@@ -94,7 +94,7 @@ To build, create a subdirectory ``build``:
   mkdir build
   cd build
   
-Building for CPU
+2. Building for CPU
 
   Invoke CMake to generate a Makefile and then run GNU Make to compile:
 
@@ -103,7 +103,7 @@ Building for CPU
     cmake ..
     make -j4         # Use 4 cores to compile sources in parallel
 
-Building for GPU
+3. Building for GPU
 
   By default, DLR will be built with CPU support only. To enable support for NVIDIA GPUs, enable CUDA, CUDNN, and TensorRT by calling CMake with these extra options.
   If you have a system install of TensorRT via Deb or RPM package, or if you are on a Jetson device, use `-DUSE_TENSORRT=ON`.
@@ -122,15 +122,16 @@ Building for GPU
 
   You will need to install NVIDIA CUDA and TensorRT toolkits and drivers beforehand.
 
-Building for OpenCL Devices
+4. Building for OpenCL Devices
 
   Similarly, to enable support for OpenCL devices, run CMake with:
 
   .. code-block:: bash
+
     cmake .. -DUSE_OPENCL=ON 
     make -j4
 
-Install Python package
+5. Install Python package
 
   Once the compilation is completed, install the Python package by running ``setup.py``:
 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -95,28 +95,27 @@ To build, create a subdirectory ``build``:
   cd build
   
 Building for CPU
-----------------
 
 Invoke CMake to generate a Makefile and then run GNU Make to compile:
 
 .. code-block:: bash
+
   cmake ..
   make -j4         # Use 4 cores to compile sources in parallel
 
 Building for GPU
-----------------
+  By default, DLR will be built with CPU support only. To enable support for NVIDIA GPUs, enable CUDA, CUDNN, and TensorRT by calling CMake with these extra options.
+  If you have a system install of TensorRT via Deb or RPM package, or if you are on a Jetson device, use `-DUSE_TENSORRT=ON`.
 
-By default, DLR will be built with CPU support only. To enable support for NVIDIA GPUs, enable CUDA, CUDNN, and TensorRT by calling CMake with these extra options.
+  .. code-block:: bash
 
-If you have a system install of TensorRT via Deb or RPM package, or if you are on a Jetson device, use `-DUSE_TENSORRT=ON`.
-
-.. code-block:: bash
-  cmake .. -DUSE_CUDA=ON -DUSE_CUDNN=ON -DUSE_TENSORRT=ON
-  make -j4
+    cmake .. -DUSE_CUDA=ON -DUSE_CUDNN=ON -DUSE_TENSORRT=ON
+    make -j4
 
 If you do not have a system install of TensorRT and have downloaded it via tar file or zip, provide the path to the extracted TensorRT directory via `-DUSE_TENSORRT=/path/to/TensorRT/`.
 
 .. code-block:: bash
+
   cmake .. -DUSE_CUDA=ON -DUSE_CUDNN=ON -DUSE_TENSORRT=/path/to/TensorRT/ 
   make -j4
 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -95,6 +95,7 @@ To build, create a subdirectory ``build``:
   cd build
   
 Building for CPU
+
   Invoke CMake to generate a Makefile and then run GNU Make to compile:
 
   .. code-block:: bash
@@ -103,6 +104,7 @@ Building for CPU
     make -j4         # Use 4 cores to compile sources in parallel
 
 Building for GPU
+
   By default, DLR will be built with CPU support only. To enable support for NVIDIA GPUs, enable CUDA, CUDNN, and TensorRT by calling CMake with these extra options.
   If you have a system install of TensorRT via Deb or RPM package, or if you are on a Jetson device, use `-DUSE_TENSORRT=ON`.
 
@@ -121,6 +123,7 @@ Building for GPU
   You will need to install NVIDIA CUDA and TensorRT toolkits and drivers beforehand.
 
 Building for OpenCL Devices
+
   Similarly, to enable support for OpenCL devices, run CMake with:
 
   .. code-block:: bash
@@ -128,14 +131,13 @@ Building for OpenCL Devices
     make -j4
 
 Install Python package
-----------------------
 
-Once the compilation is completed, install the Python package by running ``setup.py``:
+  Once the compilation is completed, install the Python package by running ``setup.py``:
 
-.. code-block:: bash
+  .. code-block:: bash
 
-  cd ../python
-  python3 setup.py install --user --force
+    cd ../python
+    python3 setup.py install --user --force
 
 Building on Mac OS X
 --------------------

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -109,14 +109,14 @@ Building for GPU
 
 By default, DLR will be built with CPU support only. To enable support for NVIDIA GPUs, enable CUDA, CUDNN, and TensorRT by calling CMake with these extra options.
 
-If you have a system install of TensorRT via Deb or RPM package, or if you are on a Jetson device, use `-DUSE_TENSORRT=ON`.
+If you have a system install of TensorRT via Deb or RPM package, or if you are on a Jetson device, use :bash:`-DUSE_TENSORRT=ON`.
 
 .. code-block:: bash
 
   cmake .. -DUSE_CUDA=ON -DUSE_CUDNN=ON -DUSE_TENSORRT=ON
   make -j4
 
-If you do not have a system install of TensorRT and have downloaded it via tar file or zip, provide the path to the extracted TensorRT directory via `-DUSE_TENSORRT=/path/to/TensorRT/`.
+If you do not have a system install of TensorRT and have downloaded it via tar file or zip, provide the path to the extracted TensorRT directory via :bash:`-DUSE_TENSORRT=/path/to/TensorRT/`.
 
 .. code-block:: bash
 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -78,7 +78,7 @@ Building DLR consists of two steps:
     cd neo-ai-dlr
 
 Building on Linux
------------------
+=================
 
 Ensure that all necessary software packages are installed: GCC (or Clang), CMake, and Python. For example, in Ubuntu, you can run
 
@@ -94,7 +94,8 @@ To build, create a subdirectory ``build``:
   mkdir build
   cd build
   
-## Building for CPU
+Building for CPU
+----------------
 
 Invoke CMake to generate a Makefile and then run GNU Make to compile:
 
@@ -102,7 +103,8 @@ Invoke CMake to generate a Makefile and then run GNU Make to compile:
   cmake ..
   make -j4         # Use 4 cores to compile sources in parallel
 
-## Building for GPU
+Building for GPU
+----------------
 
 By default, DLR will be built with CPU support only. To enable support for NVIDIA GPUs, enable CUDA, CUDNN, and TensorRT by calling CMake with these extra options.
 
@@ -120,7 +122,8 @@ If you do not have a system install of TensorRT and have downloaded it via tar f
 
 You will need to install NVIDIA CUDA and TensorRT toolkits and drivers beforehand.
 
-## Building for OpenCL Devices
+Building for OpenCL Devices
+---------------------------
 
 Similarly, to enable support for OpenCL devices, run CMake with:
 
@@ -128,7 +131,8 @@ Similarly, to enable support for OpenCL devices, run CMake with:
   cmake .. -DUSE_OPENCL=ON 
   make -j4
 
-## After compiling, install Python package
+Install Python package
+---------------------------------------
 
 Once the compilation is completed, install the Python package by running ``setup.py``:
 
@@ -138,7 +142,7 @@ Once the compilation is completed, install the Python package by running ``setup
   python3 setup.py install --user --force
 
 Building on Mac OS X
---------------------
+====================
 
 Install GCC and CMake from `Homebrew <https://brew.sh/>`_:
 
@@ -166,7 +170,7 @@ Once the compilation is completed, install the Python package by running ``setup
   python3 setup.py install --user --prefix=''
 
 Building on Windows
--------------------
+===================
 
 DLR requires `Visual Studio 2017 <https://visualstudio.microsoft.com/downloads/>`_ as well as `CMake <https://cmake.org/>`_.
 
@@ -190,7 +194,7 @@ Once the compilation is completed, install the Python package by running ``setup
   python3 setup.py install --user
 
 Building for Android on ARM
----------------------------
+===========================
 
 Android build requires `Android NDK <https://developer.android.com/ndk/downloads/>`_. We utilize the android.toolchain.cmake file in NDK package to configure the crosscompiler 
 
@@ -226,7 +230,7 @@ You can include whole ``libtensorflow-lite.a`` library into ``libdlr.so`` shared
 To build ``libtensorflow-lite.a`` for Android you can look at this `docs <https://gist.github.com/apivovarov/9f67fc02b84cf6d139c05aa1a8bc16f9>`_
 
 Building for Android Archive (AAR) file
----------------------------------------
+=======================================
 
 Install `Android Studio <https://developer.android.com/studio>`_.
 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -80,7 +80,7 @@ Building DLR consists of two steps:
 Building on Linux
 -----------------
 
-1. Ensure that all necessary software packages are installed: GCC (or Clang), CMake, and Python. For example, in Ubuntu, you can run
+Ensure that all necessary software packages are installed: GCC (or Clang), CMake, and Python. For example, in Ubuntu, you can run
 
 .. code-block:: bash
 
@@ -94,7 +94,8 @@ To build, create a subdirectory ``build``:
   mkdir build
   cd build
   
-2. Building for CPU
+Building for CPU
+""""""""""""""""
 
 Invoke CMake to generate a Makefile and then run GNU Make to compile:
 
@@ -103,10 +104,12 @@ Invoke CMake to generate a Makefile and then run GNU Make to compile:
   cmake ..
   make -j4         # Use 4 cores to compile sources in parallel
 
-3. Building for GPU
+Building for GPU
+""""""""""""""""
 
 By default, DLR will be built with CPU support only. To enable support for NVIDIA GPUs, enable CUDA, CUDNN, and TensorRT by calling CMake with these extra options.
-  If you have a system install of TensorRT via Deb or RPM package, or if you are on a Jetson device, use `-DUSE_TENSORRT=ON`.
+
+If you have a system install of TensorRT via Deb or RPM package, or if you are on a Jetson device, use `-DUSE_TENSORRT=ON`.
 
 .. code-block:: bash
 
@@ -122,7 +125,8 @@ If you do not have a system install of TensorRT and have downloaded it via tar f
 
 You will need to install NVIDIA CUDA and TensorRT toolkits and drivers beforehand.
 
-4. Building for OpenCL Devices
+Building for OpenCL Devices
+"""""""""""""""""""""""""""
 
 Similarly, to enable support for OpenCL devices, run CMake with:
 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -109,14 +109,14 @@ Building for GPU
 
 By default, DLR will be built with CPU support only. To enable support for NVIDIA GPUs, enable CUDA, CUDNN, and TensorRT by calling CMake with these extra options.
 
-If you have a system install of TensorRT via Deb or RPM package, or if you are on a Jetson device, use :bash:`-DUSE_TENSORRT=ON`.
+If you have a system install of TensorRT via Deb or RPM package, or if you are on a Jetson device, use the following configuration:
 
 .. code-block:: bash
 
   cmake .. -DUSE_CUDA=ON -DUSE_CUDNN=ON -DUSE_TENSORRT=ON
   make -j4
 
-If you do not have a system install of TensorRT and have downloaded it via tar file or zip, provide the path to the extracted TensorRT directory via :bash:`-DUSE_TENSORRT=/path/to/TensorRT/`.
+If you do not have a system install of TensorRT and have downloaded it via tar file or zip, provide the path to the extracted TensorRT directory with:
 
 .. code-block:: bash
 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -96,49 +96,49 @@ To build, create a subdirectory ``build``:
   
 2. Building for CPU
 
-  Invoke CMake to generate a Makefile and then run GNU Make to compile:
+Invoke CMake to generate a Makefile and then run GNU Make to compile:
 
-  .. code-block:: bash
+.. code-block:: bash
 
-    cmake ..
-    make -j4         # Use 4 cores to compile sources in parallel
+  cmake ..
+  make -j4         # Use 4 cores to compile sources in parallel
 
 3. Building for GPU
 
-  By default, DLR will be built with CPU support only. To enable support for NVIDIA GPUs, enable CUDA, CUDNN, and TensorRT by calling CMake with these extra options.
+By default, DLR will be built with CPU support only. To enable support for NVIDIA GPUs, enable CUDA, CUDNN, and TensorRT by calling CMake with these extra options.
   If you have a system install of TensorRT via Deb or RPM package, or if you are on a Jetson device, use `-DUSE_TENSORRT=ON`.
 
-  .. code-block:: bash
+.. code-block:: bash
 
-    cmake .. -DUSE_CUDA=ON -DUSE_CUDNN=ON -DUSE_TENSORRT=ON
-    make -j4
+  cmake .. -DUSE_CUDA=ON -DUSE_CUDNN=ON -DUSE_TENSORRT=ON
+  make -j4
 
-  If you do not have a system install of TensorRT and have downloaded it via tar file or zip, provide the path to the extracted TensorRT directory via `-DUSE_TENSORRT=/path/to/TensorRT/`.
+If you do not have a system install of TensorRT and have downloaded it via tar file or zip, provide the path to the extracted TensorRT directory via `-DUSE_TENSORRT=/path/to/TensorRT/`.
 
-  .. code-block:: bash
+.. code-block:: bash
 
-    cmake .. -DUSE_CUDA=ON -DUSE_CUDNN=ON -DUSE_TENSORRT=/path/to/TensorRT/ 
-    make -j4
+  cmake .. -DUSE_CUDA=ON -DUSE_CUDNN=ON -DUSE_TENSORRT=/path/to/TensorRT/ 
+  make -j4
 
-  You will need to install NVIDIA CUDA and TensorRT toolkits and drivers beforehand.
+You will need to install NVIDIA CUDA and TensorRT toolkits and drivers beforehand.
 
 4. Building for OpenCL Devices
 
-  Similarly, to enable support for OpenCL devices, run CMake with:
+Similarly, to enable support for OpenCL devices, run CMake with:
 
-  .. code-block:: bash
+.. code-block:: bash
 
-    cmake .. -DUSE_OPENCL=ON 
-    make -j4
+  cmake .. -DUSE_OPENCL=ON 
+  make -j4
 
 5. Install Python package
 
-  Once the compilation is completed, install the Python package by running ``setup.py``:
+Once the compilation is completed, install the Python package by running ``setup.py``:
 
-  .. code-block:: bash
+.. code-block:: bash
 
-    cd ../python
-    python3 setup.py install --user --force
+  cd ../python
+  python3 setup.py install --user --force
 
 Building on Mac OS X
 --------------------

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -78,7 +78,7 @@ Building DLR consists of two steps:
     cd neo-ai-dlr
 
 Building on Linux
-=================
+-----------------
 
 Ensure that all necessary software packages are installed: GCC (or Clang), CMake, and Python. For example, in Ubuntu, you can run
 
@@ -142,7 +142,7 @@ Once the compilation is completed, install the Python package by running ``setup
   python3 setup.py install --user --force
 
 Building on Mac OS X
-====================
+--------------------
 
 Install GCC and CMake from `Homebrew <https://brew.sh/>`_:
 
@@ -170,7 +170,7 @@ Once the compilation is completed, install the Python package by running ``setup
   python3 setup.py install --user --prefix=''
 
 Building on Windows
-===================
+-------------------
 
 DLR requires `Visual Studio 2017 <https://visualstudio.microsoft.com/downloads/>`_ as well as `CMake <https://cmake.org/>`_.
 
@@ -194,7 +194,7 @@ Once the compilation is completed, install the Python package by running ``setup
   python3 setup.py install --user
 
 Building for Android on ARM
-===========================
+---------------------------
 
 Android build requires `Android NDK <https://developer.android.com/ndk/downloads/>`_. We utilize the android.toolchain.cmake file in NDK package to configure the crosscompiler 
 
@@ -230,7 +230,7 @@ You can include whole ``libtensorflow-lite.a`` library into ``libdlr.so`` shared
 To build ``libtensorflow-lite.a`` for Android you can look at this `docs <https://gist.github.com/apivovarov/9f67fc02b84cf6d139c05aa1a8bc16f9>`_
 
 Building for Android Archive (AAR) file
-=======================================
+---------------------------------------
 
 Install `Android Studio <https://developer.android.com/studio>`_.
 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -93,7 +93,7 @@ To build, create a subdirectory ``build``:
 
   mkdir build
   cd build
-  
+
 Building for CPU
 """"""""""""""""
 
@@ -135,7 +135,8 @@ Similarly, to enable support for OpenCL devices, run CMake with:
   cmake .. -DUSE_OPENCL=ON 
   make -j4
 
-5. Install Python package
+Install Python package
+""""""""""""""""""""""
 
 Once the compilation is completed, install the Python package by running ``setup.py``:
 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -132,7 +132,7 @@ Similarly, to enable support for OpenCL devices, run CMake with:
   make -j4
 
 Install Python package
----------------------------------------
+----------------------
 
 Once the compilation is completed, install the Python package by running ``setup.py``:
 


### PR DESCRIPTION
Make steps for CPU, GPU, or OpenCL clearer. Also, include option of `-DUSE_TENSORRT=ON` for system installs of TensorRT.

Add `--force` to install of python package so that old builds of DLR are replaced.