### PR TITLE
Remove patches from build DLR with TFLite instructions

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -236,9 +236,6 @@ Build ``libtensorflow-lite.a`` as explained `here <https://www.tensorflow.org/li
 
 To build ``libtensorflow-lite.a`` for Android you can look at this `docs <https://gist.github.com/apivovarov/9f67fc02b84cf6d139c05aa1a8bc16f9>`_
 
-Attention! You need to apply the following patches to tensorflow r1.15 branch:
-https://github.com/tensorflow/tensorflow/pull/36689
-
 To build DLR with TFLite use cmake flag ``WITH_TENSORFLOW_LITE_LIB``, e.g.
 
 .. code-block:: bash


### PR DESCRIPTION
In the past we needed to patch Tensorflow TFLite r1.15 in order to make it work with DLR.
Recently the patch was merged to r.1.15 official branch and we do not need to do any patching anymore.
https://github.com/tensorflow/tensorflow/commit/1edd56da29aabc94835b7c521333797b5910770c

Removing patching step from our documentation.
