### PR TITLE
Move DLRModel declaration from dlr_common.h -> dlr_model.h.

### DIFF
--- a/include/dlr_common.h
+++ b/include/dlr_common.h
@@ -5,8 +5,8 @@
 #include <dmlc/logging.h>
 #include <runtime_base.h>
 #include <sys/types.h>
-#include <nlohmann/json.hpp>
 
+#include <nlohmann/json.hpp>
 #include <string>
 #include <vector>
 
@@ -32,7 +32,7 @@ namespace dlr {
 
 /* The following file names are reserved by SageMaker and should not be used
  * as model JSON */
-constexpr const char* SAGEMAKER_AUXILIARY_JSON_FILES[] = {"model-shapes.json",
+constexpr const char *SAGEMAKER_AUXILIARY_JSON_FILES[] = {"model-shapes.json",
                                                           "hyperparams.json"};
 
 typedef struct {
@@ -43,20 +43,20 @@ typedef struct {
   std::string metadata;
 } ModelPath;
 
-void ListDir(const std::string& dirname, std::vector<std::string>& paths);
+void ListDir(const std::string &dirname, std::vector<std::string> &paths);
 
-std::string GetBasename(const std::string& path);
+std::string GetBasename(const std::string &path);
 
-std::string GetParentFolder(const std::string& path);
+std::string GetParentFolder(const std::string &path);
 
-void LoadJsonFromFile(const std::string& path, nlohmann::json& jsonObject);
+void LoadJsonFromFile(const std::string &path, nlohmann::json &jsonObject);
 
-inline bool StartsWith(const std::string& mainStr, const std::string& toMatch) {
+inline bool StartsWith(const std::string &mainStr, const std::string &toMatch) {
   return mainStr.size() >= toMatch.size() &&
-  mainStr.compare(0, toMatch.size(), toMatch) == 0;
+         mainStr.compare(0, toMatch.size(), toMatch) == 0;
 }
 
-inline bool EndsWith(const std::string& mainStr, const std::string& toMatch) {
+inline bool EndsWith(const std::string &mainStr, const std::string &toMatch) {
   if (mainStr.size() >= toMatch.size() &&
       mainStr.compare(mainStr.size() - toMatch.size(), toMatch.size(),
                       toMatch) == 0)
@@ -74,59 +74,6 @@ DLRBackend GetBackend(std::vector<std::string> dirname);
 #define CHECK_SHAPE(msg, value, expected) \
   CHECK_EQ(value, expected)               \
       << (msg) << ". Value read: " << (value) << ", Expected: " << (expected);
-
-// Abstract class
-class DLRModel {
- protected:
-  std::string version_;
-  DLRBackend backend_;
-  size_t num_inputs_ = 1;
-  size_t num_weights_ = 0;
-  size_t num_outputs_ = 1;
-  DLContext ctx_;
-  std::vector<std::string> input_names_;
-  std::vector<std::string> input_types_;
-
- public:
-  DLRModel(const DLContext& ctx, const DLRBackend& backend)
-      : ctx_(ctx), backend_(backend) {}
-  virtual ~DLRModel() {}
-
-  /* Input related functions */
-  virtual int GetNumInputs() const { return num_inputs_; }
-  virtual const char* GetInputName(int index) const = 0;
-  virtual const char* GetInputType(int index) const = 0;
-  virtual void GetInput(const char* name, void* input) = 0;
-  virtual void SetInput(const char* name, const int64_t* shape, void* input, int dim) = 0;
-
-  /* Ouput related functions */
-  virtual int GetNumOutputs() { return num_outputs_; }
-  virtual const char* GetOutputName(const int index) const { 
-    LOG(ERROR) << "GetOutputName is not supported yet!";
-  }
-  virtual int GetOutputIndex(const char* name) const { 
-    LOG(ERROR) << "GetOutputName is not supported yet!";
-  }
-  virtual const char* GetOutputType(int index) const = 0;
-  virtual void GetOutputShape(int index, int64_t* shape) const = 0;
-  virtual void GetOutputSizeDim(int index, int64_t* size, int* dim) = 0;
-  virtual void GetOutput(int index, void* out) = 0;
-  virtual void GetOutputByName(const char* name, void* out) {
-    LOG(ERROR) << "GetOutputByName is not supported yet!";
-  }
-  
-  /* Weights releated functions */
-  virtual int GetNumWeights() const { return num_weights_; }
-  virtual const char* GetWeightName(int index) const = 0;
-  virtual std::vector<std::string> GetWeightNames() const = 0;
-  
-  virtual const char* GetBackend() const = 0;
-  virtual void SetNumThreads(int threads) = 0;
-  virtual bool HasMetadata() const {return false; }
-  virtual void UseCPUAffinity(bool use) = 0;
-  virtual void Run() = 0;
-  
-};
 
 }  // namespace dlr
 

--- a/include/dlr_hexagon/dlr_hexagon.h
+++ b/include/dlr_hexagon/dlr_hexagon.h
@@ -1,7 +1,7 @@
 #ifndef DLR_HEXAGON_H_
 #define DLR_HEXAGON_H_
 
-#include "dlr_common.h"
+#include "dlr_model.h"
 
 namespace dlr {
 

--- a/include/dlr_model.h
+++ b/include/dlr_model.h
@@ -1,0 +1,61 @@
+#ifndef DLR_MODEL_H_
+#define DLR_MODEL_H_
+
+#include "dlr_common.h"
+
+namespace dlr {
+// Abstract class
+class DLRModel {
+ protected:
+  std::string version_;
+  DLRBackend backend_;
+  size_t num_inputs_ = 1;
+  size_t num_weights_ = 0;
+  size_t num_outputs_ = 1;
+  DLContext ctx_;
+  std::vector<std::string> input_names_;
+  std::vector<std::string> input_types_;
+
+ public:
+  DLRModel(const DLContext &ctx, const DLRBackend &backend)
+      : ctx_(ctx), backend_(backend) {}
+  virtual ~DLRModel() {}
+
+  /* Input related functions */
+  virtual int GetNumInputs() const { return num_inputs_; }
+  virtual const char *GetInputName(int index) const = 0;
+  virtual const char *GetInputType(int index) const = 0;
+  virtual void GetInput(const char *name, void *input) = 0;
+  virtual void SetInput(const char *name, const int64_t *shape, void *input,
+                        int dim) = 0;
+
+  /* Ouput related functions */
+  virtual int GetNumOutputs() { return num_outputs_; }
+  virtual const char *GetOutputName(const int index) const {
+    LOG(ERROR) << "GetOutputName is not supported yet!";
+  }
+  virtual int GetOutputIndex(const char *name) const {
+    LOG(ERROR) << "GetOutputName is not supported yet!";
+  }
+  virtual const char *GetOutputType(int index) const = 0;
+  virtual void GetOutputShape(int index, int64_t *shape) const = 0;
+  virtual void GetOutputSizeDim(int index, int64_t *size, int *dim) = 0;
+  virtual void GetOutput(int index, void *out) = 0;
+  virtual void GetOutputByName(const char *name, void *out) {
+    LOG(ERROR) << "GetOutputByName is not supported yet!";
+  }
+
+  /* Weights releated functions */
+  virtual int GetNumWeights() const { return num_weights_; }
+  virtual const char *GetWeightName(int index) const = 0;
+  virtual std::vector<std::string> GetWeightNames() const = 0;
+
+  virtual const char *GetBackend() const = 0;
+  virtual void SetNumThreads(int threads) = 0;
+  virtual bool HasMetadata() const { return false; }
+  virtual void UseCPUAffinity(bool use) = 0;
+  virtual void Run() = 0;
+};
+}  // namespace dlr
+
+#endif  // DLR_MODEL_H_

--- a/include/dlr_treelite.h
+++ b/include/dlr_treelite.h
@@ -3,7 +3,7 @@
 
 #include <treelite/c_api_runtime.h>
 
-#include "dlr_common.h"
+#include "dlr_model.h"
 
 namespace dlr {
 

--- a/include/dlr_tvm.h
+++ b/include/dlr_tvm.h
@@ -3,7 +3,7 @@
 
 #include <graph/graph_runtime.h>
 #include <tvm/runtime/memory.h>
-#include "dlr_common.h"
+#include "dlr_model.h"
 
 namespace dlr {
 

--- a/src/dlr.cc
+++ b/src/dlr.cc
@@ -1,6 +1,6 @@
 #include "dlr.h"
 
-#include "dlr_common.h"
+#include "dlr_model.h"
 #include "dlr_treelite.h"
 #include "dlr_tvm.h"
 #ifdef DLR_HEXAGON


### PR DESCRIPTION
This PR contains housekeep changes to reduce the code footprint for refactor.

We will be deprecating support for Tensorflow and TFLite models going forward. This PR deletes all the C - Code related to Tensorflow and TFLite frameworks. The python implementation is independent of C++ and will be refactored along with rest of the python code.

The PR also moves DLRModel base class declaration from dlr_common.h to dlr_model.h to keep the declaration consistent with file names.

Thanks for contributing to DLR! By submitting this pull request, you confirm that your contribution is made under the terms of the [Apache 2.0 license](https://github.com/neo-ai/neo-ai-dlr/blob/master/LICENSE).

Please refer to our [guideline](https://github.com/neo-ai/neo-ai-dlr/blob/master/CONTRIBUTING.md) for useful information and tips.
