### PR TITLE
Update TFLite version to 1.15.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,8 +193,8 @@ if(WITH_TENSORFLOW_LITE_LIB)
     message("Adding libtensorflow-lite.a to DLR shared library")
 
     # Download Tensorflow and FlatBuffers source code
-    set(TENSORFLOW_VER "1.13.2")
-    set(TENSORFLOW_SHA1 "78bb81d1e78ac9c3b092dee65f6b6b3cee23b9ae")
+    set(TENSORFLOW_VER "1.15.2")
+    set(TENSORFLOW_SHA1 "b9e71bf287a186ceb9d859588671d890c45e51a7")
     set(FLATBUFFERS_VER "1.11.0")
     set(FLATBUFFERS_SHA1 "2b2633902c57c6980b3a41b44d8ad933f214d71d")
     set(TENSORFLOW_URL "https://github.com/tensorflow/tensorflow/archive/v${TENSORFLOW_VER}.tar.gz")


### PR DESCRIPTION
# Description
TFLite build needs TF tar.gz
Lets update TF version to 1.15.2 (the latest 1.x version)

# Test
tested DLR with tflite-1.15.2 on Linux x86_64

TFLite 1.15 fix needed to build libtensorflow-lite.a - https://github.com/tensorflow/tensorflow/pull/36689
```
(20-03-14 3:58:19) <0> [~/neo-ai-dlr/build]  
ip-172-19-29-73 % ./dlr_tflite_test                                                                                                                     
[==========] Running 2 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 2 tests from TFLite
[ RUN      ] TFLite.CreateDLRModelFromTFLite
[03:58:33] /home/pivovaa/neo-ai-dlr/src/dlr_tflite/dlr_tflite.cc:95: Use NNAPI: false
[03:58:33] /home/pivovaa/neo-ai-dlr/src/dlr_tflite/dlr_tflite.cc:98: Set Num Threads: 2
[03:58:33] /home/pivovaa/neo-ai-dlr/src/dlr_tflite/dlr_tflite.cc:106: AllocateTensors - OK
[03:58:33] /home/pivovaa/neo-ai-dlr/src/dlr_tflite/dlr_tflite.cc:116: TFLiteModel was created
[03:58:33] /home/pivovaa/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_test.cc:162: CreateDLRModelFromTFLite - OK
[03:58:33] /home/pivovaa/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_test.cc:47: GetDLRBackend: tflite
[03:58:33] /home/pivovaa/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_test.cc:55: GetDLRNumInputs: 1
[03:58:33] /home/pivovaa/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_test.cc:63: GetDLRNumOutputs: 1
[03:58:33] /home/pivovaa/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_test.cc:71: GetDLRNumWeights: 0
[03:58:33] /home/pivovaa/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_test.cc:79: DLRInputName: input
[03:58:33] /home/pivovaa/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_test.cc:88: GetDLROutputSizeDim.size: 1001
[03:58:33] /home/pivovaa/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_test.cc:89: GetDLROutputSizeDim.dim: 2
[03:58:33] /home/pivovaa/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_test.cc:104: GetDLROutputShape: (1,1001)
[03:58:33] /home/pivovaa/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_test.cc:24: Image read - OK, float[150528]
[03:58:33] /home/pivovaa/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_test.cc:111: Input sample: 0.521569,0.498039 ... -0.615686
[03:58:33] /home/pivovaa/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_test.cc:118: SetDLRInput - OK
[03:58:33] /home/pivovaa/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_test.cc:131: RunDLRModel - OK
[03:58:33] /home/pivovaa/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_test.cc:139: ArgMax: 283, Prop: 0.529855
[03:58:33] /home/pivovaa/neo-ai-dlr/src/dlr_tflite/dlr_tflite.cc:124: TFLiteModel was deleted
[       OK ] TFLite.CreateDLRModelFromTFLite (40 ms)
[ RUN      ] TFLite.CreateDLRModel
[03:58:33] /home/pivovaa/neo-ai-dlr/src/dlr_tflite/dlr_tflite.cc:95: Use NNAPI: false
[03:58:33] /home/pivovaa/neo-ai-dlr/src/dlr_tflite/dlr_tflite.cc:106: AllocateTensors - OK
[03:58:33] /home/pivovaa/neo-ai-dlr/src/dlr_tflite/dlr_tflite.cc:116: TFLiteModel was created
[03:58:33] /home/pivovaa/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_test.cc:180: CreateDLRModel - OK
[03:58:33] /home/pivovaa/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_test.cc:47: GetDLRBackend: tflite
[03:58:33] /home/pivovaa/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_test.cc:55: GetDLRNumInputs: 1
[03:58:33] /home/pivovaa/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_test.cc:63: GetDLRNumOutputs: 1
[03:58:33] /home/pivovaa/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_test.cc:71: GetDLRNumWeights: 0
[03:58:33] /home/pivovaa/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_test.cc:79: DLRInputName: input
[03:58:33] /home/pivovaa/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_test.cc:88: GetDLROutputSizeDim.size: 1001
[03:58:33] /home/pivovaa/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_test.cc:89: GetDLROutputSizeDim.dim: 2
[03:58:33] /home/pivovaa/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_test.cc:104: GetDLROutputShape: (1,1001)
[03:58:33] /home/pivovaa/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_test.cc:24: Image read - OK, float[150528]
[03:58:33] /home/pivovaa/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_test.cc:111: Input sample: 0.521569,0.498039 ... -0.615686
[03:58:33] /home/pivovaa/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_test.cc:118: SetDLRInput - OK
[03:58:33] /home/pivovaa/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_test.cc:131: RunDLRModel - OK
[03:58:33] /home/pivovaa/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_test.cc:139: ArgMax: 283, Prop: 0.529855
[03:58:33] /home/pivovaa/neo-ai-dlr/src/dlr_tflite/dlr_tflite.cc:124: TFLiteModel was deleted
[       OK ] TFLite.CreateDLRModel (35 ms)
[----------] 2 tests from TFLite (75 ms total)

[----------] Global test environment tear-down
[==========] 2 tests from 1 test case ran. (75 ms total)
[  PASSED  ] 2 tests.
```