### PR TITLE
Replace float* with void* in SetInput GetOutput

### DIFF
--- a/demo/cpp/run_resnet.cc
+++ b/demo/cpp/run_resnet.cc
@@ -66,7 +66,7 @@ void RunInference(DLRModelHandle model, const char* data_path,
   int64_t in_ndim = in_shape.size();
 
   if (SetDLRInput(&model, input_name.c_str(), in_shape.data(),
-                  (float*)in_data.data(), static_cast<int>(in_ndim)) != 0) {
+                  in_data.data(), static_cast<int>(in_ndim)) != 0) {
     throw std::runtime_error("Could not set input '" + input_name + "'");
   }
   if (RunDLRModel(&model) != 0) {
@@ -74,7 +74,7 @@ void RunInference(DLRModelHandle model, const char* data_path,
     throw std::runtime_error("Could not run");
   }
   for (int i = 0; i < num_outputs; i++) {
-    if (GetDLROutput(&model, i, (float*)outputs[i].data()) != 0) {
+    if (GetDLROutput(&model, i, outputs[i].data()) != 0) {
       throw std::runtime_error("Could not get output" + std::to_string(i));
     }
   }

--- a/include/dlr.h
+++ b/include/dlr.h
@@ -207,7 +207,7 @@ int GetDLRWeightName(DLRModelHandle* handle, int index,
  */
 DLR_DLL
 int SetDLRInput(DLRModelHandle* handle, const char* name, const int64_t* shape,
-                float* input, int dim);
+                void* input, int dim);
 /*!
  \brief Gets the current value of the input according the node name.
  \param handle The model handle returned from CreateDLRModel().
@@ -217,7 +217,7 @@ int SetDLRInput(DLRModelHandle* handle, const char* name, const int64_t* shape,
  message.
  */
 DLR_DLL
-int GetDLRInput(DLRModelHandle* handle, const char* name, float* input);
+int GetDLRInput(DLRModelHandle* handle, const char* name, void* input);
 /*!
  \brief Gets the shape of the index-th output.
  \param handle The model handle returned from CreateDLRModel().
@@ -238,7 +238,7 @@ int GetDLROutputShape(DLRModelHandle* handle, int index, int64_t* shape);
  error. Call DLRGetLastError() to get the error message.
  */
 DLR_DLL
-int GetDLROutput(DLRModelHandle* handle, int index, float* out);
+int GetDLROutput(DLRModelHandle* handle, int index, void* out);
 
 /*!
  \brief Gets the number of outputs.
@@ -305,7 +305,7 @@ DLR_DLL int GetDLROutputIndex(DLRModelHandle* handle, const char* name, int* ind
  array of size "size" from GetDLROutputSizeDim(). \return 0 for success, -1 for
  error. Call DLRGetLastError() to get the error message.
  */
-DLR_DLL int GetDLROutputByName(DLRModelHandle* handle, const char* name, float* out);
+DLR_DLL int GetDLROutputByName(DLRModelHandle* handle, const char* name, void* out);
 
 /*!
  \brief Gets the last error message.

--- a/include/dlr_common.h
+++ b/include/dlr_common.h
@@ -104,11 +104,11 @@ class DLRModel {
   virtual const char* GetInputType(int index) const = 0;
   virtual const char* GetWeightName(int index) const = 0;
   virtual std::vector<std::string> GetWeightNames() const = 0;
-  virtual void GetInput(const char* name, float* input) = 0;
-  virtual void SetInput(const char* name, const int64_t* shape, float* input,
+  virtual void GetInput(const char* name, void* input) = 0;
+  virtual void SetInput(const char* name, const int64_t* shape, void* input,
                         int dim) = 0;
   virtual void Run() = 0;
-  virtual void GetOutput(int index, float* out) = 0;
+  virtual void GetOutput(int index, void* out) = 0;
   virtual void GetOutputShape(int index, int64_t* shape) const = 0;
   virtual void GetOutputSizeDim(int index, int64_t* size, int* dim) = 0;
   virtual const char* GetOutputType(int index) const = 0;
@@ -128,7 +128,7 @@ class DLRModel {
     return -1;
   }
 
-  virtual void GetOutputByName(const char* name, float* out) {
+  virtual void GetOutputByName(const char* name, void* out) {
     LOG(FATAL) << "GetOutputByName is not supported yet!";
   }
 };

--- a/include/dlr_hexagon/dlr_hexagon.h
+++ b/include/dlr_hexagon/dlr_hexagon.h
@@ -53,11 +53,11 @@ class HexagonModel : public DLRModel {
   virtual const char* GetInputType(int index) const override;
   virtual const char* GetWeightName(int index) const override;
   virtual std::vector<std::string> GetWeightNames() const override;
-  virtual void GetInput(const char* name, float* input) override;
-  virtual void SetInput(const char* name, const int64_t* shape, float* input,
+  virtual void GetInput(const char* name, void* input) override;
+  virtual void SetInput(const char* name, const int64_t* shape, void* input,
                         int dim) override;
   virtual void Run() override;
-  virtual void GetOutput(int index, float* out) override;
+  virtual void GetOutput(int index, void* out) override;
   virtual void GetOutputShape(int index, int64_t* shape) const override;
   virtual void GetOutputSizeDim(int index, int64_t* size, int* dim) override;
   virtual const char* GetOutputType(int index) const override;

--- a/include/dlr_tensorflow/dlr_tensorflow.h
+++ b/include/dlr_tensorflow/dlr_tensorflow.h
@@ -61,11 +61,11 @@ class TensorflowModel : public DLRModel {
   virtual const char* GetInputType(int index) const override;
   virtual const char* GetWeightName(int index) const override;
   virtual std::vector<std::string> GetWeightNames() const override;
-  virtual void GetInput(const char* name, float* input) override;
-  virtual void SetInput(const char* name, const int64_t* shape, float* input,
+  virtual void GetInput(const char* name, void* input) override;
+  virtual void SetInput(const char* name, const int64_t* shape, void* input,
                         int dim) override;
   virtual void Run() override;
-  virtual void GetOutput(int index, float* out) override;
+  virtual void GetOutput(int index, void* out) override;
   virtual void GetOutputShape(int index, int64_t* shape) const override;
   virtual void GetOutputSizeDim(int index, int64_t* size, int* dim) override;
   virtual const char* GetOutputType(int index) const override;

--- a/include/dlr_tflite/dlr_tflite.h
+++ b/include/dlr_tflite/dlr_tflite.h
@@ -43,11 +43,11 @@ class TFLiteModel : public DLRModel {
   virtual const char* GetInputType(int index) const override;
   virtual const char* GetWeightName(int index) const override;
   virtual std::vector<std::string> GetWeightNames() const override;
-  virtual void GetInput(const char* name, float* input) override;
-  virtual void SetInput(const char* name, const int64_t* shape, float* input,
+  virtual void GetInput(const char* name, void* input) override;
+  virtual void SetInput(const char* name, const int64_t* shape, void* input,
                         int dim) override;
   virtual void Run() override;
-  virtual void GetOutput(int index, float* out) override;
+  virtual void GetOutput(int index, void* out) override;
   virtual void GetOutputShape(int index, int64_t* shape) const override;
   virtual void GetOutputSizeDim(int index, int64_t* size, int* dim) override;
   virtual const char* GetOutputType(int index) const override;

--- a/include/dlr_treelite.h
+++ b/include/dlr_treelite.h
@@ -50,11 +50,11 @@ class TreeliteModel : public DLRModel {
   virtual const char* GetInputType(int index) const override;
   virtual const char* GetWeightName(int index) const override;
   virtual std::vector<std::string> GetWeightNames() const override;
-  virtual void GetInput(const char* name, float* input) override;
-  virtual void SetInput(const char* name, const int64_t* shape, float* input,
+  virtual void GetInput(const char* name, void* input) override;
+  virtual void SetInput(const char* name, const int64_t* shape, void* input,
                         int dim) override;
   virtual void Run() override;
-  virtual void GetOutput(int index, float* out) override;
+  virtual void GetOutput(int index, void* out) override;
   virtual void GetOutputShape(int index, int64_t* shape) const override;
   virtual void GetOutputSizeDim(int index, int64_t* size, int* dim) override;
   virtual const char* GetOutputType(int index) const override;

--- a/include/dlr_tvm.h
+++ b/include/dlr_tvm.h
@@ -35,11 +35,11 @@ class TVMModel : public DLRModel {
   virtual const char* GetInputType(int index) const override;
   virtual const char* GetWeightName(int index) const override;
   virtual std::vector<std::string> GetWeightNames() const override;
-  virtual void GetInput(const char* name, float* input) override;
-  virtual void SetInput(const char* name, const int64_t* shape, float* input,
+  virtual void GetInput(const char* name, void* input) override;
+  virtual void SetInput(const char* name, const int64_t* shape, void* input,
                         int dim) override;
   virtual void Run() override;
-  virtual void GetOutput(int index, float* out) override;
+  virtual void GetOutput(int index, void* out) override;
   virtual void GetOutputShape(int index, int64_t* shape) const override;
   virtual void GetOutputSizeDim(int index, int64_t* size, int* dim) override;
   virtual const char* GetOutputType(int index) const override;
@@ -53,7 +53,7 @@ class TVMModel : public DLRModel {
   virtual bool HasMetadata() const override;
   virtual const char* GetOutputName(const int index) const override;
   virtual int GetOutputIndex(const char* name) const override;
-  virtual void GetOutputByName(const char* name, float* out) override;
+  virtual void GetOutputByName(const char* name, void* out) override;
 };
 
 }  // namespace dlr

--- a/src/dlr.cc
+++ b/src/dlr.cc
@@ -63,7 +63,7 @@ extern "C" int GetDLRWeightName(DLRModelHandle* handle, int index,
 }
 
 extern "C" int SetDLRInput(DLRModelHandle* handle, const char* name,
-                           const int64_t* shape, float* input, int dim) {
+                           const int64_t* shape, void* input, int dim) {
   API_BEGIN();
   DLRModel* model = static_cast<DLRModel*>(*handle);
   CHECK(model != nullptr) << "model is nullptr, create it first";
@@ -72,7 +72,7 @@ extern "C" int SetDLRInput(DLRModelHandle* handle, const char* name,
 }
 
 extern "C" int GetDLRInput(DLRModelHandle* handle, const char* name,
-                           float* input) {
+                           void* input) {
   API_BEGIN();
   DLRModel* model = static_cast<DLRModel*>(*handle);
   CHECK(model != nullptr) << "model is nullptr, create it first";
@@ -89,7 +89,7 @@ extern "C" int GetDLROutputShape(DLRModelHandle* handle, int index,
   API_END();
 }
 
-extern "C" int GetDLROutput(DLRModelHandle* handle, int index, float* out) {
+extern "C" int GetDLROutput(DLRModelHandle* handle, int index, void* out) {
   API_BEGIN();
   DLRModel* model = static_cast<DLRModel*>(*handle);
   CHECK(model != nullptr) << "model is nullptr, create it first";
@@ -149,7 +149,7 @@ extern "C" int GetDLROutputIndex(DLRModelHandle* handle, const char* name, int* 
   API_END();
 }
 
-extern "C" int GetDLROutputByName(DLRModelHandle* handle, const char* name, float* out) {
+extern "C" int GetDLROutputByName(DLRModelHandle* handle, const char* name, void* out) {
   API_BEGIN();
   DLRModel* model = static_cast<DLRModel*>(*handle);
   CHECK(model != nullptr) << "model is nullptr, create it first";

--- a/src/dlr_hexagon/dlr_hexagon.cc
+++ b/src/dlr_hexagon/dlr_hexagon.cc
@@ -219,7 +219,7 @@ const char* HexagonModel::GetWeightName(int index) const {
 }
 
 void HexagonModel::SetInput(const char* name, const int64_t* shape,
-                            float* input, int dim) {
+                            void* input, int dim) {
   int index = GetInputId(name);
 
   // Check Size and Dim
@@ -231,7 +231,7 @@ void HexagonModel::SetInput(const char* name, const int64_t* shape,
   std::memcpy(input_, input, input_tensors_spec_[index].bytes);
 }
 
-void HexagonModel::GetInput(const char* name, float* input) {
+void HexagonModel::GetInput(const char* name, void* input) {
   int index = GetInputId(name);
   std::memcpy(input, input_, input_tensors_spec_[index].bytes);
 }
@@ -243,7 +243,7 @@ void HexagonModel::GetOutputShape(int index, int64_t* shape) const {
   }
 }
 
-void HexagonModel::GetOutput(int index, float* out) {
+void HexagonModel::GetOutput(int index, void* out) {
   CHECK_LT(index, num_outputs_) << "Output index is out of range.";
   std::memcpy(out, output_, output_tensors_spec_[index].bytes);
 }

--- a/src/dlr_tensorflow/dlr_tensorflow.cc
+++ b/src/dlr_tensorflow/dlr_tensorflow.cc
@@ -343,16 +343,6 @@ TensorflowModel::TensorflowModel(
   }
   TF_DeleteSessionOptions(opts);
   LOG(INFO) << "Tensorflow Session was created";
-
-  // Run inference to allocate output Tensors and calculate output shapes.
-  for (int i = 0; i < num_inputs_; i++) {
-    TF_Tensor* tensor = input_tensors_[i];
-    int64_t num_elements = TF_TensorElementCount(tensor);
-    float* in_t_data = (float*)TF_TensorData(tensor);
-    std::fill_n(in_t_data, num_elements, 0.1);
-  }
-  Run();
-  LOG(INFO) << "Output Tensors were allocated";
 }
 
 // Destructor
@@ -393,7 +383,7 @@ const char* TensorflowModel::GetWeightName(int index) const {
 }
 
 void TensorflowModel::SetInput(const char* name, const int64_t* shape,
-                               float* input, int dim) {
+                               void* input, int dim) {
   int index = GetInputId(name);
   TF_Tensor* tensor = input_tensors_[index];
   CHECK_EQ(dim, TF_NumDims(tensor)) << "Incorrect input dim";
@@ -401,15 +391,15 @@ void TensorflowModel::SetInput(const char* name, const int64_t* shape,
     CHECK_EQ(shape[i], TF_Dim(tensor, i)) << "Incorrect input shape";
   }
   size_t num_bytes = TF_TensorByteSize(tensor);
-  float* in_t_data = (float*)TF_TensorData(tensor);
+  void* in_t_data = TF_TensorData(tensor);
   std::memcpy(in_t_data, input, num_bytes);
 }
 
-void TensorflowModel::GetInput(const char* name, float* input) {
+void TensorflowModel::GetInput(const char* name, void* input) {
   int index = GetInputId(name);
   TF_Tensor* tensor = input_tensors_[index];
   size_t num_bytes = TF_TensorByteSize(tensor);
-  float* in_t_data = (float*)TF_TensorData(tensor);
+  void* in_t_data = TF_TensorData(tensor);
   std::memcpy(input, in_t_data, num_bytes);
 }
 
@@ -422,11 +412,11 @@ void TensorflowModel::GetOutputShape(int index, int64_t* shape) const {
   }
 }
 
-void TensorflowModel::GetOutput(int index, float* output) {
+void TensorflowModel::GetOutput(int index, void* output) {
   CHECK_LT(index, num_outputs_) << "Output index is out of range.";
   TF_Tensor* tensor = output_tensors_[index];
   size_t num_bytes = TF_TensorByteSize(tensor);
-  float* out_t_data = (float*)TF_TensorData(tensor);
+  void* out_t_data = TF_TensorData(tensor);
   std::memcpy(output, out_t_data, num_bytes);
 }
 

--- a/src/dlr_tflite/dlr_tflite.cc
+++ b/src/dlr_tflite/dlr_tflite.cc
@@ -161,7 +161,7 @@ const char* TFLiteModel::GetWeightName(int index) const {
   return "";  // unreachable
 }
 
-void TFLiteModel::SetInput(const char* name, const int64_t* shape, float* input,
+void TFLiteModel::SetInput(const char* name, const int64_t* shape, void* input,
                            int dim) {
   int index = GetInputId(name);
   TensorSpec input_tensors_spec = input_tensors_spec_[index];
@@ -181,7 +181,7 @@ void TFLiteModel::SetInput(const char* name, const int64_t* shape, float* input,
   std::memcpy(in_t_data, input, input_tensors_spec_[index].bytes);
 }
 
-void TFLiteModel::GetInput(const char* name, float* input) {
+void TFLiteModel::GetInput(const char* name, void* input) {
   int index = GetInputId(name);
   TensorSpec input_tensors_spec = input_tensors_spec_[index];
   void* in_t_data;
@@ -202,7 +202,7 @@ void TFLiteModel::GetOutputShape(int index, int64_t* shape) const {
   }
 }
 
-void TFLiteModel::GetOutput(int index, float* out) {
+void TFLiteModel::GetOutput(int index, void* out) {
   CHECK_LT(index, num_outputs_) << "Output index is out of range.";
   TensorSpec output_tensors_spec = output_tensors_spec_[index];
   void* out_t_data;

--- a/src/dlr_treelite.cc
+++ b/src/dlr_treelite.cc
@@ -113,7 +113,7 @@ const char* TreeliteModel::GetWeightName(int index) const {
 }
 
 void TreeliteModel::SetInput(const char* name, const int64_t* shape,
-                             float* input, int dim) {
+                             void* input, int dim) {
   // NOTE: Assume that missing values are represented by NAN
   CHECK_SHAPE("Mismatch found in input dimension", dim, 2);
   // NOTE: If number of columns is less than num_feature, missing columns
@@ -128,12 +128,13 @@ void TreeliteModel::SetInput(const char* name, const int64_t* shape,
   treelite_input_.reset(new TreeliteInput);
   CHECK(treelite_input_);
   treelite_input_->row_ptr.push_back(0);
+  float* input_f = (float*) input;
 
   // NOTE: Assume row-major (C) layout
   for (size_t i = 0; i < batch_size; ++i) {
     for (uint32_t j = 0; j < num_col; ++j) {
-      if (!std::isnan(input[i * num_col + j])) {
-        treelite_input_->data.push_back(input[i * num_col + j]);
+      if (!std::isnan(input_f[i * num_col + j])) {
+        treelite_input_->data.push_back(input_f[i * num_col + j]);
         treelite_input_->col_ind.push_back(j);
       }
     }
@@ -157,7 +158,7 @@ void TreeliteModel::SetInput(const char* name, const int64_t* shape,
       << TreeliteGetLastError();
 }
 
-void TreeliteModel::GetInput(const char* name, float* input) {
+void TreeliteModel::GetInput(const char* name, void* input) {
   LOG(FATAL) << "GetInput is not supported by Treelite backend";
 }
 
@@ -168,7 +169,7 @@ void TreeliteModel::GetOutputShape(int index, int64_t* shape) const {
   shape[1] = static_cast<int64_t>(treelite_output_size_);
 }
 
-void TreeliteModel::GetOutput(int index, float* out) {
+void TreeliteModel::GetOutput(int index, void* out) {
   CHECK(treelite_input_);
   std::memcpy(
       out, treelite_output_.data(),

--- a/src/dlr_tvm.cc
+++ b/src/dlr_tvm.cc
@@ -132,7 +132,7 @@ const char* TVMModel::GetWeightName(int index) const {
   return weight_names_[index].c_str();
 }
 
-void TVMModel::SetInput(const char* name, const int64_t* shape, float* input,
+void TVMModel::SetInput(const char* name, const int64_t* shape, void* input,
                         int dim) {
   std::string str(name);
   int index = tvm_graph_runtime_->GetInputIndex(str);
@@ -150,7 +150,7 @@ void TVMModel::SetInput(const char* name, const int64_t* shape, float* input,
   set_input(str, &input_tensor);
 }
 
-void TVMModel::GetInput(const char* name, float* input) {
+void TVMModel::GetInput(const char* name, void* input) {
   std::string str(name);
   int index = tvm_graph_runtime_->GetInputIndex(str);
   tvm::runtime::NDArray arr = tvm_graph_runtime_->GetInput(index);
@@ -170,7 +170,7 @@ void TVMModel::GetOutputShape(int index, int64_t* shape) const {
               sizeof(int64_t) * outputs_[index]->ndim);
 }
 
-void TVMModel::GetOutput(int index, float* out) {
+void TVMModel::GetOutput(int index, void* out) {
   DLTensor output_tensor = *outputs_[index];
   output_tensor.ctx = DLContext{kDLCPU, 0};
   output_tensor.data = out;
@@ -263,7 +263,7 @@ int TVMModel::GetOutputIndex(const char* name) const {
   return -1;
 }
 
-void TVMModel::GetOutputByName(const char* name, float* out) {
+void TVMModel::GetOutputByName(const char* name, void* out) {
   int output_index = this->GetOutputIndex(name);
   if (output_index == -1) {
     LOG(FATAL) << "Couldn't find index for output node";

--- a/tests/cpp/dlr_hexagon/dlr_hexagon_test.cc
+++ b/tests/cpp/dlr_hexagon/dlr_hexagon_test.cc
@@ -115,14 +115,14 @@ void CheckAllDLRMethods(DLRModelHandle& handle) {
 
   // SetDLRInput
   const int64_t in_shape[4] = {1, 224, 224, 3};
-  if (SetDLRInput(&handle, input_name, in_shape, (float*)img, 4)) {
+  if (SetDLRInput(&handle, input_name, in_shape, img, 4)) {
     FAIL() << "SetDLRInput failed";
   }
   LOG(INFO) << "SetDLRInput - OK";
 
   // GetDLRInput
   uint8_t* input2 = new uint8_t[img_size];
-  if (GetDLRInput(&handle, input_name, (float*)input2)) {
+  if (GetDLRInput(&handle, input_name, input2)) {
     FAIL() << "GetDLRInput failed";
   }
   EXPECT_TRUE(std::equal(img, img + img_size, input2));
@@ -136,7 +136,7 @@ void CheckAllDLRMethods(DLRModelHandle& handle) {
 
   // GetDLROutput
   uint8_t* output = new uint8_t[out_size];
-  if (GetDLROutput(&handle, 0, (float*)output)) {
+  if (GetDLROutput(&handle, 0, output)) {
     FAIL() << "GetDLROutput failed";
   }
   LOG(INFO) << "GetDLROutput - OK";

--- a/tests/cpp/dlr_tensorflow/dlr_tensorflow_test.cc
+++ b/tests/cpp/dlr_tensorflow/dlr_tensorflow_test.cc
@@ -86,32 +86,6 @@ void CheckAllDLRMethods(DLRModelHandle& handle, const int batch_size) {
   LOG(INFO) << "DLRInputName: " << input_name;
   EXPECT_STREQ("input:0", input_name);
 
-  // GetDLROutputSizeDim
-  int64_t out_size;
-  int out_dim;
-  if (GetDLROutputSizeDim(&handle, 0, &out_size, &out_dim)) {
-    FAIL() << "GetDLROutputSizeDim failed";
-  }
-  LOG(INFO) << "GetDLROutputSizeDim.size: " << out_size;
-  LOG(INFO) << "GetDLROutputSizeDim.dim: " << out_dim;
-  EXPECT_EQ(1001 * batch_size, out_size);
-  EXPECT_EQ(2, out_dim);
-
-  // GetDLROutputShape
-  int64_t shape[out_dim];
-  if (GetDLROutputShape(&handle, 0, shape)) {
-    FAIL() << "GetDLROutputShape failed";
-  }
-  std::stringstream ss;
-  ss << "GetDLROutputShape: (" << shape[0];
-  for (int i = 1; i < out_dim; i++) {
-    ss << "," << shape[i];
-  }
-  ss << ")";
-  LOG(INFO) << ss.str();
-  const int64_t exp_shape[2] = {batch_size, 1001};
-  EXPECT_TRUE(std::equal(std::begin(exp_shape), std::end(exp_shape), shape));
-
   // Load image
   size_t img_size = 224 * 224 * 3;
   float* img = LoadImageAndPreprocess("cat224-3.txt", img_size, batch_size);
@@ -141,6 +115,32 @@ void CheckAllDLRMethods(DLRModelHandle& handle, const int batch_size) {
     FAIL() << "RunDLRModel failed";
   }
   LOG(INFO) << "RunDLRModel - OK";
+
+  // GetDLROutputSizeDim
+  int64_t out_size;
+  int out_dim;
+  if (GetDLROutputSizeDim(&handle, 0, &out_size, &out_dim)) {
+    FAIL() << "GetDLROutputSizeDim failed";
+  }
+  LOG(INFO) << "GetDLROutputSizeDim.size: " << out_size;
+  LOG(INFO) << "GetDLROutputSizeDim.dim: " << out_dim;
+  EXPECT_EQ(1001 * batch_size, out_size);
+  EXPECT_EQ(2, out_dim);
+
+  // GetDLROutputShape
+  int64_t shape[out_dim];
+  if (GetDLROutputShape(&handle, 0, shape)) {
+    FAIL() << "GetDLROutputShape failed";
+  }
+  std::stringstream ss;
+  ss << "GetDLROutputShape: (" << shape[0];
+  for (int i = 1; i < out_dim; i++) {
+    ss << "," << shape[i];
+  }
+  ss << ")";
+  LOG(INFO) << ss.str();
+  const int64_t exp_shape[2] = {batch_size, 1001};
+  EXPECT_TRUE(std::equal(std::begin(exp_shape), std::end(exp_shape), shape));
 
   // GetDLROutput (the first and the last item in the batch)
   float* output = new float[out_size];

--- a/tests/cpp/dlr_tflite/dlr_tflite_uint8_test.cc
+++ b/tests/cpp/dlr_tflite/dlr_tflite_uint8_test.cc
@@ -129,14 +129,14 @@ void CheckAllDLRMethods(DLRModelHandle& handle) {
 
   // SetDLRInput
   const int64_t in_shape[4] = {1, 224, 224, 3};
-  if (SetDLRInput(&handle, input_name, in_shape, (float*)img, 4)) {
+  if (SetDLRInput(&handle, input_name, in_shape, img, 4)) {
     FAIL() << "SetDLRInput failed";
   }
   LOG(INFO) << "SetDLRInput - OK";
 
   // GetDLRInput
   uint8_t* input2 = new uint8_t[img_size];
-  if (GetDLRInput(&handle, input_name, (float*)input2)) {
+  if (GetDLRInput(&handle, input_name, input2)) {
     FAIL() << "GetDLRInput failed";
   }
   EXPECT_TRUE(std::equal(img, img + img_size, input2));
@@ -150,7 +150,7 @@ void CheckAllDLRMethods(DLRModelHandle& handle) {
 
   // GetDLROutput
   uint8_t* output = new uint8_t[out_size];
-  if (GetDLROutput(&handle, 0, (float*)output)) {
+  if (GetDLROutput(&handle, 0, output)) {
     FAIL() << "GetDLROutput failed";
   }
   size_t max_id = ArgMax(output, out_size);


### PR DESCRIPTION
## Description
In the past DLR supported only float32 inputs/outputs.
Now it supports uint8 inputs/outputs as well. 

DLR C API SetInput and GetOutput function signatures have specific type of pointer for input/output buffers start - `float*`. Since we support not only float32 inputs now we should make C API more "generic" and use `void*` for input/output buffers start.

## Testing
### TVM model
```
# python3 load_and_run_tvm_model.py
Preparing model artifacts for resnet18_v1 ...
Preparing model artifacts for 4in2out ...
Preparing model artifacts for assign_op ...
[04:43:57] /root/workplace/neo-ai-dlr/src/dlr_tvm.cc:71: No metadata found
[04:43:57] /root/workplace/neo-ai-dlr/src/dlr_tvm.cc:233: No metadata file was found!
Testing inference on resnet18...
[04:43:57] /root/workplace/neo-ai-dlr/src/dlr_tvm.cc:71: No metadata found
[04:43:57] /root/workplace/neo-ai-dlr/src/dlr_tvm.cc:233: No metadata file was found!
Testing multi_input/multi_output support...
[04:43:57] /root/workplace/neo-ai-dlr/src/dlr_tvm.cc:71: No metadata found
[04:43:57] /root/workplace/neo-ai-dlr/src/dlr_tvm.cc:233: No metadata file was found!
Testing _assign() operator...
All tests passed!
```

### Treelite
```
# python3 load_and_run_treelite_model.py
Preparing model artifacts for xgboost-mnist ...
Preparing model artifacts for xgboost-iris ...
Preparing model artifacts for xgboost-letor ...
Testing inference on XGBoost MNIST...
Testing inference on XGBoost Iris...
Testing inference on XGBoost LETOR...
All tests passed!
```

### TVM model (via demo tool run_resnet)
```
# bin/run_resnet ../tests/python/integration/resnet18_v1 ~/workplace/models/dog_float32.npy
Loading model... 
[05:34:37] /root/workplace/neo-ai-dlr/src/dlr_tvm.cc:71: No metadata found
Running inference...
Max probability is 0.994058 at index 151
```

### TFLite float32 and uint8 tests
```
./dlr_tflite_test
[ RUN      ] TFLite.CreateDLRModelFromTFLite
[       OK ] TFLite.CreateDLRModelFromTFLite (61 ms)
[ RUN      ] TFLite.CreateDLRModel
[       OK ] TFLite.CreateDLRModel (75 ms)
[----------] 2 tests from TFLite (136 ms total)

./dlr_tflite_uint8_test
[ RUN      ] TFLite.CreateDLRModelFromTFLiteQuant
[       OK ] TFLite.CreateDLRModelFromTFLiteQuant (105 ms)
[ RUN      ] TFLite.CreateDLRModelQuant
[       OK ] TFLite.CreateDLRModelQuant (198 ms)
[----------] 2 tests from TFLite (303 ms total)
```

### Tensorflow
```
./dlr_tensorflow_test
[ RUN      ] Tensorflow.CreateDLRModelFromTensorflow
[       OK ] Tensorflow.CreateDLRModelFromTensorflow (258 ms)
[ RUN      ] Tensorflow.CreateDLRModelFromTensorflowDir
[       OK ] Tensorflow.CreateDLRModelFromTensorflowDir (249 ms)
[ RUN      ] Tensorflow.AutodetectInputsAndOutputs
[       OK ] Tensorflow.AutodetectInputsAndOutputs (139 ms)
[----------] 3 tests from Tensorflow (646 ms total)

./dlr_tensorflow_internal_test
[ RUN      ] PrepareTFConfigProto1.test1
[       OK ] PrepareTFConfigProto1.test1 (0 ms)
[ RUN      ] PrepareTFConfigProto1.test2
[       OK ] PrepareTFConfigProto1.test2 (0 ms)
[ RUN      ] PrepareTFConfigProto1.test3
[       OK ] PrepareTFConfigProto1.test3 (0 ms)
[ RUN      ] PrepareTFConfigProto1.test4
[       OK ] PrepareTFConfigProto1.test4 (0 ms)
[----------] 4 tests from PrepareTFConfigProto1 (0 ms total)
```