### PR TITLE
Add TRT env var docs + Improve install docs + Add (some) 1.2 wheel links

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,25 @@ On X86_64 CPU targets running Linux, you can install latest release of DLR packa
 
 For installation of DLR on GPU targets, non-x86 edge devices, or building DLR from source, please refer to [Installing DLR](https://neo-ai-dlr.readthedocs.io/en/latest/install.html)
 
+## Usage
+
+```python
+
+import dlr
+import numpy as np
+
+# Load model.
+# /path/to/model is a directory containing the compiled model artifacts (.so, .params, .json)
+model = dlr.DLRModel('/path/to/model', 'cpu', 0)
+
+# Prepare some input data.
+x = np.random.rand(1, 3, 224, 224)
+
+# Run inference.
+y = model.run(x)
+
+```
+
 ## Documentation
 For instructions on using DLR, please refer to [Amazon SageMaker Neo – Train Your Machine Learning Models Once, Run Them Anywhere](https://aws.amazon.com/blogs/aws/amazon-sagemaker-neo-train-your-machine-learning-models-once-run-them-anywhere/)
 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -10,38 +10,38 @@ Installing DLR
 Installing Pre-built DLR Wheels for Your Device
 ***********************************************
 
-DLR has been built and tested aginast devices in table 1. If you find your device(s) listed below, you can install DLR with the corresponding S3 link via 
+DLR has been built and tested against devices in table 1. If you find your device(s) listed below, you can install DLR with the corresponding S3 link via 
 
   .. code-block:: bash
 
-    pip install  link-to-matching-wheel-on-S3 
+    pip install  link-to-matching-wheel
 
 Table 1: List of Supported Devices
 ----------------------------------
 
-+--------------+--------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
-| Manufacturer | Device Name  |  Wheel URL on S3                                                                                                                                        |
-+==============+==============+=========================================================================================================================================================+
-| Acer         | TV AISage    |  https://neo-ai-dlr-release.s3-us-west-2.amazonaws.com/v1.1.0/acer-aarch64-linaro4_4_154-glibc2_24-libstdcpp3_4/dlr-1.1.0-py2.py3-none-any.whl          |
-+--------------+--------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
-| Amazon       | A1 Instance  |  https://neo-ai-dlr-release.s3-us-west-2.amazonaws.com/v1.1.0/a1-aarch64-ubuntu18_04-glibc2_27-libstdcpp3_4/dlr-1.1.0-py2.py3-none-any.whl              |
-+--------------+--------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
-| Amazon       | P3 Instance  |  https://neo-ai-dlr-release.s3-us-west-2.amazonaws.com/v1.1.0/p3-x86_64-cu90-ubuntu18_04-glibc2_27-libstdpp3_4/dlr-1.1.0-py2.py3-none-any.whl           |
-+--------------+--------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
-| Amazon       | Deeplens     |  https://neo-ai-dlr-release.s3-us-west-2.amazonaws.com/v1.1.0/deeplens-x86_64-igp-ubuntu16_04-glibc2_23-libstdcpp3_4/dlr-1.1.0-py2.py3-none-any.whl     |
-+--------------+--------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
-| Rockchips    | RK3399       |  https://neo-ai-dlr-release.s3-us-west-2.amazonaws.com/v1.1.0/firefly-aarch64-mali-ubuntu16_04-glibc2_23-libstdcpp3_4/dlr-1.1.0-py2.py3-none-any.whl    |
-+--------------+--------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
-| Nvidia       | Jetson_TX1   |https://neo-ai-dlr-release.s3-us-west-2.amazonaws.com/v1.1.0/jetsontx1-aarch64-cu10-ubuntu18_04-glibc2_27-libstdcpp3_4/dlr-1.1.0-py2.py3-none-any.whl    |
-+--------------+--------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
-| Nvidia       | Jetson_TX2   |https://neo-ai-dlr-release.s3-us-west-2.amazonaws.com/v1.1.0/jetsontx2-aarch64-cu10-ubuntu18_04-glibc2_27-libstdcpp3_4/dlr-1.1.0-py2.py3-none-any.whl    |
-+--------------+--------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
-| Nvidia       | Jetson_Nano  |https://neo-ai-dlr-release.s3-us-west-2.amazonaws.com/v1.1.0/jetsonnano-aarch64-cu10-ubuntu18_04-glibc2_27-libstdcpp3_4/dlr-1.1.0-py2.py3-none-any.whl   |
-+--------------+--------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
-| Nvidia       | Jetson_Xavier|https://neo-ai-dlr-release.s3-us-west-2.amazonaws.com/v1.1.0/jetsonxavier-aarch64-cu10-ubuntu18_04-glibc2_27-libstdcpp3_4/dlr-1.1.0-py2.py3-none-any.whl |
-+--------------+--------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
-| Raspberry    | Rasp3b       |  https://neo-ai-dlr-release.s3-us-west-2.amazonaws.com/v1.1.0/pi-armv7l-raspbian4.14.71-glibc2_24-libstdcpp3_4/dlr-1.1.0-py2.py3-none-any.whl           |
-+--------------+--------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
++--------------+--------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Manufacturer | Device Name  |  Wheel URL                                                                                                                                                |
++==============+==============+===========================================================================================================================================================+
+| Acer         | TV AISage    |  https://neo-ai-dlr-release.s3-us-west-2.amazonaws.com/v1.2.0/acer-aarch64-linaro4_4_154-glibc2_24-libstdcpp3_4/dlr-1.2.0-py2.py3-none-any.whl            |
++--------------+--------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Amazon       | AWS a1       |  https://neo-ai-dlr-release.s3-us-west-2.amazonaws.com/v1.2.0/a1-aarch64-ubuntu18_04-glibc2_27-libstdcpp3_4/dlr-1.2.0-py2.py3-none-any.whl                |
++--------------+--------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Amazon       | AWS p2/p3/g4 |  https://neo-ai-dlr-release.s3-us-west-2.amazonaws.com/v1.2.0/p3-x86_64-cu10-ubuntu18_04-glibc2_27-libstdpp3_4/dlr-1.2.0-py2.py3-none-any.whl             |
++--------------+--------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Amazon       | Deeplens     |  https://neo-ai-dlr-release.s3-us-west-2.amazonaws.com/v1.1.0/deeplens-x86_64-igp-ubuntu16_04-glibc2_23-libstdcpp3_4/dlr-1.1.0-py2.py3-none-any.whl       |
++--------------+--------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Rockchips    | RK3399       |  https://neo-ai-dlr-release.s3-us-west-2.amazonaws.com/v1.1.0/firefly-aarch64-mali-ubuntu16_04-glibc2_23-libstdcpp3_4/dlr-1.1.0-py2.py3-none-any.whl      |
++--------------+--------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+
+| NVIDIA       | Jetson TX1   |  https://neo-ai-dlr-release.s3-us-west-2.amazonaws.com/v1.2.0/jetsontx1-aarch64-cu10-ubuntu18_04-glibc2_27-libstdcpp3_4/dlr-1.2.0-py2.py3-none-any.whl    |
++--------------+--------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+
+| NVIDIA       | Jetson TX2   |  https://neo-ai-dlr-release.s3-us-west-2.amazonaws.com/v1.2.0/jetsontx2-aarch64-cu10-ubuntu18_04-glibc2_27-libstdcpp3_4/dlr-1.2.0-py2.py3-none-any.whl    |
++--------------+--------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+
+| NVIDIA       | Jetson Nano  |  https://neo-ai-dlr-release.s3-us-west-2.amazonaws.com/v1.2.0/jetsonnano-aarch64-cu10-ubuntu18_04-glibc2_27-libstdcpp3_4/dlr-1.2.0-py2.py3-none-any.whl   |
++--------------+--------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+
+| NVIDIA       | Jetson Xavier|  https://neo-ai-dlr-release.s3-us-west-2.amazonaws.com/v1.2.0/jetsonxavier-aarch64-cu10-ubuntu18_04-glibc2_27-libstdcpp3_4/dlr-1.2.0-py2.py3-none-any.whl |
++--------------+--------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Raspberry    | Rasp3b       |  https://neo-ai-dlr-release.s3-us-west-2.amazonaws.com/v1.1.0/pi-armv7l-raspbian4.14.71-glibc2_24-libstdcpp3_4/dlr-1.1.0-py2.py3-none-any.whl             |
++--------------+--------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+
 
 If your device is not listed in the table, use table2. You will identify your device by the processor architecture, operating system, and versions of GLIBC and LIBSTDC++. Of note, DLR installation may depend on other configuration differences or even location of dependency libraries; if the provided wheel URL does not work, please consider compiling DLR from source (see `Building DLR from source`_ section).
 
@@ -49,9 +49,9 @@ Table2: List of Supported Architectures (Incomplete)
 ----------------------------------------------------
 
 +------------------------+--------------+---------------+-------------------+--------------------------------------------------------------------------------------------------------------------------------------------+ 
-| Processor architecture | OS           | GLIBC version | LIBSTDC++ version | Wheel URL on S3                                                                                                                            | 
+| Processor architecture | OS           | GLIBC version | LIBSTDC++ version | Wheel URL                                                                                                                                  | 
 +========================+==============+===============+===================+============================================================================================================================================+ 
-| aarch64                | Ubuntu 18.04 | 2.27+         | 3.4+              |  https://neo-ai-dlr-release.s3-us-west-2.amazonaws.com/v1.1.0/a1-aarch64-ubuntu18_04-glibc2_27-libstdcpp3_4/dlr-1.1.0-py2.py3-none-any.whl | 
+| aarch64                | Ubuntu 18.04 | 2.27+         | 3.4+              |  https://neo-ai-dlr-release.s3-us-west-2.amazonaws.com/v1.2.0/a1-aarch64-ubuntu18_04-glibc2_27-libstdcpp3_4/dlr-1.2.0-py2.py3-none-any.whl | 
 +------------------------+--------------+---------------+-------------------+--------------------------------------------------------------------------------------------------------------------------------------------+ 
 | armv7l                 | Debian 9.0   | 2.24+         | 3.4+              |https://neo-ai-dlr-release.s3-us-west-2.amazonaws.com/v1.1.0/pi-armv7l-raspbian4.14.71-glibc2_24-libstdcpp3_4/dlr-1.1.0-py2.py3-none-any.whl| 
 +------------------------+--------------+---------------+-------------------+--------------------------------------------------------------------------------------------------------------------------------------------+ 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -78,6 +78,9 @@ Building DLR consists of two steps:
 Building on Linux
 -----------------
 
+Requirements
+""""""""""""
+
 Ensure that all necessary software packages are installed: GCC (or Clang), CMake, and Python. For example, in Ubuntu, you can run
 
 .. code-block:: bash
@@ -88,16 +91,23 @@ Ensure that all necessary software packages are installed: GCC (or Clang), CMake
   sudo python3 /tmp/get-pip.py
   rm /tmp/get-pip.py
 
-  
-To build, create a subdirectory ``build``:
+
+Building for CPU
+""""""""""""""""
+
+First, clone the repository.
+
+.. code-block:: bash
+
+  git clone --recursive https://github.com/neo-ai/neo-ai-dlr
+  cd neo-ai-dlr
+
+Create a subdirectory ``build``:
 
 .. code-block:: bash
 
   mkdir build
   cd build
-
-Building for CPU
-""""""""""""""""
 
 Invoke CMake to generate a Makefile and then run GNU Make to compile:
 
@@ -106,44 +116,60 @@ Invoke CMake to generate a Makefile and then run GNU Make to compile:
   cmake ..
   make -j4         # Use 4 cores to compile sources in parallel
 
+Once the compilation is completed, install the Python package by running ``setup.py``:
+
+.. code-block:: bash
+
+  cd ../python
+  python3 setup.py install --user
+
 Building for GPU
 """"""""""""""""
 
 By default, DLR will be built with CPU support only. To enable support for NVIDIA GPUs, enable CUDA, CUDNN, and TensorRT by calling CMake with these extra options.
 
-If you have a system install of TensorRT via Deb or RPM package, or if you are on a Jetson device, use the following configuration:
+If you have a system install of TensorRT via Deb or RPM package, or if you are on a Jetson device, use the following steps:
 
 .. code-block:: bash
-
+ 
+  git clone --recursive https://github.com/neo-ai/neo-ai-dlr
+  cd neo-ai-dlr
+  mkdir build
+  cd build
   cmake .. -DUSE_CUDA=ON -DUSE_CUDNN=ON -DUSE_TENSORRT=ON
   make -j4
+  cd ../python
+  python3 setup.py install --user
 
-If you do not have a system install of TensorRT and have downloaded it via tar file or zip, provide the path to the extracted TensorRT directory with:
+If you do not have a system install of TensorRT, first download the relevant .tar.gz file from https://developer.nvidia.com/nvidia-tensorrt-download
+Please follow instructions from https://docs.nvidia.com/deeplearning/tensorrt/install-guide/index.html#installing-tar to install TensorRT.
+Now, provide the extracted .tar.gz folder path to ``-DUSE_TENSORRT`` when configuring cmake.
 
 .. code-block:: bash
 
+  git clone --recursive https://github.com/neo-ai/neo-ai-dlr
+  cd neo-ai-dlr
+  mkdir build
+  cd build
   cmake .. -DUSE_CUDA=ON -DUSE_CUDNN=ON -DUSE_TENSORRT=/path/to/TensorRT/ 
   make -j4
+  cd ../python
+  python3 setup.py install --user
 
-You will need to install NVIDIA CUDA and TensorRT toolkits and drivers beforehand.
 
 Building for OpenCL Devices
 """""""""""""""""""""""""""
 
-Similarly, to enable support for OpenCL devices, run CMake with:
+Similarly, to enable support for OpenCL devices, run CMake with ``-DUSE_OPENCL=ON``:
 
 .. code-block:: bash
 
+  git clone --recursive https://github.com/neo-ai/neo-ai-dlr
+  cd neo-ai-dlr
+  mkdir build
+  cd build
   cmake .. -DUSE_OPENCL=ON 
   make -j4
-
-Install Python package
-""""""""""""""""""""""
-
-Once the compilation is completed, install the Python package by running ``setup.py``:
-
-.. code-block:: bash
-
   cd ../python
   python3 setup.py install --user
 
@@ -161,6 +187,8 @@ To ensure that Homebrew GCC is used (instead of default Apple compiler), specify
 
 .. code-block:: bash
 
+  git clone --recursive https://github.com/neo-ai/neo-ai-dlr
+  cd neo-ai-dlr
   mkdir build
   cd build
   CC=gcc-8 CXX=g++-8 cmake ..
@@ -184,6 +212,8 @@ In the DLR directory, first run CMake to generate a Visual Studio project:
 
 .. code-block:: bash
 
+  git clone --recursive https://github.com/neo-ai/neo-ai-dlr
+  cd neo-ai-dlr
   mkdir build
   cd build
   cmake .. -G"Visual Studio 15 2017 Win64"
@@ -210,12 +240,18 @@ Once done with above steps, invoke cmake with following commands to build Androi
 
 .. code-block:: bash
 
+  git clone --recursive https://github.com/neo-ai/neo-ai-dlr
+  cd neo-ai-dlr
+  mkdir build
+  cd build
   cmake .. -DANDROID_BUILD=ON \
     -DNDK_ROOT=/path/to/your/ndk/folder \
     -DCMAKE_TOOLCHAIN_FILE=/path/to/your/ndk/folder/build/cmake/android.toolchain.cmake \
     -DANDROID_PLATFORM=android-21
 
   make -j4
+  cd ../python
+  python3 setup.py install --user
 
 ``ANDROID_PLATFORM`` should correspond to ``minSdkVersion`` of your project. If ``ANDROID_PLATFORM`` is not set it will default to ``android-21``.
 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -156,6 +156,8 @@ Now, provide the extracted .tar.gz folder path to ``-DUSE_TENSORRT`` when config
   cd ../python
   python3 setup.py install --user
 
+See `Additional Options for TensorRT Optimized Models <https://neo-ai-dlr.readthedocs.io/en/latest/tensorrt.html>`_ to learn how to enable FP16 precision and more for your Neo optimized models which use TensorRT.
+
 
 Building for OpenCL Devices
 """""""""""""""""""""""""""

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -24,23 +24,23 @@ Table 1: List of Supported Devices
 +==============+==============+===========================================================================================================================================================+
 | Acer         | TV AISage    |  https://neo-ai-dlr-release.s3-us-west-2.amazonaws.com/v1.2.0/acer-aarch64-linaro4_4_154-glibc2_24-libstdcpp3_4/dlr-1.2.0-py2.py3-none-any.whl            |
 +--------------+--------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+
-| Amazon       | AWS a1       |  https://neo-ai-dlr-release.s3-us-west-2.amazonaws.com/v1.2.0/a1-aarch64-ubuntu18_04-glibc2_27-libstdcpp3_4/dlr-1.2.0-py2.py3-none-any.whl                |
+| Amazon       | AWS a1 Instance |  https://neo-ai-dlr-release.s3-us-west-2.amazonaws.com/v1.2.0/a1-aarch64-ubuntu18_04-glibc2_27-libstdcpp3_4/dlr-1.2.0-py2.py3-none-any.whl                |
 +--------------+--------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+
-| Amazon       | AWS p2/p3/g4 |  https://neo-ai-dlr-release.s3-us-west-2.amazonaws.com/v1.2.0/p3-x86_64-cu10-ubuntu18_04-glibc2_27-libstdpp3_4/dlr-1.2.0-py2.py3-none-any.whl             |
+| Amazon       | AWS p2/p3/g4 Instance w/ TensorRT 7 |  https://neo-ai-dlr-release.s3-us-west-2.amazonaws.com/v1.2.0/p3-x86_64-cu10-ubuntu18_04-glibc2_27-libstdpp3_4/dlr-1.2.0-py2.py3-none-any.whl             |
 +--------------+--------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+
 | Amazon       | Deeplens     |  https://neo-ai-dlr-release.s3-us-west-2.amazonaws.com/v1.1.0/deeplens-x86_64-igp-ubuntu16_04-glibc2_23-libstdcpp3_4/dlr-1.1.0-py2.py3-none-any.whl       |
 +--------------+--------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+
-| Rockchips    | RK3399       |  https://neo-ai-dlr-release.s3-us-west-2.amazonaws.com/v1.1.0/firefly-aarch64-mali-ubuntu16_04-glibc2_23-libstdcpp3_4/dlr-1.1.0-py2.py3-none-any.whl      |
+| Rockchips    | RK3399       |  https://neo-ai-dlr-release.s3-us-west-2.amazonaws.com/v1.2.0/firefly-aarch64-mali-ubuntu16_04-glibc2_23-libstdcpp3_4/dlr-1.2.0-py2.py3-none-any.whl      |
 +--------------+--------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+
-| NVIDIA       | Jetson TX1   |  https://neo-ai-dlr-release.s3-us-west-2.amazonaws.com/v1.2.0/jetsontx1-aarch64-cu10-ubuntu18_04-glibc2_27-libstdcpp3_4/dlr-1.2.0-py2.py3-none-any.whl    |
+| NVIDIA       | Jetson TX1 (JetPack 4.3)  |  https://neo-ai-dlr-release.s3-us-west-2.amazonaws.com/v1.2.0/jetsontx1-aarch64-cu10-ubuntu18_04-glibc2_27-libstdcpp3_4/dlr-1.2.0-py2.py3-none-any.whl    |
 +--------------+--------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+
-| NVIDIA       | Jetson TX2   |  https://neo-ai-dlr-release.s3-us-west-2.amazonaws.com/v1.2.0/jetsontx2-aarch64-cu10-ubuntu18_04-glibc2_27-libstdcpp3_4/dlr-1.2.0-py2.py3-none-any.whl    |
+| NVIDIA       | Jetson TX2 (JetPack 4.3)  |  https://neo-ai-dlr-release.s3-us-west-2.amazonaws.com/v1.2.0/jetsontx2-aarch64-cu10-ubuntu18_04-glibc2_27-libstdcpp3_4/dlr-1.2.0-py2.py3-none-any.whl    |
 +--------------+--------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+
-| NVIDIA       | Jetson Nano  |  https://neo-ai-dlr-release.s3-us-west-2.amazonaws.com/v1.2.0/jetsonnano-aarch64-cu10-ubuntu18_04-glibc2_27-libstdcpp3_4/dlr-1.2.0-py2.py3-none-any.whl   |
+| NVIDIA       | Jetson Nano (JetPack 4.3) |  https://neo-ai-dlr-release.s3-us-west-2.amazonaws.com/v1.2.0/jetsonnano-aarch64-cu10-ubuntu18_04-glibc2_27-libstdcpp3_4/dlr-1.2.0-py2.py3-none-any.whl   |
 +--------------+--------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+
-| NVIDIA       | Jetson Xavier|  https://neo-ai-dlr-release.s3-us-west-2.amazonaws.com/v1.2.0/jetsonxavier-aarch64-cu10-ubuntu18_04-glibc2_27-libstdcpp3_4/dlr-1.2.0-py2.py3-none-any.whl |
+| NVIDIA       |Jetson Xavier (JetPack 4.3)|  https://neo-ai-dlr-release.s3-us-west-2.amazonaws.com/v1.2.0/jetsonxavier-aarch64-cu10-ubuntu18_04-glibc2_27-libstdcpp3_4/dlr-1.2.0-py2.py3-none-any.whl |
 +--------------+--------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+
-| Raspberry    | Rasp3b       |  https://neo-ai-dlr-release.s3-us-west-2.amazonaws.com/v1.1.0/pi-armv7l-raspbian4.14.71-glibc2_24-libstdcpp3_4/dlr-1.1.0-py2.py3-none-any.whl             |
+| Raspberry    | Rasp3b       |  https://neo-ai-dlr-release.s3-us-west-2.amazonaws.com/v1.2.0/pi-armv7l-raspbian4.14.71-glibc2_24-libstdcpp3_4/dlr-1.2.0-py2.py3-none-any.whl             |
 +--------------+--------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+
 
 If your device is not listed in the table, use table2. You will identify your device by the processor architecture, operating system, and versions of GLIBC and LIBSTDC++. Of note, DLR installation may depend on other configuration differences or even location of dependency libraries; if the provided wheel URL does not work, please consider compiling DLR from source (see `Building DLR from source`_ section).
@@ -53,7 +53,7 @@ Table2: List of Supported Architectures (Incomplete)
 +========================+==============+===============+===================+============================================================================================================================================+ 
 | aarch64                | Ubuntu 18.04 | 2.27+         | 3.4+              |  https://neo-ai-dlr-release.s3-us-west-2.amazonaws.com/v1.2.0/a1-aarch64-ubuntu18_04-glibc2_27-libstdcpp3_4/dlr-1.2.0-py2.py3-none-any.whl | 
 +------------------------+--------------+---------------+-------------------+--------------------------------------------------------------------------------------------------------------------------------------------+ 
-| armv7l                 | Debian 9.0   | 2.24+         | 3.4+              |https://neo-ai-dlr-release.s3-us-west-2.amazonaws.com/v1.1.0/pi-armv7l-raspbian4.14.71-glibc2_24-libstdcpp3_4/dlr-1.1.0-py2.py3-none-any.whl| 
+| armv7l                 | Debian 9.0   | 2.24+         | 3.4+              |https://neo-ai-dlr-release.s3-us-west-2.amazonaws.com/v1.2.0/pi-armv7l-raspbian4.14.71-glibc2_24-libstdcpp3_4/dlr-1.2.0-py2.py3-none-any.whl| 
 +------------------------+--------------+---------------+-------------------+--------------------------------------------------------------------------------------------------------------------------------------------+ 
 
 
@@ -123,12 +123,24 @@ Once the compilation is completed, install the Python package by running ``setup
   cd ../python
   python3 setup.py install --user
 
-Building for GPU
-""""""""""""""""
+Building for NVIDIA GPU on Jetson Devices
+"""""""""""""""""""""""""""""""""""""""""
 
 By default, DLR will be built with CPU support only. To enable support for NVIDIA GPUs, enable CUDA, CUDNN, and TensorRT by calling CMake with these extra options.
 
-If you have a system install of TensorRT via Deb or RPM package, or if you are on a Jetson device, use the following steps:
+DLR requires CMake 3.13 or greater. First, we will build CMake from source.
+
+.. code-block:: bash
+
+  sudo apt-get install libssl-dev
+  wget https://github.com/Kitware/CMake/releases/download/v3.17.2/cmake-3.17.2.tar.gz
+  tar xvf cmake-3.17.2.tar.gz
+  cd cmake-3.17.2
+  ./bootstrap
+  make -j4
+  sudo make install
+
+Now, build DLR.
 
 .. code-block:: bash
  
@@ -141,9 +153,16 @@ If you have a system install of TensorRT via Deb or RPM package, or if you are o
   cd ../python
   python3 setup.py install --user
 
+Building for NVIDIA GPU (Cloud or Desktop)
+""""""""""""""""""""""""""""""""""""""""""
+
+By default, DLR will be built with CPU support only. To enable support for NVIDIA GPUs, enable CUDA, CUDNN, and TensorRT by calling CMake with these extra options.
+
 If you do not have a system install of TensorRT, first download the relevant .tar.gz file from https://developer.nvidia.com/nvidia-tensorrt-download
 Please follow instructions from https://docs.nvidia.com/deeplearning/tensorrt/install-guide/index.html#installing-tar to install TensorRT.
 Now, provide the extracted .tar.gz folder path to ``-DUSE_TENSORRT`` when configuring cmake.
+
+If you have a system install of TensorRT via Deb or RPM package, you can instead use ``-DUSE_TENSORRT=ON` which will find the install directory automatically.
 
 .. code-block:: bash
 

--- a/doc/tensorrt.rst
+++ b/doc/tensorrt.rst
@@ -1,0 +1,108 @@
+################################################
+Additional Options for TensorRT Optimized Models
+################################################
+
+.. contents:: Contents
+  :local:
+  :backlinks: none
+
+***************
+TensorRT in Neo
+***************
+
+For targets with NVIDIA GPUs, Neo may use `TensorRT <https://developer.nvidia.com/tensorrt>`_ to optimize all or part of your model.
+If your optimized model is using TensorRT, you will see outputs similar to the following
+during the first inference after loading the model.
+
+
+.. code-block:: none
+
+  Building new TensorRT engine for subgraph tensorrt_0
+  Finished building TensorRT engine for subgraph tensorrt_0
+
+
+*****************************
+Additional Flags for TensorRT
+*****************************
+
+DLR provides several runtime flags to configure the TensorRT components of your optimized model.
+These flags are all configured through environment variables.
+
+The examples will use the following test script ``run.py``.
+  
+.. code-block:: python
+
+  import dlr
+  import numpy as np
+  import time
+
+  model = dlr.DLRModel('my_compiled_model/', 'gpu', 0)
+  x = np.random.rand(1, 3, 224, 224)
+  # Warmup
+  model.run(x)
+
+  times = []
+  for i in range(100):
+    start = time.time()
+    model.run(x)
+    times.append(time.time() - start)
+  print('Latency:', 1000.0 * np.mean(times), 'ms')
+
+Example output
+
+.. code-block:: bash
+
+  $ python3 run.py
+
+  Building new TensorRT engine for subgraph tensorrt_0
+  Finished building TensorRT engine for subgraph tensorrt_0
+  Latency: 3.320300579071045 ms
+
+Automatic FP16 Conversion
+-------------------------
+
+Environment variable ``TVM_TENSORRT_USE_FP16=1`` can be set to automatically convert the TensorRT
+components of your model to 16-bit floating point precision. This can greatly increase performance,
+but may cause some slight loss in the model accuracy.
+
+.. code-block:: bash
+
+  $ TVM_TENSORRT_USE_FP16=1 python3 run.py
+
+  Building new TensorRT engine for subgraph tensorrt_0
+  Finished building TensorRT engine for subgraph tensorrt_0
+  Latency: 1.7122554779052734 ms
+
+
+Caching TensorRT Engines
+------------------------
+
+During the first inference, DLR will invoke the TensorRT API to build an engine. This can be time consuming, so you can set ``TVM_TENSORRT_CACHE_DIR``
+to point to a directory to save these built engines to on the disk. The next time you load the model and give it the same directory,
+DLR will load the already built engines to avoid the long warmup time.
+
+.. code-block:: bash
+
+  $ TVM_TENSORRT_CACHE_DIR=. python3 run.py
+
+  Building new TensorRT engine for subgraph tensorrt_0
+  Caching TensorRT engine to ./8030730458607885728.plan
+  Finished building TensorRT engine for subgraph tensorrt_0
+  Latency: 4.380748271942139 ms
+
+  $ TVM_TENSORRT_CACHE_DIR=. python3 run.py
+
+  Loading cached TensorRT engine from ./8030730458607885728.plan
+  Latency: 4.414560794830322 ms
+
+Changing the TensorRT Workspace Size
+------------------------------------
+
+TensorRT has a paramter to configure the maximum amount of scratch space that each layer in the model can use.
+It is generally best to use the highest value which does not cause you to run out of memory.
+Neo will automatically set the max workspace size to 256 megabytes for Jetson Nano and Jetson TX1 targets, and 1 gigabyte for all other NVIDIA GPU targets.
+You can use ``TVM_TENSORRT_MAX_WORKSPACE_SIZE`` to override this by specifying the workspace size in bytes you would like to use.
+
+.. code-block:: bash
+
+  $ TVM_TENSORRT_MAX_WORKSPACE_SIZE=2147483647 python3 run.py


### PR DESCRIPTION
* Add example usage code to readme
* Install docs did not give full step-by-step instructions for each different configuration, now they do.
* Added doc page for TensorRT environment vars
* Added links to most DLR 1.2 wheels - still missing RK3399, Rasp3b, and Deeplens