### PR TITLE
Update pip3 in Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -134,15 +134,19 @@ def CloudInstallAndTest(cloudTarget) {
     }
     sh """
     ls -lh python/dist/*.whl
-    pip3 install python/dist/*.whl
+    echo "Updating pip3..."
+    sudo -H pip3 install -U pip setuptools
+    pip3 --version
+    echo "Installing DLR Python package..."
+    pip3 install --prefer-binary python/dist/*.whl
     """
     if (cloudTarget == "p2" || cloudTarget == "p3") {
       sh """
-      sudo pip3 install --upgrade tensorflow_gpu
+      sudo -H pip3 install --prefer-binary -U tensorflow_gpu
       """
     } else {
       sh """
-      sudo pip3 install --upgrade tensorflow
+      sudo -H pip3 install --prefer-binary -U tensorflow
       """
     }
     sh """

--- a/python/dlr/tf_model.py
+++ b/python/dlr/tf_model.py
@@ -26,8 +26,8 @@ def _load_frozen_graph(frozen_graph_file, device):
     """
     logging.info("Loading frozen graph: {}".format(frozen_graph_file))
     with tf.device(device):
-        with tf.gfile.GFile(frozen_graph_file, 'rb') as f:
-            graph_def = tf.GraphDef()
+        with tf.io.gfile.GFile(frozen_graph_file, 'rb') as f:
+            graph_def = tf.compat.v1.GraphDef()
             graph_def.ParseFromString(f.read())
         with tf.Graph().as_default() as graph:
             tf.import_graph_def(graph_def, name=PREFIX)
@@ -106,9 +106,9 @@ class TFModelImpl(IDLRModel):
         # Turn on XLA JIT compilation
         # Turning on JIT at the session level will not result in operations being compiled for the CPU.
         # Currently JIT at the session level only supports GPU.
-        config = tf.ConfigProto()
-        config.graph_options.optimizer_options.global_jit_level = tf.OptimizerOptions.ON_1
-        self._sess = tf.Session(graph=self._graph, config=config)
+        config = tf.compat.v1.ConfigProto()
+        config.graph_options.optimizer_options.global_jit_level = tf.compat.v1.OptimizerOptions.ON_1
+        self._sess = tf.compat.v1.Session(graph=self._graph, config=config)
 
     def __enter__(self):
         return self

--- a/tests/python/unittest/test_tf_model.py
+++ b/tests/python/unittest/test_tf_model.py
@@ -2,15 +2,17 @@
 from __future__ import print_function
 from dlr import DLRModel
 import numpy as np
+import tensorflow as tf
+# https://github.com/tensorflow/tensorflow/issues/18165
+tf.compat.v1.disable_eager_execution()
 
 FROZEN_GRAPH_PATH = "/tmp/test_graph.pb"
 
 
 def _generate_frozen_graph():
-    import tensorflow as tf
-    graph = tf.get_default_graph()
-    a = tf.placeholder(tf.float32, shape=[2, 2], name="input1")
-    b = tf.placeholder(tf.float32, shape=[2, 2], name="input2")
+    graph = tf.compat.v1.get_default_graph()
+    a = tf.compat.v1.placeholder(tf.float32, shape=[2, 2], name="input1")
+    b = tf.compat.v1.placeholder(tf.float32, shape=[2, 2], name="input2")
     ab = tf.matmul(a, b)
     mm = tf.matmul(a, ab, name="preproc/mm")
     tf.square(mm, name="preproc/output1")
@@ -18,13 +20,13 @@ def _generate_frozen_graph():
     with graph.control_dependencies([id1]):
         mm_flat = tf.reshape(mm, shape=[-1])
         tf.argmax(mm_flat, name="preproc/output2")
