### PR TITLE
Fixed meteadata apis to be more resiliant to json inside the file

### DIFF
--- a/src/dlr.cc
+++ b/src/dlr.cc
@@ -136,7 +136,7 @@ extern "C" int GetDLROutputName(DLRModelHandle* handle, const int index, const c
   DLRModel* model = static_cast<DLRModel*>(*handle);
   CHECK(model != nullptr) << "model is nullptr, create it first";
   *name = model->GetOutputName(index);
-  CHECK(name != nullptr) << "name is nullptr, check if metadata file has output node data";
+  CHECK(name != nullptr) << "name is nullptr, check for metadata file and see if it has output node data";
   API_END();
 }
 
@@ -145,7 +145,7 @@ extern "C" int GetDLROutputIndex(DLRModelHandle* handle, const char* name, int* 
   DLRModel* model = static_cast<DLRModel*>(*handle);
   CHECK(model != nullptr) << "model is nullptr, create it first";
   *index = model->GetOutputIndex(name);
-  CHECK(*index != -1) << "output index is -1, check if metadata file has output node data";
+  CHECK(*index != -1) << "name is nullptr, check for metadata file and see if it has output node data";
   API_END();
 }
 

--- a/src/dlr.cc
+++ b/src/dlr.cc
@@ -136,6 +136,7 @@ extern "C" int GetDLROutputName(DLRModelHandle* handle, const int index, const c
   DLRModel* model = static_cast<DLRModel*>(*handle);
   CHECK(model != nullptr) << "model is nullptr, create it first";
   *name = model->GetOutputName(index);
+  CHECK(name != nullptr) << "name is nullptr, check if metadata file has output node data";
   API_END();
 }
 
@@ -144,6 +145,7 @@ extern "C" int GetDLROutputIndex(DLRModelHandle* handle, const char* name, int* 
   DLRModel* model = static_cast<DLRModel*>(*handle);
   CHECK(model != nullptr) << "model is nullptr, create it first";
   *index = model->GetOutputIndex(name);
+  CHECK(*index != -1) << "output index is -1, check if metadata file has output node data";
   API_END();
 }
 

