### PR TITLE
[Docs] Fix python-api docs

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -19,29 +19,29 @@ DLR has been built and tested against devices in table 1. If you find your devic
 Table 1: List of Supported Devices
 ----------------------------------
 
-+--------------+--------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+
-| Manufacturer | Device Name  |  Wheel URL                                                                                                                                                |
-+==============+==============+===========================================================================================================================================================+
-| Acer         | TV AISage    |  https://neo-ai-dlr-release.s3-us-west-2.amazonaws.com/v1.2.0/acer-aarch64-linaro4_4_154-glibc2_24-libstdcpp3_4/dlr-1.2.0-py2.py3-none-any.whl            |
-+--------------+--------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+
-| Amazon       | AWS a1 Instance |  https://neo-ai-dlr-release.s3-us-west-2.amazonaws.com/v1.2.0/a1-aarch64-ubuntu18_04-glibc2_27-libstdcpp3_4/dlr-1.2.0-py2.py3-none-any.whl                |
-+--------------+--------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+
-| Amazon       | AWS p2/p3/g4 Instance w/ TensorRT 7 |  https://neo-ai-dlr-release.s3-us-west-2.amazonaws.com/v1.2.0/p3-x86_64-cu10-ubuntu18_04-glibc2_27-libstdpp3_4/dlr-1.2.0-py2.py3-none-any.whl             |
-+--------------+--------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+
-| Amazon       | Deeplens     |  https://neo-ai-dlr-release.s3-us-west-2.amazonaws.com/v1.1.0/deeplens-x86_64-igp-ubuntu16_04-glibc2_23-libstdcpp3_4/dlr-1.1.0-py2.py3-none-any.whl       |
-+--------------+--------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+
-| Rockchips    | RK3399       |  https://neo-ai-dlr-release.s3-us-west-2.amazonaws.com/v1.2.0/firefly-aarch64-mali-ubuntu16_04-glibc2_23-libstdcpp3_4/dlr-1.2.0-py2.py3-none-any.whl      |
-+--------------+--------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+
++--------------+---------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Manufacturer | Device Name               |  Wheel URL                                                                                                                                                |
++==============+===========================+===========================================================================================================================================================+
+| Acer         | TV AISage                 |  https://neo-ai-dlr-release.s3-us-west-2.amazonaws.com/v1.2.0/acer-aarch64-linaro4_4_154-glibc2_24-libstdcpp3_4/dlr-1.2.0-py2.py3-none-any.whl            |
++--------------+---------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Amazon       | AWS a1                    |  https://neo-ai-dlr-release.s3-us-west-2.amazonaws.com/v1.2.0/a1-aarch64-ubuntu18_04-glibc2_27-libstdcpp3_4/dlr-1.2.0-py2.py3-none-any.whl                |
++--------------+---------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Amazon       | AWS p2/p3/g4              |  https://neo-ai-dlr-release.s3-us-west-2.amazonaws.com/v1.2.0/p3-x86_64-cu10-ubuntu18_04-glibc2_27-libstdpp3_4/dlr-1.2.0-py2.py3-none-any.whl             |
++--------------+---------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Amazon       | Deeplens                  |  https://neo-ai-dlr-release.s3-us-west-2.amazonaws.com/v1.1.0/deeplens-x86_64-igp-ubuntu16_04-glibc2_23-libstdcpp3_4/dlr-1.1.0-py2.py3-none-any.whl       |
++--------------+---------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Rockchips    | RK3399                    |  https://neo-ai-dlr-release.s3-us-west-2.amazonaws.com/v1.2.0/firefly-aarch64-mali-ubuntu16_04-glibc2_23-libstdcpp3_4/dlr-1.2.0-py2.py3-none-any.whl      |
++--------------+---------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+
 | NVIDIA       | Jetson TX1 (JetPack 4.3)  |  https://neo-ai-dlr-release.s3-us-west-2.amazonaws.com/v1.2.0/jetsontx1-aarch64-cu10-ubuntu18_04-glibc2_27-libstdcpp3_4/dlr-1.2.0-py2.py3-none-any.whl    |
-+--------------+--------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+
++--------------+---------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+
 | NVIDIA       | Jetson TX2 (JetPack 4.3)  |  https://neo-ai-dlr-release.s3-us-west-2.amazonaws.com/v1.2.0/jetsontx2-aarch64-cu10-ubuntu18_04-glibc2_27-libstdcpp3_4/dlr-1.2.0-py2.py3-none-any.whl    |
-+--------------+--------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+
++--------------+---------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+
 | NVIDIA       | Jetson Nano (JetPack 4.3) |  https://neo-ai-dlr-release.s3-us-west-2.amazonaws.com/v1.2.0/jetsonnano-aarch64-cu10-ubuntu18_04-glibc2_27-libstdcpp3_4/dlr-1.2.0-py2.py3-none-any.whl   |
