### PR TITLE
Add Hexagon adapter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -325,6 +325,10 @@ if(WITH_TENSORFLOW_LIB)
     list(APPEND DLR_SRC "src/dlr_tensorflow/dlr_tensorflow.cc")
     list(APPEND DLR_LINKER_LIBS -L${WITH_TENSORFLOW_LIB}/lib -ltensorflow_framework -ltensorflow)
 endif()
+if(WITH_HEXAGON)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DDLR_HEXAGON")
+    list(APPEND DLR_SRC "src/dlr_hexagon/dlr_hexagon.cc")
+endif()
 if(AAR_BUILD)
     list(APPEND DLR_SRC "src/jni/dlr_jni.cc")
 endif()
@@ -382,7 +386,7 @@ endforeach()
 add_custom_target(demo DEPENDS ${DEMO_EXECS})
 
 # Tests
-if(NOT(ANDROID_BUILD OR AAR_BUILD))
+if(NOT(AAR_BUILD))
   include(cmake/googletest.cmake)
   fetch_googletest(
     ${PROJECT_SOURCE_DIR}/cmake
@@ -400,6 +404,10 @@ if(NOT(ANDROID_BUILD OR AAR_BUILD))
     file(GLOB TENSORFLOW_TEST_SRCS tests/cpp/dlr_tensorflow/*.cc)
     list(APPEND TEST_SRCS ${TENSORFLOW_TEST_SRCS})
   endif()
+  if(WITH_HEXAGON)
+    file(GLOB HEXAGON_TEST_SRCS tests/cpp/dlr_hexagon/*.cc)
+    list(APPEND TEST_SRCS ${HEXAGON_TEST_SRCS})
+  endif()
   foreach(__srcpath ${TEST_SRCS})
     get_filename_component(__srcname ${__srcpath} NAME)
     string(REPLACE ".cc" "" __execname ${__srcname})
@@ -411,7 +419,7 @@ if(NOT(ANDROID_BUILD OR AAR_BUILD))
   endforeach()
 
   if(WITH_TENSORFLOW_LITE_LIB)
-      # Download Test TFLite model and input data
+      # Download Test TFLite model
       file(MAKE_DIRECTORY mobilenet_v2_0.75_224)
       download_file(
         https://neo-ai-dlr-test-artifacts.s3-us-west-2.amazonaws.com/tflite-models/mobilenet_v2_0.75_224.tflite
@@ -419,15 +427,9 @@ if(NOT(ANDROID_BUILD OR AAR_BUILD))
         SHA1
         c653a09facaf2dfb5e3910030b3f74ad04259e30
       )
-      download_file(
-        https://neo-ai-dlr-test-artifacts.s3-us-west-2.amazonaws.com/tflite-models/cat224-3.txt
-        ./cat224-3.txt
-        SHA1
-        e35e82f3371bed37caa7ecece417f50876414077
-      )
   endif() # WITH_TENSORFLOW_LITE_LIB
   if(WITH_TENSORFLOW_LIB)
-      # Download Test Tensorflow model and input data
+      # Download Test Tensorflow model
       file(MAKE_DIRECTORY mobilenet_v1_1.0_224)
       download_file(
         https://neo-ai-dlr-test-artifacts.s3-us-west-2.amazonaws.com/tf-models/mobilenet_v1_1.0_224_frozen.pb
@@ -435,14 +437,32 @@ if(NOT(ANDROID_BUILD OR AAR_BUILD))
         SHA1
         4df8525bcf2ec96296098ba7fec0fff1abe32fce
       )
+  endif() # WITH_TENSORFLOW_LIB
+  if(WITH_HEXAGON)
+      # Download Test Hexagon model for Android 64 aarch64
+      file(MAKE_DIRECTORY dlr_hexagon_model)
       download_file(
-        https://neo-ai-dlr-test-artifacts.s3-us-west-2.amazonaws.com/tf-models/cat224-3.txt
+        https://neo-ai-dlr-test-artifacts.s3-us-west-2.amazonaws.com/hexagon-models/android_ReleaseG_aarch64/mobilenet_v1_0.75_224_quant_hexagon_model.so
+        ./dlr_hexagon_model/mobilenet_v1_0.75_224_quant_hexagon_model.so
+        SHA1
+        989d6f1613e948e432a31d5b5741bff7f9a9bacb
+      )
+      # Download Hexagon NNLib for Hexagon V65
+      download_file(
+        https://neo-ai-dlr-test-artifacts.s3-us-west-2.amazonaws.com/hexagon-models/hexagon_ReleaseG_dynamic_toolv83_v65/libhexagon_nn_skel.so
+        ./dlr_hexagon_model/libhexagon_nn_skel.so
+        SHA1
+        6746c34f54aad3df24d9fc5f632ebd9dfc64ed69
+      )
+  endif() # WITH_HEXAGON
+  if(WITH_TENSORFLOW_LITE_LIB OR WITH_TENSORFLOW_LIB OR WITH_HEXAGON)
+      download_file(
+        https://neo-ai-dlr-test-artifacts.s3-us-west-2.amazonaws.com/tflite-models/cat224-3.txt
         ./cat224-3.txt
         SHA1
         e35e82f3371bed37caa7ecece417f50876414077
       )
-  endif() # WITH_TENSORFLOW_LIB
+  endif() # WITH_TENSORFLOW_LITE_LIB OR WITH_TENSORFLOW_LIB OR WITH_HEXAGON
 endif()
-
 # Group sources
 #auto_source_group("${SOURCES}")

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -141,7 +141,7 @@ Once the compilation is completed, install the Python package by running ``setup
 .. code-block:: bash
 
   cd ../python
-  python3 setup.py install --user --force
+  python3 setup.py install --user
 
 Building on Mac OS X
 --------------------
@@ -178,7 +178,7 @@ DLR requires `Visual Studio 2017 <https://visualstudio.microsoft.com/downloads/>
 
 In the DLR directory, first run CMake to generate a Visual Studio project:
 
-.. code-block:: cmd
+.. code-block:: bash
 
   mkdir build
   cd build
@@ -190,7 +190,7 @@ NVIDIA GPUs are not yet supported for Windows target.
 
 Once the compilation is completed, install the Python package by running ``setup.py``:
 
-.. code-block:: cmd
+.. code-block:: bash
 
   cd ../python
   python3 setup.py install --user
@@ -268,13 +268,25 @@ Install `Android Studio <https://developer.android.com/studio>`_.
   ls -lah dlr/build/outputs/aar/dlr-release.aar
 
 
+Building DLR with Hexagon support
+---------------------------------
+
+To build DLR with Hexagon compiled models support use flag ``-DWITH_HEXAGON=1``
+
+.. code-block:: bash
+
+  cmake .. -DWITH_HEXAGON=1
+
+.. code-block:: bash
+
+  ./dlr_hexagon_test
 
 
 ***********************************
 Validation After Build (Linux Only)
 ***********************************
 
-.. code-block:: cmd
+.. code-block:: bash
 
   cd tests/python/integration/
   python load_and_run_tvm_model.py

--- a/include/dlr.h
+++ b/include/dlr.h
@@ -103,11 +103,25 @@ typedef struct DLR_TFTensorDesc {
  size \param threads Number of threads to use (ignored if zero of less) \return
  0 for success, -1 for error. Call DLRGetLastError() to get the error message.
  */
+DLR_DLL
 int CreateDLRModelFromTensorflow(DLRModelHandle* handle, const char* model_path,
                                  const DLR_TFTensorDesc* inputs, int input_size,
                                  const char* outputs[], int output_size,
                                  const DLR_TFConfig tf_config);
 #endif  // DLR_TENSORFLOW
+
+#ifdef DLR_HEXAGON
+/*!
+ \brief Creates a DLR model from Hexagon
+ \param handle The pointer to save the model handle.
+ \param model_path Path to _hexagon_model.so file or to the top-level directory containing the file
+ \param debug_level 0 - no debug, 100 - max debug.
+ \return 0 for success, -1 for error. Call DLRGetLastError() to get the error message.
+ */
+DLR_DLL
+int CreateDLRModelFromHexagon(DLRModelHandle* handle, const char* model_path,
+                              int debug_level);
+#endif  // DLR_HEXAGON
 
 /*!
  \brief Deletes a DLR model.

--- a/include/dlr_common.h
+++ b/include/dlr_common.h
@@ -45,6 +45,13 @@ void ListDir(const std::string& dirname, std::vector<std::string>& paths);
 
 std::string GetBasename(const std::string& path);
 
+std::string GetParentFolder(const std::string& path);
+
+inline bool StartsWith(const std::string& mainStr, const std::string& toMatch) {
+  return mainStr.size() >= toMatch.size() &&
+  mainStr.compare(0, toMatch.size(), toMatch) == 0;
+}
+
 inline bool EndsWith(const std::string& mainStr, const std::string& toMatch) {
   if (mainStr.size() >= toMatch.size() &&
       mainStr.compare(mainStr.size() - toMatch.size(), toMatch.size(),
@@ -54,7 +61,7 @@ inline bool EndsWith(const std::string& mainStr, const std::string& toMatch) {
     return false;
 }
 
-enum class DLRBackend { kTVM, kTREELITE, kTFLITE, kTENSORFLOW };
+enum class DLRBackend { kTVM, kTREELITE, kTFLITE, kTENSORFLOW, kHEXAGON };
 
 /*! \brief Get the backend based on the contents of the model folder.
  */

--- a/include/dlr_hexagon/dlr_hexagon.h
+++ b/include/dlr_hexagon/dlr_hexagon.h
@@ -1,0 +1,69 @@
+#ifndef DLR_HEXAGON_H_
+#define DLR_HEXAGON_H_
+
+#include "dlr_common.h"
+
+namespace dlr {
+
+/*! \brief Get the paths of the Hexagon model files.
+ */
+std::string GetHexagonModelFile(const std::string& dirname);
+bool FindHexagonNNSkelFile(const std::string& dirname);
+void* FindSymbol(void* handle, const char* fn_name);
+
+typedef struct {
+  std::string name;
+  int dim;
+  std::vector<int> shape;
+  int64_t size;
+  size_t bytes;
+} HexagonTensorSpec;
+
+/*! \brief class HexagonModel
+ */
+class HexagonModel : public DLRModel {
+ private:
+  std::vector<HexagonTensorSpec> input_tensors_spec_;
+  std::vector<HexagonTensorSpec> output_tensors_spec_;
+  void GenTensorSpec(bool isInput);
+  int GetInputId(const char* name);
+  void PrintHexagonNNLog();
+  int graph_id_;
+  uint8_t* input_;
+  uint8_t* output_;
+  int debug_level_;
+  char* log_buf_;
+  int log_buf_size_;
+
+  int (*dlr_hexagon_model_init)(int*, uint8_t**, uint8_t**, int);
+  int (*dlr_hexagon_model_exec)(int, uint8_t*, uint8_t*);
+  void (*dlr_hexagon_model_close)(int);
+  int (*dlr_hexagon_nn_getlog)(int, unsigned char*, int);
+  int (*dlr_hexagon_input_spec)(int, char**, int*, int**, int*, int*);
+  int (*dlr_hexagon_output_spec)(int, char**, int*, int**, int*, int*);
+
+ public:
+  /*! \brief Load model files from given folder path.
+   */
+  explicit HexagonModel(const std::string& model_path, const DLContext& ctx,
+                        const int debug_level);
+  ~HexagonModel();
+
+  virtual const char* GetInputName(int index) const override;
+  virtual const char* GetWeightName(int index) const override;
+  virtual std::vector<std::string> GetWeightNames() const override;
+  virtual void GetInput(const char* name, float* input) override;
+  virtual void SetInput(const char* name, const int64_t* shape, float* input,
+                        int dim) override;
+  virtual void Run() override;
+  virtual void GetOutput(int index, float* out) override;
+  virtual void GetOutputShape(int index, int64_t* shape) const override;
+  virtual void GetOutputSizeDim(int index, int64_t* size, int* dim) override;
+  virtual const char* GetBackend() const override;
+  virtual void SetNumThreads(int threads) override;
+  virtual void UseCPUAffinity(bool use) override;
+};
+
+}  // namespace dlr
+
+#endif  // DLR_HEXAGON_H_

--- a/src/dlr_common.cc
+++ b/src/dlr_common.cc
@@ -4,6 +4,14 @@
 
 using namespace dlr;
 
+std::string dlr::GetParentFolder(const std::string& path) {
+  size_t found = path.find_last_of("/\\");
+  if (found >= 0) {
+    return path.substr(0, found);
+  }
+  return "";
+}
+
 std::string dlr::GetBasename(const std::string& path) {
 #ifdef _WIN32
   /* remove any trailing backward or forward slashes
@@ -53,6 +61,9 @@ DLRBackend dlr::GetBackend(std::vector<std::string> dir_paths) {
   if (EndsWith(dir_paths[0], ".pb")) {
     return DLRBackend::kTENSORFLOW;
   }
+  if (EndsWith(dir_paths[0], "_hexagon_model.so")) {
+    return DLRBackend::kHEXAGON;
+  }
   // Scan Directory content to guess the backend.
   std::vector<std::string> paths;
   for (auto dir : dir_paths) {
@@ -65,6 +76,8 @@ DLRBackend dlr::GetBackend(std::vector<std::string> dir_paths) {
       return DLRBackend::kTFLITE;
     } else if (EndsWith(filename, ".pb")) {
       return DLRBackend::kTENSORFLOW;
+    } else if (EndsWith(filename, "_hexagon_model.so")) {
+      return DLRBackend::kHEXAGON;
     }
   }
   return DLRBackend::kTREELITE;

--- a/src/dlr_hexagon/dlr_hexagon.cc
+++ b/src/dlr_hexagon/dlr_hexagon.cc
@@ -1,0 +1,269 @@
+#include "dlr_hexagon/dlr_hexagon.h"
+
+#include <dlfcn.h>
+
+#include <cstdlib>
+#include <cstring>
+
+using namespace dlr;
+
+std::string dlr::GetHexagonModelFile(const std::string& dirname) {
+  // Support the case where user provides full path to _hexagon_model.so file.
+  if (EndsWith(dirname, "_hexagon_model.so")) {
+    return dirname;
+  }
+  // Scan Dir to find _hexagon_model.so file
+  std::string hexagon_model_so_file;
+  std::vector<std::string> paths_vec;
+  ListDir(dirname, paths_vec);
+  for (auto filename : paths_vec) {
+    std::string basename = GetBasename(filename);
+    if (EndsWith(basename, "_hexagon_model.so")) {
+      if (hexagon_model_so_file.empty()) {
+        hexagon_model_so_file = filename;
+      } else {
+        LOG(FATAL) << "Multiple _hexagon_model.so files under the folder: "
+                   << dirname;
+      }
+    }
+  }
+  if (hexagon_model_so_file.empty()) {
+    LOG(FATAL) << "No _hexagon_model.so file found under folder: " << dirname;
+  }
+  return hexagon_model_so_file;
+}
+
+bool dlr::FindHexagonNNSkelFile(const std::string& dirname) {
+  // Scan Dir to find libhexagon_nn_skel.so
+  std::vector<std::string> paths_vec;
+  ListDir(dirname, paths_vec);
+  for (auto filename : paths_vec) {
+    std::string basename = GetBasename(filename);
+    if (basename == "libhexagon_nn_skel.so") {
+      return true;
+    }
+  }
+  LOG(INFO) << "libhexagon_nn_skel.so file is not found under folder: "
+            << dirname;
+  return false;
+}
+
+void* dlr::FindSymbol(void* handle, const char* fn_name) {
+  LOG(INFO) << "Loading " << fn_name;
+  void* fn = dlsym(handle, fn_name);
+  if (!fn) {
+    LOG(FATAL) << "dlsym error for " << fn_name << ":" << dlerror();
+  }
+  return fn;
+}
+
+void HexagonModel::PrintHexagonNNLog() {
+  int err = (*dlr_hexagon_nn_getlog)(graph_id_, (unsigned char*)log_buf_,
+                                     log_buf_size_);
+  if (err == 0) {
+    LOG(INFO) << log_buf_;
+  }
+}
+
+void HexagonModel::GenTensorSpec(bool isInput) {
+  int err = 0;
+  int id = 0;
+  char* name = NULL;
+  int dim = 0;
+  int* shape = NULL;
+  int length = 0;
+  int bytes = 0;
+
+  while (true) {
+    if (isInput) {
+      err = (*dlr_hexagon_input_spec)(id, &name, &dim, &shape, &length, &bytes);
+    } else {
+      err =
+          (*dlr_hexagon_output_spec)(id, &name, &dim, &shape, &length, &bytes);
+    }
+    if (err != 0) break;
+    HexagonTensorSpec t_spec;
+    t_spec.name = std::string(name);
+    t_spec.dim = dim;
+    // Use vector(first, last) to copy int* to vector. Do not keep pointers of
+    // internal TF data structures.
+    t_spec.shape = std::vector<int>(shape, shape + dim);
+    t_spec.bytes = bytes;
+    t_spec.size = length;
+    if (isInput) {
+      input_tensors_spec_.push_back(t_spec);
+      // Fill in input_names_ vector as well because it is defined in base class
+      // DLRModel
+      input_names_.push_back(t_spec.name);
+    } else {
+      output_tensors_spec_.push_back(t_spec);
+    }
+    id++;
+  }
+}
+
+int HexagonModel::GetInputId(const char* name) {
+  // In most of the cases it will be just 1 element in the vector.
+  // Scan vector to find tensor by name.
+  for (int i = 0; i < num_inputs_; i++) {
+    if (input_tensors_spec_[i].name.compare(name) == 0) {
+      return i;
+    }
+  }
+  LOG(FATAL) << "Input Tensor not found, name: " << name;
+  return -1;  // unreachable
+}
+
+// Constructor
+HexagonModel::HexagonModel(const std::string& model_path, const DLContext& ctx,
+                           const int debug_level)
+    : DLRModel(ctx, DLRBackend::kHEXAGON) {
+  const std::string model_so_file = GetHexagonModelFile(model_path);
+  LOG(INFO) << "Model: " << model_so_file;
+  const std::string model_folder = GetParentFolder(model_so_file);
+  if (FindHexagonNNSkelFile(model_folder)) {
+    char* model_folder_abs = realpath(model_folder.c_str(), NULL);
+    LOG(INFO) << "ADSP_LIBRARY_PATH=" << model_folder_abs;
+    setenv("ADSP_LIBRARY_PATH", model_folder_abs, 1);
+    free(model_folder_abs);
+  } else {
+    LOG(INFO)
+        << "libhexagon_nn_skel.so file is not found. User needs to set "
+           "ADSP_LIBRARY_PATH to point to libhexagon_nn_skel.so file folder";
+  }
+
+  void* handle = dlopen(model_so_file.c_str(), RTLD_NOW | RTLD_LOCAL);
+  if (!handle) {
+    LOG(FATAL) << "Model file open error: " << dlerror();
+    return;  // unreachable
+  }
+
+  *(void**)(&dlr_hexagon_model_init) =
+      FindSymbol(handle, "dlr_hexagon_model_init");
+  *(void**)(&dlr_hexagon_model_exec) =
+      FindSymbol(handle, "dlr_hexagon_model_exec");
+  *(void**)(&dlr_hexagon_model_close) =
+      FindSymbol(handle, "dlr_hexagon_model_close");
+  *(void**)(&dlr_hexagon_nn_getlog) =
+      FindSymbol(handle, "dlr_hexagon_nn_getlog");
+  *(void**)(&dlr_hexagon_input_spec) =
+      FindSymbol(handle, "dlr_hexagon_input_spec");
+  *(void**)(&dlr_hexagon_output_spec) =
+      FindSymbol(handle, "dlr_hexagon_output_spec");
+
+  graph_id_ = 0;
+  input_ = NULL;
+  output_ = NULL;
+  log_buf_ = NULL;
+  debug_level_ = debug_level;
+  int err = 0;
+  log_buf_size_ = 2 * 1024 * 1024;
+  log_buf_ = new char[log_buf_size_];
+  if (log_buf_ == NULL) {
+    LOG(FATAL) << "Can not allocate print buffer, size: " << log_buf_size_;
+    return;  // unreachable
+  }
+
+  err = (*dlr_hexagon_model_init)(&graph_id_, &input_, &output_, debug_level_);
+  if (err != 0) {
+    PrintHexagonNNLog();
+    LOG(FATAL) << "dlr_hexagon_model_init failed: " << err;
+    return;  // unreachable
+  }
+  PrintHexagonNNLog();
+
+  // Save the number of inputs
+  GenTensorSpec(true /*isInput*/);
+  num_inputs_ = input_tensors_spec_.size();
+
+  // Save the number of outputs
+  GenTensorSpec(false /*isInput*/);
+  num_outputs_ = output_tensors_spec_.size();
+
+  LOG(INFO) << "HexagonModel was created";
+}
+
+// Destructor
+HexagonModel::~HexagonModel() {
+  if (graph_id_ != 0 && dlr_hexagon_model_close != NULL) {
+    (*dlr_hexagon_model_close)(graph_id_);
+    input_ = NULL;
+    output_ = NULL;
+    graph_id_ = 0;
+  }
+  if (log_buf_ != NULL) {
+    delete[] log_buf_;
+    log_buf_ = NULL;
+  }
+  LOG(INFO) << "HexagonModel was deleted";
+}
+
+std::vector<std::string> HexagonModel::GetWeightNames() const {
+  LOG(FATAL) << "GetWeightNames is not supported by Hexagon backend";
+  return std::vector<std::string>();  // unreachable
+}
+
+const char* HexagonModel::GetInputName(int index) const {
+  CHECK_LT(index, num_inputs_) << "Input index is out of range.";
+  return input_names_[index].c_str();
+}
+
+const char* HexagonModel::GetWeightName(int index) const {
+  LOG(FATAL) << "GetWeightName is not supported by Hexagon backend";
+  return "";  // unreachable
+}
+
+void HexagonModel::SetInput(const char* name, const int64_t* shape,
+                            float* input, int dim) {
+  int index = GetInputId(name);
+
+  // Check Size and Dim
+  CHECK_EQ(dim, input_tensors_spec_[index].dim) << "Incorrect input dim";
+  for (int i = 0; i < dim; i++) {
+    CHECK_EQ(shape[i], input_tensors_spec_[index].shape[i])
+        << "Incorrect input shape";
+  }
+  std::memcpy(input_, input, input_tensors_spec_[index].bytes);
+}
+
+void HexagonModel::GetInput(const char* name, float* input) {
+  int index = GetInputId(name);
+  std::memcpy(input, input_, input_tensors_spec_[index].bytes);
+}
+
+void HexagonModel::GetOutputShape(int index, int64_t* shape) const {
+  CHECK_LT(index, num_outputs_) << "Output index is out of range.";
+  for (int i = 0; i < output_tensors_spec_[index].dim; i++) {
+    shape[i] = (int64_t)output_tensors_spec_[index].shape[i];
+  }
+}
+
+void HexagonModel::GetOutput(int index, float* out) {
+  CHECK_LT(index, num_outputs_) << "Output index is out of range.";
+  std::memcpy(out, output_, output_tensors_spec_[index].bytes);
+}
+
+void HexagonModel::GetOutputSizeDim(int index, int64_t* size, int* dim) {
+  CHECK_LT(index, num_outputs_) << "Output index is out of range.";
+  *size = output_tensors_spec_[index].size;
+  *dim = output_tensors_spec_[index].dim;
+}
+
+void HexagonModel::Run() {
+  int err = (*dlr_hexagon_model_exec)(graph_id_, input_, output_);
+  // Invoke
+  if (err != 0) {
+    LOG(FATAL) << "Failed to exec hexagon model: " << err;
+    return;  // unreachable
+  }
+}
+
+const char* HexagonModel::GetBackend() const { return "hexagon"; }
+
+void HexagonModel::SetNumThreads(int threads) {
+  LOG(FATAL) << "SetNumThreads is not supported by Hexagon backend";
+}
+
+void HexagonModel::UseCPUAffinity(bool use) {
+  LOG(FATAL) << "UseCPUAffinity is not supported by Hexagon backend";
+}

--- a/tests/cpp/dlr_hexagon/dlr_hexagon_test.cc
+++ b/tests/cpp/dlr_hexagon/dlr_hexagon_test.cc
@@ -1,0 +1,201 @@
+#include <dmlc/logging.h>
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <cstring>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+
+#include "dlr.h"
+
+uint8_t* LoadImageAndPreprocess(const std::string& img_path, size_t size) {
+  std::string line;
+  std::ifstream fp(img_path);
+  uint8_t* img = new uint8_t[size];
+  size_t i = 0;
+  if (fp.is_open()) {
+    while (getline(fp, line) && i < size) {
+      int v = std::stoi(line);
+      img[i++] = v;
+    }
+    fp.close();
+  }
+
+  EXPECT_EQ(size, i);
+  LOG(INFO) << "Image read - OK, uint8_t[" << i << "]";
+  return img;
+}
+
+int ArgMax(uint8_t* data, int size) {
+  int idx = 0;
+  uint8_t v = 0;
+  for (int i = 0; i < size; i++) {
+    uint8_t vi = data[i];
+    if (vi > v) {
+      idx = i;
+      v = vi;
+    }
+  }
+  return idx;
+}
+
+void CheckAllDLRMethods(DLRModelHandle& handle) {
+  // GetDLRBackend
+  const char* backend_name;
+  if (GetDLRBackend(&handle, &backend_name)) {
+    FAIL() << "GetDLRBackend failed";
+  }
+  LOG(INFO) << "GetDLRBackend: " << backend_name;
+  EXPECT_STREQ("hexagon", backend_name);
+
+  // GetDLRNumInputs
+  int num_inputs;
+  if (GetDLRNumInputs(&handle, &num_inputs)) {
+    FAIL() << "GetDLRNumInputs failed";
+  }
+  LOG(INFO) << "GetDLRNumInputs: " << num_inputs;
+  EXPECT_EQ(1, num_inputs);
+
+  // GetDLRNumOutputs
+  int num_outputs;
+  if (GetDLRNumOutputs(&handle, &num_outputs)) {
+    FAIL() << "GetDLRNumOutputs failed";
+  }
+  LOG(INFO) << "GetDLRNumOutputs: " << num_outputs;
+  EXPECT_EQ(1, num_outputs);
+
+  // GetDLRNumWeights
+  int num_weights;
+  if (GetDLRNumWeights(&handle, &num_weights)) {
+    FAIL() << "GetDLRNumWeights failed";
+  }
+  LOG(INFO) << "GetDLRNumWeights: " << num_weights;
+  EXPECT_EQ(0, num_weights);
+
+  // GetDLRInputName
+  const char* input_name;
+  if (GetDLRInputName(&handle, 0, &input_name)) {
+    FAIL() << "GetDLRInputName failed";
+  }
+  LOG(INFO) << "DLRInputName: " << input_name;
+  EXPECT_STREQ("input", input_name);
+
+  // GetDLROutputSizeDim
+  int64_t out_size;
+  int out_dim;
+  if (GetDLROutputSizeDim(&handle, 0, &out_size, &out_dim)) {
+    FAIL() << "GetDLROutputSizeDim failed";
+  }
+  LOG(INFO) << "GetDLROutputSizeDim.size: " << out_size;
+  LOG(INFO) << "GetDLROutputSizeDim.dim: " << out_dim;
+  EXPECT_EQ(1001, out_size);
+  EXPECT_EQ(4, out_dim);
+
+  // GetDLROutputShape
+  int64_t shape[out_dim];
+  if (GetDLROutputShape(&handle, 0, shape)) {
+    FAIL() << "GetDLROutputShape failed";
+  }
+  std::stringstream ss;
+  ss << "GetDLROutputShape: (" << shape[0];
+  for (int i = 1; i < out_dim; i++) {
+    ss << "," << shape[i];
+  }
+  ss << ")";
+  LOG(INFO) << ss.str();
+  const int64_t exp_shape[4] = {1, 1, 1, 1001};
+  EXPECT_TRUE(std::equal(std::begin(exp_shape), std::end(exp_shape), shape));
+
+  // Load image
+  size_t img_size = 224 * 224 * 3;
+  uint8_t* img = LoadImageAndPreprocess("cat224-3.txt", img_size);
+  LOG(INFO) << "Input sample: [" << +img[0] << "," << +img[1] << "..."
+            << +img[img_size - 1] << "]";
+
+  // SetDLRInput
+  const int64_t in_shape[4] = {1, 224, 224, 3};
+  if (SetDLRInput(&handle, input_name, in_shape, (float*)img, 4)) {
+    FAIL() << "SetDLRInput failed";
+  }
+  LOG(INFO) << "SetDLRInput - OK";
+
+  // GetDLRInput
+  uint8_t* input2 = new uint8_t[img_size];
+  if (GetDLRInput(&handle, input_name, (float*)input2)) {
+    FAIL() << "GetDLRInput failed";
+  }
+  EXPECT_TRUE(std::equal(img, img + img_size, input2));
+  LOG(INFO) << "GetDLRInput - OK";
+
+  // RunDLRModel
+  if (RunDLRModel(&handle)) {
+    FAIL() << "RunDLRModel failed";
+  }
+  LOG(INFO) << "RunDLRModel - OK";
+
+  // GetDLROutput
+  uint8_t* output = new uint8_t[out_size];
+  if (GetDLROutput(&handle, 0, (float*)output)) {
+    FAIL() << "GetDLROutput failed";
+  }
+  LOG(INFO) << "GetDLROutput - OK";
+  size_t max_id = ArgMax(output, out_size);
+  LOG(INFO) << "ArgMax: " << max_id << ", Prop: " << +output[max_id];
+  // TFLite class range is 1-1000 (output size 1001)
+  // Imagenet1000 class range is 0-999
+  // https://gist.github.com/yrevar/942d3a0ac09ec9e5eb3a
+  EXPECT_EQ(282, max_id);  // TFLite 282 maps to Imagenet 281 - tabby, tabby cat
+  EXPECT_GE(output[max_id], 150);
+  EXPECT_GE(output[283], 80);  // TFLite 283 maps to Imagenet 282 - tiger cat
+
+  // clean up
+  delete[] img;
+  delete[] input2;
+  delete[] output;
+}
+
+TEST(Hexagon, CreateDLRModelFromHexagonFromFile) {
+  // CreateDLRModelFromHexagon (use _hexagon_model.so file)
+  const char* model_file =
+      "./dlr_hexagon_model/mobilenet_v1_0.75_224_quant_hexagon_model.so";
+  int debug_level = 0;
+
+  DLRModelHandle handle = NULL;
+  if (CreateDLRModelFromHexagon(&handle, model_file, debug_level)) {
+    FAIL() << DLRGetLastError() << std::endl;
+  }
+  LOG(INFO) << "CreateDLRModelFromHexagon - OK";
+
+  CheckAllDLRMethods(handle);
+
+  // DeleteDLRModel
+  DeleteDLRModel(&handle);
+}
+
+TEST(Hexagon, CreateDLRModelFromDir) {
+  // CreateDLRModel (use folder containing _hexagon_model.so file)
+  const char* model_dir = "./dlr_hexagon_model";
+  // Use undefined number of threads
+  const int dev_type = 1;  // 1 - kDLCPU
+  const int dev_id = 0;
+
+  DLRModelHandle handle = NULL;
+  if (CreateDLRModel(&handle, model_dir, dev_type, dev_id)) {
+    FAIL() << DLRGetLastError() << std::endl;
+  }
+  LOG(INFO) << "CreateDLRModel - OK";
+
+  CheckAllDLRMethods(handle);
+
+  // DeleteDLRModel
+  DeleteDLRModel(&handle);
+}
+
+int main(int argc, char** argv) {
+  testing::InitGoogleTest(&argc, argv);
+#ifndef _WIN32
+  testing::FLAGS_gtest_death_test_style = "threadsafe";
+#endif  // _WIN32
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
This PR adds DLR adapter to run models which use Hexagon NNLib and which were compiled by Hexagon SDK (for Linux or Android)

Currently we have a [hexagon-converter](https://github.com/apivovarov/hexagon-converter) which converts TFLite quantized models to C program which uses Hexagon NNLib API to assemble model graph and store model weights.
Hexagon SDK compiles the program to shared library for ARM cpu with particular extern functions, such as `dlr_hexagon_model_init`, `dlr_hexagon_model_exec`, etc.
Hexagon SDK also compiles Hexagon NNLib to shared library for Hexagon DSP.
The compilation output is
- `dlr_hexagon_model.so` - model graph and weights (Compiled for ARM CPU Linux/Android)
- `libhexagon_nn_skel.so` - Hexagon NNLib compiled for Hexagon DSP

DLR Adapter loads model file (e.g. `dlr_hexagon_model.so`) at runtime, it also "dlsym" extern functions (symbols) such as `dlr_hexagon_model_init`, `dlr_hexagon_model_exec` and calls them to init the model, get pointers to input/output buffers and run inference.

Hexagon SDK runtime uses `ADSP_LIBRARY_PATH` to find `libhexagon_nn_skel.so` file.
if `libhexagon_nn_skel.so` is present in the model folder then DLR adapter will set `ADSP_LIBRARY_PATH` automatically. If not then User needs to set `ADSP_LIBRARY_PATH` to point to `libhexagon_nn_skel.so` file folder

# Test
I tested DLR with hexagon compiled model `mobilenet_v1_0.75_224_quant_hexagon_model.so`.
I run it on `QCS605` dev board (Android 8.1, 64 bits)
Run log: https://textuploader.com/145zt
