### PR TITLE
Install pip3 using get-pip.py in Docker files

### DIFF
--- a/container/Dockerfile.cpu
+++ b/container/Dockerfile.cpu
@@ -9,10 +9,11 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     python3 \
-    python3-pip \
     python3-setuptools \
+    curl \
+    ca-certificates \
     && rm -rf /var/lib/apt/lists/* \
-    && pip3 install wheel \
+    && curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python3 get-pip.py && rm get-pip.py \
     && rm -rf /root/.cache/pip
 
 ### Stage 1: Build
@@ -57,8 +58,8 @@ RUN apt-get update && \
 
 COPY --from=builder /workspace/python/dist/*.whl /home/model-server/
 
-RUN pip3 install --pre --no-cache-dir multi-model-server==1.1.0 \
-    && pip3 install --no-cache-dir numpy scipy xlrd Pillow boto3 six requests mxnet tensorflow \
+RUN pip3 install --pre --no-cache-dir multi-model-server \
+    && pip3 install --no-cache-dir --prefer-binary numpy scipy xlrd Pillow boto3 six requests mxnet tensorflow \
     && pip3 install /home/model-server/dlr-*.whl \
     && rm -rf /root/.cache/pip
 

--- a/container/Dockerfile.gpu
+++ b/container/Dockerfile.gpu
@@ -15,10 +15,11 @@ ENV LD_LIBRARY_PATH=/packages/TensorRT-7.0.0.11/lib:$LD_LIBRARY_PATH
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     python3 \
-    python3-pip \
     python3-setuptools \
+    curl \
+    ca-certificates \
     && rm -rf /var/lib/apt/lists/* \
-    && pip3 install wheel \
+    && curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python3 get-pip.py && rm get-pip.py \
     && rm -rf /root/.cache/pip
 
 ### Stage 1: Build
@@ -64,8 +65,8 @@ RUN apt-get update && \
 
 COPY --from=builder /workspace/python/dist/*.whl /home/model-server/
 
-RUN pip3 install --pre --no-cache-dir multi-model-server==1.1.0 \
-    && pip3 install --no-cache-dir numpy scipy xlrd Pillow boto3 six requests mxnet-cu100 tensorflow_gpu \
+RUN pip3 install --pre --no-cache-dir multi-model-server \
+    && pip3 install --no-cache-dir --prefer-binary numpy scipy xlrd Pillow boto3 six requests mxnet-cu100 tensorflow_gpu \
     && pip3 install /home/model-server/dlr-*.whl \
     && rm -rf /root/.cache/pip
 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -83,7 +83,11 @@ Ensure that all necessary software packages are installed: GCC (or Clang), CMake
 .. code-block:: bash
 
   sudo apt-get update
-  sudo apt-get install -y python3 python3-pip gcc build-essential cmake
+  sudo apt-get install -y python3 python3-setuptools build-essential cmake curl ca-certificates
+  curl https://bootstrap.pypa.io/get-pip.py -o /tmp/get-pip.py
+  sudo python3 /tmp/get-pip.py
+  rm /tmp/get-pip.py
+
   
 To build, create a subdirectory ``build``:
 


### PR DESCRIPTION
Install `pip3` using `get-pip.py` in `Dockerfile.cpu` and `Dockerfile.gpu` files.

Use the latest pre-release version of multi-model-server (PR #162)