### PR TITLE
C API to get Input/Output Type

### DIFF
--- a/demo/cpp/model_peeker.cc
+++ b/demo/cpp/model_peeker.cc
@@ -43,6 +43,14 @@ void peek_model(DLRModelHandle model) {
   }
   std::cout << std::endl;
 
+  std::cout << "input_types: ";
+  for (int i = 0; i < num_inputs; i++) {
+    const char* input_type;
+    GetDLRInputType(&model, i, &input_type);
+    std::cout << input_type << ", ";
+  }
+  std::cout << std::endl;
+
   // weight_names.resize(num_weights);
   // std::cout << "weight_names: ";
   // for (int i = 0; i < num_weights; i++) {
@@ -66,6 +74,13 @@ void peek_model(DLRModelHandle model) {
     }
     std::cout << "]" << std::endl;
   }
+  std::cout << "output_types: ";
+  for (int i = 0; i < num_outputs; i++) {
+    const char* output_type;
+    GetDLROutputType(&model, i, &output_type);
+    std::cout << output_type << ", ";
+  }
+  std::cout << std::endl;
 }
 
 int main(int argc, char** argv) {

--- a/include/dlr.h
+++ b/include/dlr.h
@@ -173,6 +173,17 @@ DLR_DLL
 int GetDLRInputName(DLRModelHandle* handle, int index, const char** input_name);
 
 /*!
+ \brief Gets the type of the index-th input.
+ \param handle The model handle returned from CreateDLRModel().
+ \param index The index of the input.
+ \param input_type The pointer to save the type of the index-th input.
+ \return 0 for success, -1 for error. Call DLRGetLastError() to get the error
+ message.
+ */
+DLR_DLL
+int GetDLRInputType(DLRModelHandle* handle, int index, const char** input_type);
+
+/*!
  \brief Gets the name of the index-th weight.
  \param handle The model handle returned from CreateDLRModel().
  \param index The index of the weight.
@@ -250,6 +261,19 @@ int GetDLRNumOutputs(DLRModelHandle* handle, int* num_outputs);
 DLR_DLL
 int GetDLROutputSizeDim(DLRModelHandle* handle, int index, int64_t* size,
                         int* dim);
+
+/*!
+ \brief Gets the type of the index-th input.
+ \param handle The model handle returned from CreateDLRModel().
+ \param index The index of the input.
+ \param input_type The pointer to save the type of the index-th input.
+ \return 0 for success, -1 for error. Call DLRGetLastError() to get the error
+ message.
+ */
+DLR_DLL
+int GetDLROutputType(DLRModelHandle* handle, int index,
+                     const char** output_type);
+
 /*!
  \brief Gets the last error message.
  \return Null-terminated string containing the error message.

--- a/include/dlr_common.h
+++ b/include/dlr_common.h
@@ -81,6 +81,7 @@ class DLRModel {
   size_t num_outputs_ = 1;
   DLContext ctx_;
   std::vector<std::string> input_names_;
+  std::vector<std::string> input_types_;
 
  public:
   DLRModel(const DLContext& ctx, const DLRBackend& backend)
@@ -96,6 +97,7 @@ class DLRModel {
     *num_weights = num_weights_;
   }
   virtual const char* GetInputName(int index) const = 0;
+  virtual const char* GetInputType(int index) const = 0;
   virtual const char* GetWeightName(int index) const = 0;
   virtual std::vector<std::string> GetWeightNames() const = 0;
   virtual void GetInput(const char* name, float* input) = 0;
@@ -105,6 +107,7 @@ class DLRModel {
   virtual void GetOutput(int index, float* out) = 0;
   virtual void GetOutputShape(int index, int64_t* shape) const = 0;
   virtual void GetOutputSizeDim(int index, int64_t* size, int* dim) = 0;
+  virtual const char* GetOutputType(int index) const = 0;
   virtual const char* GetBackend() const = 0;
   virtual void SetNumThreads(int threads) = 0;
   virtual void UseCPUAffinity(bool use) = 0;

--- a/include/dlr_hexagon/dlr_hexagon.h
+++ b/include/dlr_hexagon/dlr_hexagon.h
@@ -50,6 +50,7 @@ class HexagonModel : public DLRModel {
   ~HexagonModel();
 
   virtual const char* GetInputName(int index) const override;
+  virtual const char* GetInputType(int index) const override;
   virtual const char* GetWeightName(int index) const override;
   virtual std::vector<std::string> GetWeightNames() const override;
   virtual void GetInput(const char* name, float* input) override;
@@ -59,6 +60,7 @@ class HexagonModel : public DLRModel {
   virtual void GetOutput(int index, float* out) override;
   virtual void GetOutputShape(int index, int64_t* shape) const override;
   virtual void GetOutputSizeDim(int index, int64_t* size, int* dim) override;
+  virtual const char* GetOutputType(int index) const override;
   virtual const char* GetBackend() const override;
   virtual void SetNumThreads(int threads) override;
   virtual void UseCPUAffinity(bool use) override;

--- a/include/dlr_tensorflow/dlr_tensorflow.h
+++ b/include/dlr_tensorflow/dlr_tensorflow.h
@@ -58,6 +58,7 @@ class TensorflowModel : public DLRModel {
   ~TensorflowModel();
 
   virtual const char* GetInputName(int index) const override;
+  virtual const char* GetInputType(int index) const override;
   virtual const char* GetWeightName(int index) const override;
   virtual std::vector<std::string> GetWeightNames() const override;
   virtual void GetInput(const char* name, float* input) override;
@@ -67,6 +68,7 @@ class TensorflowModel : public DLRModel {
   virtual void GetOutput(int index, float* out) override;
   virtual void GetOutputShape(int index, int64_t* shape) const override;
   virtual void GetOutputSizeDim(int index, int64_t* size, int* dim) override;
+  virtual const char* GetOutputType(int index) const override;
   virtual const char* GetBackend() const override;
   virtual void SetNumThreads(int threads) override;
   virtual void UseCPUAffinity(bool use) override;

--- a/include/dlr_tflite/dlr_tflite.h
+++ b/include/dlr_tflite/dlr_tflite.h
@@ -40,6 +40,7 @@ class TFLiteModel : public DLRModel {
   ~TFLiteModel();
 
   virtual const char* GetInputName(int index) const override;
+  virtual const char* GetInputType(int index) const override;
   virtual const char* GetWeightName(int index) const override;
   virtual std::vector<std::string> GetWeightNames() const override;
   virtual void GetInput(const char* name, float* input) override;
@@ -49,6 +50,7 @@ class TFLiteModel : public DLRModel {
   virtual void GetOutput(int index, float* out) override;
   virtual void GetOutputShape(int index, int64_t* shape) const override;
   virtual void GetOutputSizeDim(int index, int64_t* size, int* dim) override;
+  virtual const char* GetOutputType(int index) const override;
   virtual const char* GetBackend() const override;
   virtual void SetNumThreads(int threads) override;
   virtual void UseCPUAffinity(bool use) override;

--- a/include/dlr_treelite.h
+++ b/include/dlr_treelite.h
@@ -47,6 +47,7 @@ class TreeliteModel : public DLRModel {
   }
 
   virtual const char* GetInputName(int index) const override;
+  virtual const char* GetInputType(int index) const override;
   virtual const char* GetWeightName(int index) const override;
   virtual std::vector<std::string> GetWeightNames() const override;
   virtual void GetInput(const char* name, float* input) override;
@@ -56,6 +57,7 @@ class TreeliteModel : public DLRModel {
   virtual void GetOutput(int index, float* out) override;
   virtual void GetOutputShape(int index, int64_t* shape) const override;
   virtual void GetOutputSizeDim(int index, int64_t* size, int* dim) override;
+  virtual const char* GetOutputType(int index) const override;
   virtual const char* GetBackend() const override;
   virtual void SetNumThreads(int threads) override;
   virtual void UseCPUAffinity(bool use) override;

--- a/include/dlr_tvm.h
+++ b/include/dlr_tvm.h
@@ -19,6 +19,7 @@ class TVMModel : public DLRModel {
   tvm::runtime::ObjectPtr<tvm::runtime::GraphRuntime> tvm_graph_runtime_;
   std::shared_ptr<tvm::runtime::Module> tvm_module_;
   std::vector<const DLTensor*> outputs_;
+  std::vector<std::string> output_types_;
   std::vector<std::string> weight_names_;
   void SetupTVMModule(std::vector<std::string> model_path);
 
@@ -31,6 +32,7 @@ class TVMModel : public DLRModel {
   }
 
   virtual const char* GetInputName(int index) const override;
+  virtual const char* GetInputType(int index) const override;
   virtual const char* GetWeightName(int index) const override;
   virtual std::vector<std::string> GetWeightNames() const override;
   virtual void GetInput(const char* name, float* input) override;
@@ -40,6 +42,7 @@ class TVMModel : public DLRModel {
   virtual void GetOutput(int index, float* out) override;
   virtual void GetOutputShape(int index, int64_t* shape) const override;
   virtual void GetOutputSizeDim(int index, int64_t* size, int* dim) override;
+  virtual const char* GetOutputType(int index) const override;
   virtual const char* GetBackend() const override;
   virtual void SetNumThreads(int threads) override;
   virtual void UseCPUAffinity(bool use) override;

--- a/src/dlr.cc
+++ b/src/dlr.cc
@@ -44,6 +44,15 @@ extern "C" int GetDLRInputName(DLRModelHandle* handle, int index,
   API_END();
 }
 
+extern "C" int GetDLRInputType(DLRModelHandle* handle, int index,
+                               const char** input_type) {
+  API_BEGIN();
+  DLRModel* model = static_cast<DLRModel*>(*handle);
+  CHECK(model != nullptr) << "model is nullptr, create it first";
+  *input_type = model->GetInputType(index);
+  API_END();
+}
+
 extern "C" int GetDLRWeightName(DLRModelHandle* handle, int index,
                                 const char** weight_name) {
   API_BEGIN();
@@ -94,6 +103,15 @@ extern "C" int GetDLROutputSizeDim(DLRModelHandle* handle, int index,
   DLRModel* model = static_cast<DLRModel*>(*handle);
   CHECK(model != nullptr) << "model is nullptr, create it first";
   model->GetOutputSizeDim(index, size, dim);
+  API_END();
+}
+
+extern "C" int GetDLROutputType(DLRModelHandle* handle, int index,
+                                const char** output_type) {
+  API_BEGIN();
+  DLRModel* model = static_cast<DLRModel*>(*handle);
+  CHECK(model != nullptr) << "model is nullptr, create it first";
+  *output_type = model->GetOutputType(index);
   API_END();
 }
 

--- a/src/dlr_hexagon/dlr_hexagon.cc
+++ b/src/dlr_hexagon/dlr_hexagon.cc
@@ -208,6 +208,11 @@ const char* HexagonModel::GetInputName(int index) const {
   return input_names_[index].c_str();
 }
 
+const char* HexagonModel::GetInputType(int index) const {
+  LOG(FATAL) << "GetInputType is not supported by Hexagon backend";
+  return "";  // unreachable
+}
+
 const char* HexagonModel::GetWeightName(int index) const {
   LOG(FATAL) << "GetWeightName is not supported by Hexagon backend";
   return "";  // unreachable
@@ -247,6 +252,11 @@ void HexagonModel::GetOutputSizeDim(int index, int64_t* size, int* dim) {
   CHECK_LT(index, num_outputs_) << "Output index is out of range.";
   *size = output_tensors_spec_[index].size;
   *dim = output_tensors_spec_[index].dim;
+}
+
+const char* HexagonModel::GetOutputType(int index) const {
+  LOG(FATAL) << "GetOutputType is not supported by Hexagon backend";
+  return "";  // unreachable
 }
 
 void HexagonModel::Run() {

--- a/src/dlr_tensorflow/dlr_tensorflow.cc
+++ b/src/dlr_tensorflow/dlr_tensorflow.cc
@@ -382,6 +382,11 @@ const char* TensorflowModel::GetInputName(int index) const {
   return input_names_[index].c_str();
 }
 
+const char* TensorflowModel::GetInputType(int index) const {
+  LOG(FATAL) << "GetInputType is not supported by Tensorflow backend";
+  return "";  // unreachable
+}
+
 const char* TensorflowModel::GetWeightName(int index) const {
   LOG(FATAL) << "GetWeightName is not supported by Tensorflow backend";
   return "";  // unreachable
@@ -430,6 +435,11 @@ void TensorflowModel::GetOutputSizeDim(int index, int64_t* size, int* dim) {
   TF_Tensor* tensor = output_tensors_[index];
   *size = TF_TensorElementCount(tensor);
   *dim = TF_NumDims(tensor);
+}
+
+const char* TensorflowModel::GetOutputType(int index) const {
+  LOG(FATAL) << "GetOutputType is not supported by Tensorflow backend";
+  return "";  // unreachable
 }
 
 void TensorflowModel::Run() {

--- a/src/dlr_tflite/dlr_tflite.cc
+++ b/src/dlr_tflite/dlr_tflite.cc
@@ -5,6 +5,14 @@
 
 using namespace dlr;
 
+// TFLite Type names
+// https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/c/common.h
+static std::string TFLITE_TYPES_STR[12]{
+    /* 0 */ "none",  /* 1 */ "float32",  /* 2 */ "int32",
+    /* 3 */ "uint8", /* 4 */ "int64",    /* 5 */ "string",
+    /* 6 */ "bool",  /* 7 */ "int16",    /* 8 */ "complex64",
+    /* 9 */ "int8",  /* 10 */ "float16", /* 11 */ "float64"};
+
 std::string dlr::GetTFLiteFile(const std::string& dirname) {
   // Support the case where user provides full path to tflite file.
   if (EndsWith(dirname, ".tflite")) {
@@ -141,6 +149,13 @@ const char* TFLiteModel::GetInputName(int index) const {
   return input_names_[index].c_str();
 }
 
+const char* TFLiteModel::GetInputType(int index) const {
+  CHECK_LT(index, num_inputs_) << "Input index is out of range.";
+  TensorSpec input_tensors_spec = input_tensors_spec_[index];
+  int type_id = input_tensors_spec.type;
+  return TFLITE_TYPES_STR[type_id].c_str();
+}
+
 const char* TFLiteModel::GetWeightName(int index) const {
   LOG(FATAL) << "GetWeightName is not supported by TFLite backend";
   return "";  // unreachable
@@ -153,8 +168,7 @@ void TFLiteModel::SetInput(const char* name, const int64_t* shape, float* input,
   // Check Size and Dim
   CHECK_EQ(dim, input_tensors_spec.dim) << "Incorrect input dim";
   for (int i = 0; i < dim; i++) {
-    CHECK_EQ(shape[i], input_tensors_spec.shape[i])
-        << "Incorrect input shape";
+    CHECK_EQ(shape[i], input_tensors_spec.shape[i]) << "Incorrect input shape";
   }
   void* in_t_data;
   if (input_tensors_spec.type == TfLiteType::kTfLiteFloat32) {
@@ -162,7 +176,7 @@ void TFLiteModel::SetInput(const char* name, const int64_t* shape, float* input,
   } else if (input_tensors_spec.type == TfLiteType::kTfLiteUInt8) {
     in_t_data = interpreter_->typed_input_tensor<uint8_t>(index);
   } else {
-      LOG(FATAL) << "Input tensor type is not supported by TFLite backend";
+    LOG(FATAL) << "Input tensor type is not supported by TFLite backend";
   }
   std::memcpy(in_t_data, input, input_tensors_spec_[index].bytes);
 }
@@ -176,7 +190,7 @@ void TFLiteModel::GetInput(const char* name, float* input) {
   } else if (input_tensors_spec.type == TfLiteType::kTfLiteUInt8) {
     in_t_data = interpreter_->typed_input_tensor<uint8_t>(index);
   } else {
-      LOG(FATAL) << "Input tensor type is not supported by TFLite backend";
+    LOG(FATAL) << "Input tensor type is not supported by TFLite backend";
   }
   std::memcpy(input, in_t_data, input_tensors_spec.bytes);
 }
@@ -197,7 +211,7 @@ void TFLiteModel::GetOutput(int index, float* out) {
   } else if (output_tensors_spec.type == TfLiteType::kTfLiteUInt8) {
     out_t_data = interpreter_->typed_output_tensor<uint8_t>(index);
   } else {
-      LOG(FATAL) << "Output tensor type is not supported by TFLite backend";
+    LOG(FATAL) << "Output tensor type is not supported by TFLite backend";
   }
   std::memcpy(out, out_t_data, output_tensors_spec_[index].bytes);
 }
@@ -206,6 +220,13 @@ void TFLiteModel::GetOutputSizeDim(int index, int64_t* size, int* dim) {
   CHECK_LT(index, num_outputs_) << "Output index is out of range.";
   *size = output_tensors_spec_[index].size;
   *dim = output_tensors_spec_[index].dim;
+}
+
+const char* TFLiteModel::GetOutputType(int index) const {
+  CHECK_LT(index, num_outputs_) << "Output index is out of range.";
+  TensorSpec output_tensors_spec = output_tensors_spec_[index];
+  int type_id = output_tensors_spec.type;
+  return TFLITE_TYPES_STR[type_id].c_str();
 }
 
 void TFLiteModel::Run() {

--- a/src/dlr_treelite.cc
+++ b/src/dlr_treelite.cc
@@ -60,6 +60,7 @@ void TreeliteModel::SetupTreeliteModule(std::vector<std::string> model_path) {
   num_outputs_ = 1;
   // Give a dummy input name to Treelite model.
   input_names_.push_back("data");
+  input_types_.push_back("float32");
   CHECK_EQ(TreelitePredictorLoad(paths.model_lib.c_str(), num_worker_threads,
                                  &treelite_model_),
            0)
@@ -101,6 +102,11 @@ const char* TreeliteModel::GetInputName(int index) const {
   return "data";
 }
 
+const char* TreeliteModel::GetInputType(int index) const {
+  CHECK_LT(index, num_inputs_) << "Input index is out of range.";
+  return "float32";
+}
+
 const char* TreeliteModel::GetWeightName(int index) const {
   LOG(FATAL) << "GetWeightName is not supported by Treelite backend";
   return "";  // unreachable
@@ -113,7 +119,8 @@ void TreeliteModel::SetInput(const char* name, const int64_t* shape,
   // NOTE: If number of columns is less than num_feature, missing columns
   //       will be automatically padded with missing values
   CHECK_LE(static_cast<size_t>(shape[1]), treelite_num_feature_)
-      << "ClientError: Mismatch found in input shape at dimension 1. Value read: "
+      << "ClientError: Mismatch found in input shape at dimension 1. Value "
+         "read: "
       << shape[1] << ", Expected: " << treelite_num_feature_ << " or less";
 
   const size_t batch_size = static_cast<size_t>(shape[0]);
@@ -177,6 +184,11 @@ void TreeliteModel::GetOutputSizeDim(int index, int64_t* size, int* dim) {
     *size = treelite_output_size_;
   }
   *dim = 2;
+}
+
+const char* TreeliteModel::GetOutputType(int index) const {
+  CHECK_LT(index, num_outputs_) << "Output index is out of range.";
+  return "float32";
 }
 
 void TreeliteModel::Run() {

--- a/src/dlr_tvm.cc
+++ b/src/dlr_tvm.cc
@@ -87,14 +87,20 @@ void TVMModel::SetupTVMModule(std::vector<std::string> model_path) {
                       std::inserter(input_names_, input_names_.begin()));
   // Save the number of inputs
   num_inputs_ = input_names_.size();
+  input_types_.resize(num_inputs_);
+  for (int i = 0; i < num_inputs_; i++) {
+    input_types_[i] = tvm_graph_runtime_->GetInputType(i);
+  }
 
   // Get the number of output and reserve space to save output tensor
   // pointers.
   num_outputs_ = tvm_graph_runtime_->NumOutputs();
   outputs_.resize(num_outputs_);
+  output_types_.resize(num_outputs_);
   for (int i = 0; i < num_outputs_; i++) {
     tvm::runtime::NDArray output = tvm_graph_runtime_->GetOutput(i);
     outputs_[i] = output.operator->();
+    output_types_[i] = tvm_graph_runtime_->GetOutputType(i);
   }
 }
 
@@ -105,6 +111,11 @@ std::vector<std::string> TVMModel::GetWeightNames() const {
 const char* TVMModel::GetInputName(int index) const {
   CHECK_LT(index, num_inputs_) << "Input index is out of range.";
   return input_names_[index].c_str();
+}
+
+const char* TVMModel::GetInputType(int index) const {
+  CHECK_LT(index, num_inputs_) << "Input index is out of range.";
+  return input_types_[index].c_str();
 }
 
 const char* TVMModel::GetWeightName(int index) const {
@@ -165,6 +176,11 @@ void TVMModel::GetOutputSizeDim(int index, int64_t* size, int* dim) {
     *size *= tensor->shape[i];
   }
   *dim = tensor->ndim;
+}
+
+const char* TVMModel::GetOutputType(int index) const {
+  CHECK_LT(index, num_outputs_) << "Output index is out of range.";
+  return output_types_[index].c_str();
 }
 
 void TVMModel::Run() {

--- a/tests/cpp/dlr_tflite/dlr_tflite_test.cc
+++ b/tests/cpp/dlr_tflite/dlr_tflite_test.cc
@@ -80,6 +80,14 @@ void CheckAllDLRMethods(DLRModelHandle& handle) {
   LOG(INFO) << "DLRInputName: " << input_name;
   EXPECT_STREQ("input", input_name);
 
+  // GetDLRInputType
+  const char* input_type;
+  if (GetDLRInputType(&handle, 0, &input_type)) {
+    FAIL() << "GetDLRInputType failed";
+  }
+  LOG(INFO) << "DLRInputType: " << input_type;
+  EXPECT_STREQ("float32", input_type);
+
   // GetDLROutputSizeDim
   int64_t out_size;
   int out_dim;
@@ -105,6 +113,14 @@ void CheckAllDLRMethods(DLRModelHandle& handle) {
   LOG(INFO) << ss.str();
   const int64_t exp_shape[2] = {1, 1001};
   EXPECT_TRUE(std::equal(std::begin(exp_shape), std::end(exp_shape), shape));
+
+  // GetDLROutputType
+  const char* output_type;
+  if (GetDLROutputType(&handle, 0, &output_type)) {
+    FAIL() << "GetDLROutputType failed";
+  }
+  LOG(INFO) << "DLROutputType: " << output_type;
+  EXPECT_STREQ("float32", output_type);
 
   // Load image
   size_t img_size = 224 * 224 * 3;

--- a/tests/cpp/dlr_tflite/dlr_tflite_uint8_test.cc
+++ b/tests/cpp/dlr_tflite/dlr_tflite_uint8_test.cc
@@ -79,6 +79,14 @@ void CheckAllDLRMethods(DLRModelHandle& handle) {
   LOG(INFO) << "DLRInputName: " << input_name;
   EXPECT_STREQ("input", input_name);
 
+  // GetDLRInputType
+  const char* input_type;
+  if (GetDLRInputType(&handle, 0, &input_type)) {
+    FAIL() << "GetDLRInputType failed";
+  }
+  LOG(INFO) << "DLRInputType: " << input_type;
+  EXPECT_STREQ("uint8", input_type);
+
   // GetDLROutputSizeDim
   int64_t out_size;
   int out_dim;
@@ -104,6 +112,14 @@ void CheckAllDLRMethods(DLRModelHandle& handle) {
   LOG(INFO) << ss.str();
   const int64_t exp_shape[2] = {1, 1001};
   EXPECT_TRUE(std::equal(std::begin(exp_shape), std::end(exp_shape), shape));
+
+  // GetDLROutputType
+  const char* output_type;
+  if (GetDLROutputType(&handle, 0, &output_type)) {
+    FAIL() << "GetDLROutputType failed";
+  }
+  LOG(INFO) << "DLROutputType: " << output_type;
+  EXPECT_STREQ("uint8", output_type);
 
   // Load image
   size_t img_size = 224 * 224 * 3;
@@ -142,9 +158,9 @@ void CheckAllDLRMethods(DLRModelHandle& handle) {
   // TFLite class range is 1-1000 (output size 1001)
   // Imagenet1000 class range is 0-999
   // https://gist.github.com/yrevar/942d3a0ac09ec9e5eb3a
-  EXPECT_EQ(282, max_id); // TFLite 282 maps to Imagenet 281 - tabby, tabby cat
+  EXPECT_EQ(282, max_id);  // TFLite 282 maps to Imagenet 281 - tabby, tabby cat
   EXPECT_GE(output[max_id], 150);
-  EXPECT_GE(output[283], 80); // TFLite 283 maps to Imagenet 282 - tiger cat
+  EXPECT_GE(output[283], 80);  // TFLite 283 maps to Imagenet 282 - tiger cat
 
   // clean up
   delete[] img;


### PR DESCRIPTION
This PR adds C API to get Input/Output Type.

API was implemented for TVM, Treelite and TFLite backends.

Other backends will throw "not supported error" for now. Will add Tensorflow and Hexagon impl later if needed.

# Testing
TFLite impl was tested by google tests - `dlr_tflite_test` and `dlr_tflite_uint8_test`
```
[16:27:32] /Users/pivovaa/workplace/neo-ai-dlr/src/dlr_tflite/dlr_tflite.cc:110: Use NNAPI: false
[16:27:32] /Users/pivovaa/workplace/neo-ai-dlr/src/dlr_tflite/dlr_tflite.cc:121: AllocateTensors - OK
[16:27:32] /Users/pivovaa/workplace/neo-ai-dlr/src/dlr_tflite/dlr_tflite.cc:131: TFLiteModel was created
[16:27:32] /Users/pivovaa/workplace/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_test.cc:202: CreateDLRModel - OK
[16:27:32] /Users/pivovaa/workplace/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_test.cc:48: GetDLRBackend: tflite
[16:27:32] /Users/pivovaa/workplace/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_test.cc:56: GetDLRNumInputs: 1
[16:27:32] /Users/pivovaa/workplace/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_test.cc:64: GetDLRNumOutputs: 1
[16:27:32] /Users/pivovaa/workplace/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_test.cc:72: GetDLRNumWeights: 0
[16:27:32] /Users/pivovaa/workplace/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_test.cc:80: DLRInputName: input
[16:27:32] /Users/pivovaa/workplace/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_test.cc:88: DLRInputType: float32
[16:27:32] /Users/pivovaa/workplace/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_test.cc:97: GetDLROutputSizeDim.size: 1001
[16:27:32] /Users/pivovaa/workplace/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_test.cc:98: GetDLROutputSizeDim.dim: 2
[16:27:32] /Users/pivovaa/workplace/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_test.cc:113: GetDLROutputShape: (1,1001)
[16:27:32] /Users/pivovaa/workplace/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_test.cc:122: DLROutputType: float32
[16:27:32] /Users/pivovaa/workplace/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_test.cc:25: Image read - OK, float[150528]
[16:27:32] /Users/pivovaa/workplace/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_test.cc:128: Input sample: 0.521569,0.498039 ... -0.615686
[16:27:32] /Users/pivovaa/workplace/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_test.cc:136: SetDLRInput - OK
[16:27:32] /Users/pivovaa/workplace/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_test.cc:144: GetDLRInput - OK
[16:27:32] /Users/pivovaa/workplace/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_test.cc:150: RunDLRModel - OK
[16:27:32] /Users/pivovaa/workplace/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_test.cc:158: ArgMax: 283, Prop: 0.529855
[16:27:32] /Users/pivovaa/workplace/neo-ai-dlr/src/dlr_tflite/dlr_tflite.cc:139: TFLiteModel was deleted
```
```
[16:29:30] /Users/pivovaa/workplace/neo-ai-dlr/src/dlr_tflite/dlr_tflite.cc:110: Use NNAPI: false
[16:29:30] /Users/pivovaa/workplace/neo-ai-dlr/src/dlr_tflite/dlr_tflite.cc:121: AllocateTensors - OK
[16:29:30] /Users/pivovaa/workplace/neo-ai-dlr/src/dlr_tflite/dlr_tflite.cc:131: TFLiteModel was created
[16:29:30] /Users/pivovaa/workplace/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_uint8_test.cc:200: CreateDLRModel - OK
[16:29:30] /Users/pivovaa/workplace/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_uint8_test.cc:47: GetDLRBackend: tflite
[16:29:30] /Users/pivovaa/workplace/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_uint8_test.cc:55: GetDLRNumInputs: 1
[16:29:30] /Users/pivovaa/workplace/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_uint8_test.cc:63: GetDLRNumOutputs: 1
[16:29:30] /Users/pivovaa/workplace/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_uint8_test.cc:71: GetDLRNumWeights: 0
[16:29:30] /Users/pivovaa/workplace/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_uint8_test.cc:79: DLRInputName: input
[16:29:30] /Users/pivovaa/workplace/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_uint8_test.cc:87: DLRInputType: uint8
[16:29:30] /Users/pivovaa/workplace/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_uint8_test.cc:96: GetDLROutputSizeDim.size: 1001
[16:29:30] /Users/pivovaa/workplace/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_uint8_test.cc:97: GetDLROutputSizeDim.dim: 2
[16:29:30] /Users/pivovaa/workplace/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_uint8_test.cc:112: GetDLROutputShape: (1,1001)
[16:29:30] /Users/pivovaa/workplace/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_uint8_test.cc:121: DLROutputType: uint8
[16:29:30] /Users/pivovaa/workplace/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_uint8_test.cc:24: Image read - OK, uint8_t[150528]
[16:29:30] /Users/pivovaa/workplace/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_uint8_test.cc:127: Input sample: 194,191 ... 49
[16:29:30] /Users/pivovaa/workplace/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_uint8_test.cc:135: SetDLRInput - OK
[16:29:30] /Users/pivovaa/workplace/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_uint8_test.cc:143: GetDLRInput - OK
[16:29:30] /Users/pivovaa/workplace/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_uint8_test.cc:149: RunDLRModel - OK
[16:29:30] /Users/pivovaa/workplace/neo-ai-dlr/tests/cpp/dlr_tflite/dlr_tflite_uint8_test.cc:157: ArgMax: 282, Prop: 164
[16:29:30] /Users/pivovaa/workplace/neo-ai-dlr/src/dlr_tflite/dlr_tflite.cc:139: TFLiteModel was deleted
```

TVM was tested using `model_peeker`
```
# bin/model_peeker ~/workplace/models/mobilenetv2_0.75_cpu
backend is tvm
num_inputs = 1
num_weights = 107
num_outputs = 1
input_names: data, 
input_types: float32, 
output shapes: 
[1, 1000, ]
output_types: float32,
```