-    with tf.Session() as sess:
-        output_graph_def = tf.graph_util.convert_variables_to_constants(
+    with tf.compat.v1.Session() as sess:
+        output_graph_def = tf.compat.v1.graph_util.convert_variables_to_constants(
             sess,
             graph.as_graph_def(),
             ["preproc/output1", "preproc/output2"]
         )
-        with tf.gfile.GFile(FROZEN_GRAPH_PATH, "wb") as f:
+        with tf.io.gfile.GFile(FROZEN_GRAPH_PATH, "wb") as f:
             f.write(output_graph_def.SerializeToString())
 
 

--- a/tests/python/unittest/test_tflite_model.py
+++ b/tests/python/unittest/test_tflite_model.py
@@ -2,25 +2,37 @@
 from __future__ import print_function
 from dlr import DLRModel
 import numpy as np
+import shutil
+import tensorflow as tf
+import tensorflow.lite as lite
+import uuid
+# https://github.com/tensorflow/tensorflow/issues/18165
+tf.compat.v1.disable_eager_execution()
 
 TFLITE_FILE_PATH = "/tmp/test_model.tflite"
 
 
 def _generate_tflite_file():
-    import tensorflow as tf
-    import tensorflow.lite as lite
-    a = tf.placeholder(tf.float32, shape=[2, 2], name="input1")
-    b = tf.placeholder(tf.float32, shape=[2, 2], name="input2")
+    tf_saved_model_path = "/tmp/test-tf-model-{}".format(str(uuid.uuid1()))
+    a = tf.compat.v1.placeholder(tf.float32, shape=[2, 2], name="input1")
+    b = tf.compat.v1.placeholder(tf.float32, shape=[2, 2], name="input2")
     ab = tf.matmul(a, b)
     mm = tf.matmul(a, ab, name="preproc/mm")
     out0 = tf.square(mm, name="preproc/output1")
     mm_flat = tf.reshape(mm, shape=[-1])
     out1 = tf.argmax(mm_flat, name="preproc/output2")
-    with tf.Session() as sess:
-        converter = lite.TFLiteConverter.from_session(sess, input_tensors=[a, b], output_tensors=[out0, out1])
+    try:
+        with tf.compat.v1.Session() as sess:
+            tf.compat.v1.saved_model.simple_save(sess, tf_saved_model_path,
+                                                 inputs={"input1": a, "input2": b},
+                                                 outputs={"preproc/output1": out0,
+                                                          "preproc/output2": out1})
+        converter = lite.TFLiteConverter.from_saved_model(tf_saved_model_path)
         tflite_model = converter.convert()
         with open(TFLITE_FILE_PATH, "wb") as f:
             f.write(tflite_model)
+    finally:
+        shutil.rmtree(tf_saved_model_path, ignore_errors=True)
 
 
 def test_tflite_model():
@@ -28,10 +40,10 @@ def test_tflite_model():
 
     m = DLRModel(TFLITE_FILE_PATH)
     inp_names = m.get_input_names()
-    assert inp_names == ['input1', 'input2']
+    assert sorted(inp_names) == ['input1', 'input2']
 
     out_names = m.get_output_names()
-    assert out_names == ['preproc/output1', 'preproc/output2']
+    assert sorted(out_names) == ['preproc/output1', 'preproc/output2']
 
     inp1 = np.array([[4., 1.], [3., 2.]]).astype("float32")
     inp2 = np.array([[0., 1.], [1., 0.]]).astype("float32")


### PR DESCRIPTION
I noticed that Jenkins command `pip3 install --upgrade tensorflow` builds python `grpcio` package from source which fails quite often. Better to install `grpcio` from binary distribution

Source package might be used because of very old `pip3` 9.0.1.

Lets update `pip3` to the latest version 20.1.1 and install `tensorflow` with `--prefer-binary` option

```
[2020-05-23T00:25:04.335Z]   Downloading pip-20.1.1-py2.py3-none-any.whl (1.5 MB)
[2020-05-23T00:25:04.724Z] Installing collected packages: pip
[2020-05-23T00:25:04.724Z]   Attempting uninstall: pip
[2020-05-23T00:25:04.724Z]     Found existing installation: pip 9.0.1
[2020-05-23T00:25:04.724Z]     Uninstalling pip-9.0.1:
[2020-05-23T00:25:05.112Z]       Successfully uninstalled pip-9.0.1
[2020-05-23T00:25:07.592Z] Successfully installed pip-20.1.1
```