### PR TITLE
Use json get_ref

### DIFF
--- a/src/dlr_tvm.cc
+++ b/src/dlr_tvm.cc
@@ -224,9 +224,7 @@ void TVMModel::UseCPUAffinity(bool use) {
   }
 }
 
-bool TVMModel::HasMetadata() const {
-  return this->metadata != nullptr;
-}
+bool TVMModel::HasMetadata() const { return this->metadata != nullptr; }
 
 const char* TVMModel::GetOutputName(const int index) const {
   if (!this->HasMetadata()) {
@@ -234,7 +232,9 @@ const char* TVMModel::GetOutputName(const int index) const {
     return nullptr;
   }
   try {
-    return this->metadata["Model"]["Outputs"][index]["name"].get<std::string>().c_str();
+    return this->metadata["Model"]["Outputs"][index]["name"]
+        .get_ref<const std::string&>()
+        .c_str();
   } catch (nlohmann::detail::type_error e) {
     LOG(INFO) << "Couldn't find output nodes in metadata file";
     return nullptr;
@@ -249,8 +249,10 @@ int TVMModel::GetOutputIndex(const char* name) const {
 
   try {
     for (int i = 0; i < this->num_outputs_; i++) {
-      std::string name_str = this->metadata["Model"]["Outputs"][i]["name"];
-      if (name == name_str) {
+      const std::string& name_str =
+          this->metadata["Model"]["Outputs"][i]["name"]
+              .get_ref<const std::string&>();
+      if (name_str == name) {
         return i;
       }
     }


### PR DESCRIPTION
Niels Lohmann recommends to use `json.get_ref()` instead of `json.get()` in case we use json object as a shared read-only storage of strings.

https://github.com/nlohmann/json/issues/2130

## Testing
### model_peeker
```
# bin/model_peeker ../tests/python/integration/resnet18_v1
[07:40:46] /root/workplace/neo-ai-dlr/src/dlr_tvm.cc:68: Loading metadata file: ../tests/python/integration/resnet18_v1/resnet18.meta
backend is tvm
num_inputs = 1
num_weights = 62
num_outputs = 1
input_names: data,
input_types: float32,
output shapes:
[1, 1000, ]
output_names: softmax_tensor (index: 0),
output_types: float32,
```

### run_resnet
```
# bin/run_resnet ../tests/python/integration/resnet18_v1 ~/workplace/models/dog_float32.npy
Loading model...
[07:41:08] /root/workplace/neo-ai-dlr/src/dlr_tvm.cc:68: Loading metadata file: ../tests/python/integration/resnet18_v1/resnet18.meta
Running inference...
Max probability is 0.994058 at index 151
```