### PR TITLE
Backwards compatibile with numpy < 1.16.1. Add trt doc to index

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -13,4 +13,5 @@ Contents
   install
   python-api
   c-api
+  tensorrt
   Internal docs <http://neo-ai-dlr.readthedocs.io/en/latest/dev/>

--- a/python/dlr/dlr_model.py
+++ b/python/dlr/dlr_model.py
@@ -8,6 +8,32 @@ from .compatibility import check_tensorrt_compatibility
 
 from .libpath import find_lib_path
 
+# Map from dtype string to ctype type.
+# Equivalent to np.ctypeslib.as_ctypes_type which requires numpy>=1.16.1
+DTYPE_TO_CTYPE = {
+    "float32": ctypes.c_float,
+    "float64": ctypes.c_double,
+    "uint8": ctypes.c_ubyte,
+    "uint32": ctypes.c_uint,
+    "uint64": ctypes.c_ulong,
+    "int8": ctypes.c_byte,
+    "int32": ctypes.c_int,
+    "int64": ctypes.c_long,
+}
+
+def _get_ctype_from_dtype(dtype):
+    """
+    Convert type string to ctype type.
+
+    Parameters
+    ----------
+    dtype: str
+        Type as a string, e.g. "float32".
+    """
+    if dtype not in DTYPE_TO_CTYPE:
+        raise ValueError("Model has input or output datatype {} which is not supported.".format(dtype))
+    return DTYPE_TO_CTYPE[dtype]
+
 class DLRError(Exception):
     """Error thrown by DLR"""
     pass
@@ -136,16 +162,6 @@ class DLRModelImpl(IDLRModel):
         self._fetch_output_names()
         self._fetch_input_dtypes()
         self._fetch_output_dtypes()
-        self.dtype_to_ctype = {
-            "float32": ctypes.c_float,
-            "float64": ctypes.c_double,
-            "uint8": ctypes.c_ubyte,
-            "uint32": ctypes.c_uint,
-            "uint64": ctypes.c_ulong,
-            "int8": ctypes.c_byte,
-            "int32": ctypes.c_int,
-            "int64": ctypes.c_long,
-        }
 
     def __del__(self):
         if getattr(self, "handle", None) is not None and self.handle is not None:
@@ -309,7 +325,7 @@ class DLRModelImpl(IDLRModel):
             The data to be set.
         """
         input_dtype = self._get_input_or_weight_dtype_by_name(name)
-        input_ctype = self._get_ctype_from_dtype(input_dtype)
+        input_ctype = _get_ctype_from_dtype(input_dtype)
         # float32 inputs can accept any data (backward compatibility).
         if input_dtype == "float32":
             type_match = True
@@ -402,7 +418,7 @@ class DLRModelImpl(IDLRModel):
             raise ValueError("index is expected between 0 and "
                              "len(output_shapes)-1, but got %d" % index)
         output_dtype = self.get_output_dtype(index)
-        output_ctype = self._get_ctype_from_dtype(output_dtype)
+        output_ctype = _get_ctype_from_dtype(output_dtype)
         output = np.zeros(self.output_size_dim[index][0], dtype=output_dtype)
         _check_call(_LIB.GetDLROutput(byref(self.handle), c_int(index),
                     output.ctypes.data_as(ctypes.POINTER(output_ctype))))
@@ -472,7 +488,7 @@ class DLRModelImpl(IDLRModel):
                              'input {}, we cannot infer its shape. '.format(name) +
                              'Shape parameter should be explicitly specified')
         input_dtype = self._get_input_or_weight_dtype_by_name(name)
-        input_ctype = self._get_ctype_from_dtype(input_dtype)
+        input_ctype = _get_ctype_from_dtype(input_dtype)
         if shape is None:
             shape = self.input_shapes[name]
         shape = np.array(shape)
@@ -482,16 +498,3 @@ class DLRModelImpl(IDLRModel):
                                      out.ctypes.data_as(ctypes.POINTER(input_ctype))))
         out = out.reshape(shape)
         return out
-
-    def _get_ctype_from_dtype(self, dtype):
-        """
-        Convert type string to ctype type.
-
-        Parameters
-        ----------
-        dtype: str
-            Type as a string, e.g. "float32".
-        """
-        if dtype not in self.dtype_to_ctype:
-            raise ValueError("Model has input or output datatype {} which is not supported.".format(dtype))
-        return self.dtype_to_ctype[dtype]

--- a/python/dlr/dlr_model.py
+++ b/python/dlr/dlr_model.py
@@ -28,7 +28,7 @@ def _get_ctype_from_dtype(dtype):
         "int64": ctypes.c_long,
     }
     if dtype not in dtype_to_ctype:
-        raise ValueError("Model has input or output datatype \"{}\" which is not supported.".format(dtype))
+        raise ValueError("Model has input or output datatype {} which is not supported.".format(dtype))
     return dtype_to_ctype[dtype]
 
 class DLRError(Exception):


### PR DESCRIPTION
1. Numpy 1.16.1 is required for `numpy.ctypeslib.as_ctypes_type` which we are now using. We have devices which are restricted to numpy 1.14.5. Add a method to ensure backwards compatibility.
https://numpy.org/devdocs/release/1.16.1-notes.html

2. Add tensorrt doc page to index.