### PR TITLE
Added unit tests for treelite model.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -467,6 +467,22 @@ if(NOT(AAR_BUILD))
     # this is OS-agnostic
     execute_process(COMMAND ${CMAKE_COMMAND} -E tar -xf /tmp/resnet_v1.5_50-ml_c4.tar.gz
                     WORKING_DIRECTORY ${RESNET_MODEL})
+    file(REMOVE /tmp/resnet_v1.5_50-ml_c4.tar.gz)
+  endif()
+
+  set(XGBOOST_TEST_MODEL ${CMAKE_CURRENT_BINARY_DIR}/xgboost_test)
+  if(NOT IS_DIRECTORY ${XGBOOST_TEST_MODEL})
+    file(MAKE_DIRECTORY ${XGBOOST_TEST_MODEL})
+    download_file(
+      https://neo-ai-dlr-test-artifacts.s3-us-west-2.amazonaws.com/compiled-models/xgboost_test.tar.gz
+      /tmp/xgboost_test.tar.gz
+      SHA1
+      4c8ac5f20db6c7c6d674dd2ac9d9e14ce887281e
+    )
+    # this is OS-agnostic
+    execute_process(COMMAND ${CMAKE_COMMAND} -E tar -xf /tmp/xgboost_test.tar.gz
+                    WORKING_DIRECTORY ${XGBOOST_TEST_MODEL})
+    file(REMOVE /tmp/xgboost_test.tar.gz)
   endif()
 
 

--- a/tests/cpp/dlr_treelite_test.cc
+++ b/tests/cpp/dlr_treelite_test.cc
@@ -1,13 +1,95 @@
+#include "dlr_treelite.h"
+
 #include <gtest/gtest.h>
 
-#include "dlr.h"
-
-TEST(Treelite, Test1) { EXPECT_EQ(1, 1); }
-
-int main(int argc, char** argv) {
+int main(int argc, char **argv) {
   testing::InitGoogleTest(&argc, argv);
 #ifndef _WIN32
   testing::FLAGS_gtest_death_test_style = "threadsafe";
 #endif  // _WIN32
   return RUN_ALL_TESTS();
+}
+
+class TreeliteTest : public ::testing::Test {
+ protected:
+  float *data;
+  const int64_t in_size = 69;
+  const int in_dim = 2;
+  const int64_t in_shape[2] = {1, 69};
+  const int64_t out_size = 1;
+  const int out_dim = 2;
+
+  dlr::TreeliteModel *model;
+
+  TreeliteTest() {
+    // Setup input data
+    data = new float[in_size];
+    for (auto i = 0; i < in_size; i++) {
+      data[i] = static_cast<float>(rand()) / static_cast<float>(RAND_MAX);
+    }
+
+    // Instantiate model
+    const int device_type = 1;
+    const int device_id = 0;
+    DLContext ctx = {static_cast<DLDeviceType>(device_type), device_id};
+    std::vector<std::string> paths = {"./xgboost_test"};
+    model = new dlr::TreeliteModel(paths, ctx);
+  }
+
+  ~TreeliteTest() {
+    delete model;
+    delete data;
+  }
+};
+
+TEST_F(TreeliteTest, TestGetNumInputs) { EXPECT_EQ(model->GetNumInputs(), 1); }
+
+TEST_F(TreeliteTest, TestGetInputName) {
+  EXPECT_STREQ(model->GetInputName(0), "data");
+}
+
+TEST_F(TreeliteTest, TestGetInputType) {
+  EXPECT_STREQ(model->GetInputType(0), "float32");
+}
+
+TEST_F(TreeliteTest, TestGetInput) {
+  EXPECT_NO_THROW(model->SetInput("data", in_shape, data, in_dim));
+  try {
+    float observed_input_data[in_size];
+    model->GetInput("data", observed_input_data);
+  } catch (std::exception &e) {
+    std::string err_msg{e.what()};
+    EXPECT_TRUE(err_msg.find("GetInput is not supported by Treelite backend"));
+  }
+}
+
+TEST_F(TreeliteTest, TestGetNumOutputs) {
+  EXPECT_EQ(model->GetNumOutputs(), 1);
+}
+
+TEST_F(TreeliteTest, TestGetOutputType) {
+  EXPECT_STREQ(model->GetOutputType(0), "float32");
+}
+
+TEST_F(TreeliteTest, TestGetOutputShape) {
+  EXPECT_NO_THROW(model->SetInput("data", in_shape, data, in_dim));
+  int64_t out_shape[2];
+  EXPECT_NO_THROW(model->GetOutputShape(0, out_shape));
+  EXPECT_EQ(out_shape[0], 1);
+  EXPECT_EQ(out_shape[1], 1);
+}
+
+TEST_F(TreeliteTest, TestGetOutputSizeDim) {
+  int64_t output_size;
+  int output_dim;
+  EXPECT_NO_THROW(model->GetOutputSizeDim(0, &output_size, &output_dim));
+  EXPECT_EQ(output_size, out_size);
+  EXPECT_EQ(output_dim, out_dim);
+}
+
+TEST_F(TreeliteTest, TestGetOutput) {
+  EXPECT_NO_THROW(model->SetInput("data", in_shape, data, in_dim));
+  EXPECT_NO_THROW(model->Run());
+  float output[1];
+  EXPECT_NO_THROW(model->GetOutput(0, output));
 }


### PR DESCRIPTION
This PR adds unit tests for treelite model.
Output of ./dlr_treelite_test
```bash
[==========] Running 9 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 9 tests from TreeliteTest
[ RUN      ] TreeliteTest.TestGetNumInputs
[       OK ] TreeliteTest.TestGetNumInputs (29 ms)
[ RUN      ] TreeliteTest.TestGetInputName
[       OK ] TreeliteTest.TestGetInputName (18 ms)
[ RUN      ] TreeliteTest.TestGetInputType
[       OK ] TreeliteTest.TestGetInputType (18 ms)
[ RUN      ] TreeliteTest.TestGetInput
[       OK ] TreeliteTest.TestGetInput (29 ms)
[ RUN      ] TreeliteTest.TestGetNumOutputs
[       OK ] TreeliteTest.TestGetNumOutputs (13 ms)
[ RUN      ] TreeliteTest.TestGetOutputType
[       OK ] TreeliteTest.TestGetOutputType (20 ms)
[ RUN      ] TreeliteTest.TestGetOutputShape
[       OK ] TreeliteTest.TestGetOutputShape (19 ms)
[ RUN      ] TreeliteTest.TestGetOutputSizeDim
[       OK ] TreeliteTest.TestGetOutputSizeDim (29 ms)
[ RUN      ] TreeliteTest.TestGetOutput
[       OK ] TreeliteTest.TestGetOutput (15 ms)
[----------] 9 tests from TreeliteTest (194 ms total)

[----------] Global test environment tear-down
[==========] 9 tests from 1 test case ran. (194 ms total)
[  PASSED  ] 9 tests.
```

Thanks for contributing to DLR! By submitting this pull request, you confirm that your contribution is made under the terms of the [Apache 2.0 license](https://github.com/neo-ai/neo-ai-dlr/blob/master/LICENSE).

Please refer to our [guideline](https://github.com/neo-ai/neo-ai-dlr/blob/master/CONTRIBUTING.md) for useful information and tips.
