### PR TITLE
Fix undefined behavior with GetDLRVersion.

### DIFF
--- a/src/dlr.cc
+++ b/src/dlr.cc
@@ -329,9 +329,9 @@ extern "C" int GetDLRBackend(DLRModelHandle* handle, const char** name) {
 
 extern "C" int GetDLRVersion(const char** out) {
   API_BEGIN();
-  std::string version_str = std::to_string(DLR_MAJOR) + "." +
-                            std::to_string(DLR_MINOR) + "." +
-                            std::to_string(DLR_PATCH);
+  static const std::string version_str = std::to_string(DLR_MAJOR) + "." +
+                                         std::to_string(DLR_MINOR) + "." +
+                                         std::to_string(DLR_PATCH);
   *out = version_str.c_str();
   API_END();
 }


### PR DESCRIPTION
GetDLRVersion builds a new string to hold the version and then returns a pointer to it. The string goes out of scope when the function returns, so accessing the pointer is  undefined behavior.

Make version_str static so it persists after GetDLRVersion returns, so that the output pointer is still valid.


The current code can give errors like:
```
 ERROR error in DLRModel instantiation 'utf-8' codec can't decode byte 0x90 in position 0: invalid start byte
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/dist-packages/dlr/api.py", line 82, in __init__
    self._impl = DLRModelImpl(model_path, dev_type, dev_id)
  File "/usr/local/lib/python3.6/dist-packages/dlr/dlr_model.py", line 118, in __init__
    self.version = self._get_version()
  File "/usr/local/lib/python3.6/dist-packages/dlr/dlr_model.py", line 97, in _get_version
    return version.value.decode('utf-8')
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x90 in position 0: invalid start byte
```