-+--------------+--------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+
++--------------+---------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+
 | NVIDIA       |Jetson Xavier (JetPack 4.3)|  https://neo-ai-dlr-release.s3-us-west-2.amazonaws.com/v1.2.0/jetsonxavier-aarch64-cu10-ubuntu18_04-glibc2_27-libstdcpp3_4/dlr-1.2.0-py2.py3-none-any.whl |
-+--------------+--------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+
-| Raspberry    | Rasp3b       |  https://neo-ai-dlr-release.s3-us-west-2.amazonaws.com/v1.2.0/pi-armv7l-raspbian4.14.71-glibc2_24-libstdcpp3_4/dlr-1.2.0-py2.py3-none-any.whl             |
-+--------------+--------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+
++--------------+---------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Raspberry    | Rasp3b                    |  https://neo-ai-dlr-release.s3-us-west-2.amazonaws.com/v1.2.0/pi-armv7l-raspbian4.14.71-glibc2_24-libstdcpp3_4/dlr-1.2.0-py2.py3-none-any.whl             |
++--------------+---------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+
 
 If your device is not listed in the table, use table2. You will identify your device by the processor architecture, operating system, and versions of GLIBC and LIBSTDC++. Of note, DLR installation may depend on other configuration differences or even location of dependency libraries; if the provided wheel URL does not work, please consider compiling DLR from source (see `Building DLR from source`_ section).
 
@@ -163,7 +163,7 @@ If you do not have a system install of TensorRT, first download the relevant .ta
 Please follow instructions from https://docs.nvidia.com/deeplearning/tensorrt/install-guide/index.html#installing-tar to install TensorRT.
 Now, provide the extracted .tar.gz folder path to ``-DUSE_TENSORRT`` when configuring cmake.
 
