### PR TITLE
Fixed dlr.cc mistake

### DIFF
--- a/src/dlr.cc
+++ b/src/dlr.cc
@@ -135,7 +135,6 @@ extern "C" int GetDLROutputName(DLRModelHandle* handle, const int index, const c
   API_BEGIN();
   DLRModel* model = static_cast<DLRModel*>(*handle);
   CHECK(model != nullptr) << "model is nullptr, create it first";
-  *name = model->GetOutputName(index);
   try {
     *name = model->GetOutputName(index);
   } catch (dmlc::Error& e) {


### PR DESCRIPTION
Duplicate GetOutput is outside of the try catch block seems like a miss or merge conflict.

Thanks for contributing to DLR! By submitting this pull request, you confirm that your contribution is made under the terms of the [Apache 2.0 license](https://github.com/neo-ai/neo-ai-dlr/blob/master/LICENSE).

Please refer to our [guideline](https://github.com/neo-ai/neo-ai-dlr/blob/master/CONTRIBUTING.md) for useful information and tips.
