### PR TITLE
Ignore libdlr from the model artifacts.

### DIFF
--- a/include/dlr_common.h
+++ b/include/dlr_common.h
@@ -19,13 +19,16 @@
 
 #endif
 
-/* OS-specific library file extension */
+/* OS-specific library file extension and the name of the generated dynamic library*/
 #ifdef _WIN32
 #define LIBEXT ".dll"
+#define LIBDLR "dlr.dll"
 #elif __APPLE__
 #define LIBEXT ".dylib"
+#define LIBDLR "libdlr.dylib"
 #else
 #define LIBEXT ".so"
+#define LIBDLR "libdlr.so"
 #endif
 
 namespace dlr {

--- a/src/dlr_treelite.cc
+++ b/src/dlr_treelite.cc
@@ -34,7 +34,7 @@ ModelPath dlr::GetTreelitePaths(std::vector<std::string> dirname) {
     ListDir(dir, paths_vec);
   }
   for (auto filename : paths_vec) {
-    if (EndsWith(filename, LIBEXT)) {
+    if (filename != LIBDLR && EndsWith(filename, LIBEXT)) {
       paths.model_lib = filename;
     } else if (filename == "version.json") {
       paths.ver_json = filename;

--- a/src/dlr_tvm.cc
+++ b/src/dlr_tvm.cc
@@ -22,7 +22,7 @@ ModelPath dlr::GetTvmPaths(std::vector<std::string> dirname) {
             [basename](const std::string& s) { return (s != basename); }) &&
         filename != "version.json") {
       paths.model_json = filename;
-    } else if (EndsWith(filename, LIBEXT)) {
+    } else if (filename != LIBDLR && EndsWith(filename, LIBEXT)) {
       paths.model_lib = filename;
     } else if (EndsWith(filename, ".tensorrt")) {
       paths.model_lib = filename;


### PR DESCRIPTION
Since we are shipping libdlr as part of model artifacts we want to prevent dlr from using the libdlr as compiled model file.

## Tested in notebook.

```python
from dlr import DLRModel
```


```python
dlm = DLRModel("./xgboost/")
```

    2020-06-24 22:14:44,938 INFO Found libdlr.so in model artifact. Using dlr from ./xgboost/libdlr.so
    2020-06-24 22:14:44,938 INFO Found libdlr.so in model artifact. Using dlr from ./xgboost/libdlr.so



```python
dlm.get_input_dtypes()
```




    ['float32']




```python
dlm.get_input_names()
```




    ['data']




```python
dlm.get_input_dtype(0)
```




    'float32'




```python
dlm.get_output_dtype(0)
```




    'float32'





Thanks for contributing to DLR! By submitting this pull request, you confirm that your contribution is made under the terms of the [Apache 2.0 license](https://github.com/neo-ai/neo-ai-dlr/blob/master/LICENSE).

Please refer to our [guideline](https://github.com/neo-ai/neo-ai-dlr/blob/master/CONTRIBUTING.md) for useful information and tips.