-If you have a system install of TensorRT via Deb or RPM package, you can instead use ``-DUSE_TENSORRT=ON` which will find the install directory automatically.
+If you have a system install of TensorRT via Deb or RPM package, you can instead use ``-DUSE_TENSORRT=ON`` which will find the install directory automatically.
 
 .. code-block:: bash
 
@@ -272,8 +272,6 @@ Once done with above steps, invoke cmake with following commands to build Androi
     -DANDROID_PLATFORM=android-21
 
   make -j4
-  cd ../python
-  python3 setup.py install --user
 
 ``ANDROID_PLATFORM`` should correspond to ``minSdkVersion`` of your project. If ``ANDROID_PLATFORM`` is not set it will default to ``android-21``.
 

--- a/python/dlr/api.py
+++ b/python/dlr/api.py
@@ -51,6 +51,18 @@ def _is_module_found(name):
 # Wrapper class
 class DLRModel(IDLRModel):
     def __init__(self, model_path, dev_type=None, dev_id=None, error_log_file=None, use_default_dlr=False):
+        """
+        Load a Neo-compiled model.
+
+        Parameters
+        ----------
+        model_path : str
+            Full path to the directory containing the compiled model artifacts (.so, .params, .json)
+        dev_type : str
+            Device type ('cpu', 'gpu', or 'opencl')
+        dev_id : int
+            Device ID
+        """
         self.neo_logger = create_logger(log_file=error_log_file)
         try:
             # Find correct runtime implementation for the model
@@ -85,6 +97,14 @@ class DLRModel(IDLRModel):
             raise ex
 
     def run(self, input_values):
+        """
+        Run inference. Returns a list of np.ndarrays.
+
+        Parameters
+        ----------
+        input_values : np.ndarray or dict
+            A numpy array for a single input model or dict of input_name -> np.ndarray.
+        """
         try:
             return self._impl.run(input_values)
         except Exception as ex:

--- a/python/dlr/api.py
+++ b/python/dlr/api.py
@@ -60,8 +60,14 @@ class DLRModel(IDLRModel):
             Full path to the directory containing the compiled model artifacts (.so, .params, .json)
         dev_type : str
             Device type ('cpu', 'gpu', or 'opencl')
-        dev_id : int
-            Device ID
+        dev_id : int (optional)
+            Device ID. Default is 0.
+        error_log_file: str (optional)
+            File to log errors to.
+        use_default_dlr: bool
+            DLR will load libdlr.so from the compiled model artifacts if it is available. This
+            setting can override that behavior to use the system installed DLR when use_default_dlr
+            is True.
         """
         self.neo_logger = create_logger(log_file=error_log_file)
         try:
@@ -98,12 +104,24 @@ class DLRModel(IDLRModel):
 
     def run(self, input_values):
         """
-        Run inference. Returns a list of np.ndarrays.
+        Run inference with given input(s)
 
         Parameters
         ----------
-        input_values : np.ndarray or dict
-            A numpy array for a single input model or dict of input_name -> np.ndarray.
+        input_values : a single :py:class:`numpy.ndarray` or a dictionary
+            For decision tree models, provide a single :py:class:`numpy.ndarray`
+            to indicate a single input, as decision trees always accept only one
+            input.
+
+            For deep learning models, provide a dictionary where keys are input
+            names (of type :py:class:`str`) and values are input tensors (of type
+            :py:class:`numpy.ndarray`). Deep learning models allow more than one
+            input, so each input must have a unique name.
+
+        Returns
+        -------
+        out : :py:class:`numpy.ndarray`
+            Prediction result
         """
         try:
             return self._impl.run(input_values)
@@ -112,6 +130,13 @@ class DLRModel(IDLRModel):
             raise ex
 
     def get_input_names(self):
+        """
+        Get all input names
+
+        Returns
+        -------
+        out : list of :py:class:`str`
+        """
         try:
             return self._impl.get_input_names()
         except Exception as ex:
@@ -119,6 +144,17 @@ class DLRModel(IDLRModel):
             raise ex
 
     def get_input(self, name, shape=None):
+        """
+        Get the current value of an input.
+
+        Parameters
+        ----------
+        name : str
+            The name of an input
+        shape : np.array (optional)
+            If given, use as the shape of the returned array. Otherwise, the shape of
+            the returned array will be inferred from the last call to set_input().
+        """
         try:
             return self._impl.get_input(name, shape)
         except Exception as ex:
@@ -126,6 +162,13 @@ class DLRModel(IDLRModel):
             raise ex
 
     def get_output_names(self):
+        """
+        Get all output names. Only valid when the model has a metadata file.
+
+        Returns
+        -------
+        names : list of :py:class:`str`
+        """
         try:
             return self._impl.get_output_names()
         except Exception as ex:
@@ -133,6 +176,13 @@ class DLRModel(IDLRModel):
             raise ex
 
     def get_version(self):
+        """
+        Get version of loaded DLR library.
+
+        Returns
+        -------
+        version : str "{major}.{minor}.{patch}"
+        """
         try:
             return self._impl.get_version()
         except Exception as ex:
@@ -140,6 +190,13 @@ class DLRModel(IDLRModel):
             raise ex
 
     def has_metadata(self):
+        """
+        Whether the model has a metadata file which provides additional information such as output names.
+
+        Returns
+        -------
+        has_metadata : bool
+        """
         try:
             return self._impl.has_metadata()
         except Exception as ex:
@@ -147,6 +204,13 @@ class DLRModel(IDLRModel):
             raise ex
 
     def get_input_dtypes(self):
+        """
+        Get datatype of all inputs.
+
+        Returns
+        -------
+        dtypes : list of :py:class:`str`
+        """
         try:
             return self._impl.get_input_dtypes()
         except Exception as ex:
@@ -154,6 +218,13 @@ class DLRModel(IDLRModel):
             raise ex
 
     def get_output_dtypes(self):
+        """
+        Get datatype of all outputs.
+
+        Returns
+        -------
+        dtypes : list of :py:class:`str`
+        """
         try:
             return self._impl.get_output_dtypes()
         except Exception as ex:
@@ -161,6 +232,18 @@ class DLRModel(IDLRModel):
             raise ex
 
     def get_input_name(self, index):
+        """
+        Get the name of the input at the given index.
+
+        Parameters
+        ----------
+        index : int
+            Index of the input
+
+        Returns
+        -------
+        name : str
+        """
         try:
             return self._impl.get_input_name(index)
         except Exception as ex:
@@ -168,6 +251,18 @@ class DLRModel(IDLRModel):
             raise ex
 
     def get_output_name(self, index):
+        """
+        Get the name of the output at the given index. Only valid when the model has a metadata file.
+
+        Parameters
+        ----------
+        index : int
+            Index of the input
+
+        Returns
+        -------
+        name : str
+        """
         try:
             return self._impl.get_output_name(index)
         except Exception as ex:
@@ -175,6 +270,18 @@ class DLRModel(IDLRModel):
             raise ex
 
     def get_input_dtype(self, index):
+        """
+        Get the type of the input at the given index.
+
+        Parameters
+        ----------
+        index : int
+            Index of the input
+
+        Returns
+        -------
+        type : str
+        """
         try:
             return self._impl.get_input_dtype(index)
         except Exception as ex:
@@ -182,9 +289,20 @@ class DLRModel(IDLRModel):
             raise ex
 
     def get_output_dtype(self, index):
+        """
+        Get the type of the output at the given index.
+
+        Parameters
+        ----------
+        index : int
+            Index of the input
+
+        Returns
+        -------
+        type : str
+        """
         try:
             return self._impl.get_output_dtype(index)
         except Exception as ex:
             self.neo_logger.exception("error in getting output data type {} {}".format(self._impl.__class__.__name__, ex))
             raise ex
-


### PR DESCRIPTION
Our python docs are generated from DLRModel base classes which has no documentation: https://neo-ai-dlr.readthedocs.io/en/latest/python-api.html

Added documentation to DLRModel class so that we will generate useful docs.


Also fix invalid table in install.rst