### PR TITLE
Fix default GetOutputName and GetOutputIndex

### DIFF
--- a/include/dlr_common.h
+++ b/include/dlr_common.h
@@ -121,11 +121,11 @@ class DLRModel {
   }
 
   virtual const char* GetOutputName(const int index) const {
-    LOG(FATAL) << "GetOutputName is not supported yet!";
+    return nullptr;
   }
 
   virtual int GetOutputIndex(const char* name) const {
-    LOG(FATAL) << "GetOutputIndex is not supported yet!";
+    return -1;
   }
 
   virtual void GetOutputByName(const char* name, float* out) {

--- a/include/dlr_tvm.h
+++ b/include/dlr_tvm.h
@@ -51,9 +51,9 @@ class TVMModel : public DLRModel {
     Following methods use metadata file to lookup input and output names.
   */
   virtual bool HasMetadata() const override;
-  virtual const char* GetOutputName(const int index) const;
-  virtual int GetOutputIndex(const char* name) const;
-  virtual void GetOutputByName(const char* name, float* out);
+  virtual const char* GetOutputName(const int index) const override;
+  virtual int GetOutputIndex(const char* name) const override;
+  virtual void GetOutputByName(const char* name, float* out) override;
 };
 
 }  // namespace dlr

--- a/src/dlr_tvm.cc
+++ b/src/dlr_tvm.cc
@@ -228,7 +228,6 @@ bool TVMModel::HasMetadata() const {
   return this->metadata != nullptr;
 }
 
-
 const char* TVMModel::GetOutputName(const int index) const {
   if (!this->HasMetadata()) {
     LOG(INFO) << "No metadata file was found!";


### PR DESCRIPTION
- Don't crash inside `libdlr.so` for default impl of `GetOutputName` and `GetOutputIndex`.

- Fix warnings in dlr_tvm