### PR TITLE
Improve metadata json querying code

### DIFF
--- a/demo/cpp/model_peeker.cc
+++ b/demo/cpp/model_peeker.cc
@@ -83,9 +83,12 @@ void peek_model(DLRModelHandle model) {
     std::cout << "output_names: ";
     for (int i = 0; i < num_outputs; i++) {
       int index;
-      GetDLROutputName(&model, i, &output_names[i]);
-      GetDLROutputIndex(&model, output_names[i], &index);
-      std::cout << output_names[i] << " (index: " << index << ")" << ", ";
+      if (GetDLROutputName(&model, i, &output_names[i]) == 0) {
+        GetDLROutputIndex(&model, output_names[i], &index);
+        std::cout << output_names[i] << " (index: " << index << ")" << ", ";
+      } else {
+        std::cout << "<unknown> (index: " << i << ")" << ", ";
+      }
     }
     std::cout << std::endl;
   }

--- a/src/dlr.cc
+++ b/src/dlr.cc
@@ -136,7 +136,7 @@ extern "C" int GetDLROutputName(DLRModelHandle* handle, const int index, const c
   DLRModel* model = static_cast<DLRModel*>(*handle);
   CHECK(model != nullptr) << "model is nullptr, create it first";
   *name = model->GetOutputName(index);
-  CHECK(name != nullptr) << "name is nullptr, check for metadata file and see if it has output node data";
+  CHECK(*name != nullptr) << "name is nullptr, check for metadata file and see if it has output node data";
   API_END();
 }
 

--- a/src/dlr_common.cc
+++ b/src/dlr_common.cc
@@ -1,5 +1,7 @@
 #include "dlr_common.h"
+
 #include <dmlc/filesystem.h>
+
 #include <fstream>
 using namespace dlr;
 
@@ -52,9 +54,15 @@ void dlr::ListDir(const std::string& dirname, std::vector<std::string>& paths) {
   }
 }
 
-void dlr::LoadJsonFromFile(const std::string& path, nlohmann::json& jsonObject) {
-  std::ifstream jsonFile (path);
-  jsonFile >> jsonObject;
+void dlr::LoadJsonFromFile(const std::string& path,
+                           nlohmann::json& jsonObject) {
+  std::ifstream jsonFile(path);
+  try {
+    jsonFile >> jsonObject;
+  } catch (nlohmann::json::exception&) {
+    LOG(INFO) << "Failed to load metadata file";
+    jsonObject = nullptr;
+  }
 }
 
 DLRBackend dlr::GetBackend(std::vector<std::string> dir_paths) {


### PR DESCRIPTION
This PR fixes the following based on Niels recommendations:
- catch json exceptions properly
- use `.at(<name>/<index>)` instead of `[]` when querying json.
- use `.is_null()` instead of overloaded `== nullptr` which might be confusing because compares "object" to null-pointer. IMHO, using object method is better.
- catch json Loading errors
- fix bug in `dlr.cc` `GetDLROutputName` to check name for nullptr

Json parsing recommendations:
- https://github.com/nlohmann/json/issues/2150
- https://github.com/nlohmann/json/issues/2156

# Testing
I used model_peeker to test getOutputName for tvm compiled model

#### Happy case:
```
# bin/model_peeker ~/workplace/models/mobilenetv2_0.75_cpu
[20:54:51] /root/workplace/neo-ai-dlr/src/dlr_tvm.cc:68: Loading metadata file: /root/workplace/models/mobilenetv2_0.75_cpu/model.meta
backend is tvm
num_inputs = 1
num_weights = 107
num_outputs = 1
input_names: data, 
input_types: float32, 
output shapes: 
[1, 1000, ]
output_names: argmax (index: 0), 
output_types: float32,
```

#### meta file exists but does not have Outputs (or empty Outputs array) (or no "name" node inside outputs  array):
```
[20:45:26] /root/workplace/neo-ai-dlr/src/dlr_tvm.cc:68: Loading metadata file: /root/workplace/models/mobilenetv2_0.75_cpu/model.meta
backend is tvm
num_inputs = 1
num_weights = 107
num_outputs = 1
input_names: data,
input_types: float32,
output shapes:
[1, 1000, ]
output_names: [20:45:27] /root/workplace/neo-ai-dlr/src/dlr_tvm.cc:238: Output node with index 0 not found in metadata file
```

#### broken meta file:
```
# bin/model_peeker ~/workplace/models/mobilenetv2_0.75_cpu
[20:50:45] /root/workplace/neo-ai-dlr/src/dlr_tvm.cc:68: Loading metadata file: /root/workplace/models/mobilenetv2_0.75_cpu/model.meta
[20:50:45] /root/workplace/neo-ai-dlr/src/dlr_common.cc:61: Failed to load metadata file
backend is tvm
num_inputs = 1
num_weights = 107
num_outputs = 1
input_names: data,
input_types: float32,
output shapes:
[1, 1000, ]
output_types: float32,
```