### PR TITLE
Remove --force-reinstall in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -132,11 +132,11 @@ def CloudInstallAndTest(cloudTarget) {
     """
     if (cloudTarget == "p2" || cloudTarget == "p3") {
       sh """
-      sudo pip3 install --upgrade --force-reinstall tensorflow_gpu
+      sudo pip3 install --upgrade tensorflow_gpu
       """
     } else {
       sh """
-      sudo pip3 install --upgrade --force-reinstall tensorflow
+      sudo pip3 install --upgrade tensorflow
       """
     }
     sh """


### PR DESCRIPTION
Currently Jenkins file uses `pip3 install` with both `--upgrade and --force-reinstall` parameters.
It causes unnecessary packages download and reinstallation. In some cases it might cause CI build to fail because some packages might be temporary unavailable in PyPi repo.

To minimize network traffic and risk of stepping on PyPi availability issue we can remove `--force-reinstall` flag.

Using`--upgrade` parameter solely is enough to install the latest package version with all required dependencies.
