### PR TITLE
Update pip and setuptools in Dockerfiles

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -135,7 +135,7 @@ def CloudInstallAndTest(cloudTarget) {
     sh """
     ls -lh python/dist/*.whl
     echo "Updating pip3..."
-    sudo -H pip3 install -U pip setuptools
+    sudo -H pip3 install -U pip setuptools wheel
     pip3 --version
     echo "Installing DLR Python package..."
     pip3 install --prefer-binary python/dist/*.whl

--- a/container/Dockerfile.cpu
+++ b/container/Dockerfile.cpu
@@ -9,13 +9,15 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     python3 \
-    python3-setuptools \
+    python3-distutils \
     wget \
     curl \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/* \
     && curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python3 get-pip.py && rm get-pip.py \
     && rm -rf /root/.cache/pip
+
+RUN pip3 install -U pip setuptools wheel
 
 ### Stage 1: Build
 FROM base AS builder

--- a/container/Dockerfile.gpu
+++ b/container/Dockerfile.gpu
@@ -15,13 +15,15 @@ ENV LD_LIBRARY_PATH=/packages/TensorRT-7.0.0.11/lib:$LD_LIBRARY_PATH
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     python3 \
-    python3-setuptools \
+    python3-distutils \
     wget \
     curl \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/* \
     && curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python3 get-pip.py && rm get-pip.py \
     && rm -rf /root/.cache/pip
+
+RUN pip3 install -U pip setuptools wheel
 
 ### Stage 1: Build
 FROM base AS builder

--- a/container/ec2_compilation_container/Dockerfile
+++ b/container/ec2_compilation_container/Dockerfile
@@ -5,11 +5,12 @@ RUN apt update
 RUN apt install -y build-essential
 RUN apt install -y llvm-6.0 clang-6.0
 RUN apt install -y cmake git wget curl vim zip
-RUN apt install -y python3 python3-dev
+RUN apt install -y python3 python3-dev python3-distutils
 RUN apt install -y libedit-dev libxml2-dev antlr4
 
 RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python3 get-pip.py && rm get-pip.py
 
+RUN pip3 install -U pip setuptools wheel
 RUN pip3 install numpy decorator attrs antlr4-python3-runtime
 
 RUN wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/cuda-repo-ubuntu1604_10.0.130-1_amd64.deb

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -86,10 +86,11 @@ Ensure that all necessary software packages are installed: GCC (or Clang), CMake
 .. code-block:: bash
 
   sudo apt-get update
-  sudo apt-get install -y python3 python3-setuptools build-essential cmake curl ca-certificates
+  sudo apt-get install -y python3 python3-distutils build-essential cmake curl ca-certificates
   curl https://bootstrap.pypa.io/get-pip.py -o /tmp/get-pip.py
   sudo python3 /tmp/get-pip.py
   rm /tmp/get-pip.py
+  sudo pip3 install -U pip setuptools wheel
 
 
 Building for CPU

--- a/examples/android/tvm_compiler/Dockerfile
+++ b/examples/android/tvm_compiler/Dockerfile
@@ -5,11 +5,12 @@ RUN apt update
 RUN apt install -y build-essential
 RUN apt install -y llvm-9 clang-9
 RUN apt install -y cmake git wget curl vim zip
-RUN apt install -y python3 python3-dev
+RUN apt install -y python3 python3-dev python3-distutils
 RUN apt install -y libedit-dev libxml2-dev antlr4
 
 RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python3 get-pip.py && rm get-pip.py
 
+RUN pip3 install -U pip setuptools wheel
 RUN pip3 install numpy decorator attrs antlr4-python3-runtime
 
 WORKDIR /root

--- a/tests/ci_build/Dockerfile.gpu_bare
+++ b/tests/ci_build/Dockerfile.gpu_bare
@@ -15,13 +15,15 @@ ENV LD_LIBRARY_PATH=/packages/TensorRT-7.0.0.11/lib:$LD_LIBRARY_PATH
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     python3 \
-    python3-setuptools \
+    python3-distutils \
     wget \
     curl \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/* \
     && curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python3 get-pip.py && rm get-pip.py \
     && rm -rf /root/.cache/pip
+
+RUN pip3 install -U pip setuptools wheel
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \


### PR DESCRIPTION
it should fix CI errors such as `ERROR: google-auth 1.17.2 has requirement setuptools>=40.3.0, but you'll have setuptools 39.0.1 which is incompatible.` https://neo-ai-ci.amazon-ml.com/blue/organizations/jenkins/neo-ai-dlr/detail/PR-198/8/pipeline