--- a/src/dlr_tvm.cc
+++ b/src/dlr_tvm.cc
@@ -231,7 +231,8 @@ bool TVMModel::HasMetadata() const {
 
 const char* TVMModel::GetOutputName(const int index) const {
   if (!this->HasMetadata()) {
-    LOG(FATAL) << "No metadata file was found!";
+    LOG(INFO) << "No metadata file was found!";
+    return nullptr;
   }
   try {
     return this->metadata["Model"]["Outputs"][index]["name"].get<std::string>().c_str();
@@ -243,7 +244,8 @@ const char* TVMModel::GetOutputName(const int index) const {
 
 int TVMModel::GetOutputIndex(const char* name) const {
   if (!this->HasMetadata()) {
-    LOG(FATAL) << "No metadata file was found!";
+    LOG(INFO) << "No metadata file was found!";
+    return -1;
   }
 
   try {

--- a/src/dlr_tvm.cc
+++ b/src/dlr_tvm.cc
@@ -228,27 +228,42 @@ bool TVMModel::HasMetadata() const {
   return this->metadata != nullptr;
 }
 
+
 const char* TVMModel::GetOutputName(const int index) const {
   if (!this->HasMetadata()) {
     LOG(FATAL) << "No metadata file was found!";
   }
-  return this->metadata["Model"]["Outputs"][index]["name"].get<std::string>().c_str();
+  try {
+    return this->metadata["Model"]["Outputs"][index]["name"].get<std::string>().c_str();
+  } catch (nlohmann::detail::type_error e) {
+    LOG(INFO) << "Couldn't find output nodes in metadata file";
+    return nullptr;
+  }
 }
 
 int TVMModel::GetOutputIndex(const char* name) const {
   if (!this->HasMetadata()) {
     LOG(FATAL) << "No metadata file was found!";
   }
-  for (int i = 0; i < this->num_outputs_; i++) {
-    std::string name_str = this->metadata["Model"]["Outputs"][i]["name"];
-    if (name == name_str) {
-      return i;
+
+  try {
+    for (int i = 0; i < this->num_outputs_; i++) {
+      std::string name_str = this->metadata["Model"]["Outputs"][i]["name"];
+      if (name == name_str) {
+        return i;
+      }
     }
-  } 
-  LOG(FATAL) << "Invalid node name!";
+  } catch (nlohmann::detail::type_error e) {
+    LOG(INFO) << "Couldn't find output nodes in metadata file";
+  }
+
+  return -1;
 }
 
 void TVMModel::GetOutputByName(const char* name, float* out) {
   int output_index = this->GetOutputIndex(name);
+  if (output_index == -1) {
+    LOG(FATAL) << "Couldn't find index for output node";
+  }
   this->GetOutput(output_index, out);
 }


### PR DESCRIPTION
Thanks for contributing to DLR! By submitting this pull request, you confirm that your contribution is made under the terms of the [Apache 2.0 license](https://github.com/neo-ai/neo-ai-dlr/blob/master/LICENSE).

Please refer to our [guideline](https://github.com/neo-ai/neo-ai-dlr/blob/master/CONTRIBUTING.md) for useful information and tips.


### Model Peeker with Bad and Good Metadata

```
root@c60dadd939b7:/home/DLR/neo-ai-dlr/build# echo {} > /home/DLR/compiled/compiled.meta
root@c60dadd939b7:/home/DLR/neo-ai-dlr/build# ./bin/model_peeker /home/DLR/compiled/
[21:45:25] /home/DLR/neo-ai-dlr/src/dlr_tvm.cc:68: Loading metadata file: /home/DLR/compiled/compiled.meta
backend is tvm
num_inputs = 1
num_weights = 108
num_outputs = 2
input_names: input_tensor,
input_types: float32,
output shapes:
[64, ]
[64, 1001, ]
Has Metadata 1
output_names: [21:45:25] /home/DLR/neo-ai-dlr/src/dlr_tvm.cc:239: Couldn't find output nodes in metadata file
[21:45:25] /home/DLR/neo-ai-dlr/src/dlr_tvm.cc:257: Couldn't find output nodes in metadata file
[21:45:25] /home/DLR/neo-ai-dlr/src/dlr_tvm.cc:239: Couldn't find output nodes in metadata file
[21:45:25] /home/DLR/neo-ai-dlr/src/dlr_tvm.cc:257: Couldn't find output nodes in metadata file
root@c60dadd939b7:/home/DLR/neo-ai-dlr/build# cat /home/compiled.meta > /home/DLR/compiled/compiled.meta
root@c60dadd939b7:/home/DLR/neo-ai-dlr/build# ./bin/model_peeker /home/DLR/compiled/
[21:45:34] /home/DLR/neo-ai-dlr/src/dlr_tvm.cc:68: Loading metadata file: /home/DLR/compiled/compiled.meta
backend is tvm
num_inputs = 1
num_weights = 108
num_outputs = 2
input_names: input_tensor,
input_types: float32,
output shapes:
[64, ]
[64, 1001, ]
Has Metadata 1
output_names: ArgMax (index: 0), softmax_tensor (index: 1),
output_types: int32, float32,
root@c60dadd939b7:/home/DLR/neo-ai-dlr/build#
```

### Python Apis with bad and good metadata

### GOOD Metadata
```python
from dlr import DLRModel
```


```python
dlm = DLRModel("./compiled")
```


```python
dlm.get_output_dtypes()
```




    ['int32', 'float32']




```python
dlm.get_input_dtypes()
```




    ['float32']




```python
dlm.get_output_names()
```




    ['ArgMax', 'softmax_tensor']




```python
dlm.get_input_names()
```




    ['input_tensor']




```python
dlm.get_input_dtype(0)
```




    'float32'




```python
dlm.get_output_dtype(0)
```




    'int32'




```python

```

### BAD METADATA

```python
from dlr import DLRModel
```


```python
dlm = DLRModel("./compiled")
```


```python
dlm.get_output_dtypes()
```




    ['int32', 'float32']




```python
dlm.get_input_dtypes()
```




    ['float32']




```python
dlm.get_output_names()
```

    2020-05-21 21:47:00,698 ERROR error in getting output names DLRModelImpl 
    Traceback (most recent call last):
      File "/home/DLR/neo-ai-dlr/python/dlr/api.py", line 110, in get_output_names
        return self._impl.get_output_names()
      File "/home/DLR/neo-ai-dlr/python/dlr/dlr_model.py", line 222, in get_output_names
        raise NotImplementedError
    NotImplementedError
    2020-05-21 21:47:00,698 ERROR error in getting output names DLRModelImpl 
    Traceback (most recent call last):
      File "/home/DLR/neo-ai-dlr/python/dlr/api.py", line 110, in get_output_names
        return self._impl.get_output_names()
      File "/home/DLR/neo-ai-dlr/python/dlr/dlr_model.py", line 222, in get_output_names
        raise NotImplementedError
    NotImplementedError
    2020-05-21 21:47:00,698 ERROR error in getting output names DLRModelImpl 
    Traceback (most recent call last):
      File "/home/DLR/neo-ai-dlr/python/dlr/api.py", line 110, in get_output_names
        return self._impl.get_output_names()
      File "/home/DLR/neo-ai-dlr/python/dlr/dlr_model.py", line 222, in get_output_names
        raise NotImplementedError
    NotImplementedError



    ---------------------------------------------------------------------------

    NotImplementedError                       Traceback (most recent call last)

    <ipython-input-20-4ab75d921cbc> in <module>
    ----> 1 dlm.get_output_names()
    

    /home/DLR/neo-ai-dlr/python/dlr/api.py in get_output_names(self)
        111         except Exception as ex:
        112             self.neo_logger.exception("error in getting output names {} {}".format(self._impl.__class__.__name__, ex))
    --> 113             raise ex
        114 
        115     def get_version(self):


    /home/DLR/neo-ai-dlr/python/dlr/api.py in get_output_names(self)
        108     def get_output_names(self):
        109         try:
    --> 110             return self._impl.get_output_names()
        111         except Exception as ex:
        112             self.neo_logger.exception("error in getting output names {} {}".format(self._impl.__class__.__name__, ex))


    /home/DLR/neo-ai-dlr/python/dlr/dlr_model.py in get_output_names(self)
        220     def get_output_names(self):
        221         if not self.output_names:
    --> 222             raise NotImplementedError
        223         return self.output_names
        224 


    NotImplementedError: 



```python
dlm.get_input_names()
```




    ['input_tensor']




```python
dlm.get_input_dtype(0)
```




    'float32'




```python
dlm.get_output_dtype(0)
```




    'int32'




```python

```
