### PR TITLE
Support RelayVM models in DLR.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,8 @@
+# Run the following command to reformat a file:
+# clang-format -i -style=Google <file>
+# Or use clang-format-diff to only reformat the changed lines:
+# https://clang.llvm.org/docs/ClangFormat.html
+BasedOnStyle: Google
+DerivePointerAlignment: false
+ColumnLimit:     100
+PointerAlignment: Left

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -434,6 +434,16 @@ if(NOT(AAR_BUILD))
   )
   endif()
   
+  set(STREET_IMAGE ${CMAKE_CURRENT_BINARY_DIR}/street_small.npy)
+  if(NOT EXISTS ${STREET_IMAGE})
+  download_file(
+    https://neo-ai-dlr-test-artifacts.s3-us-west-2.amazonaws.com/test-data/street_small.npy
+    ${STREET_IMAGE}
+    SHA1
+    206d1a12646a5fe43d0877d38bd137c70a5adc3b
+  )
+  endif()
+  
   # Download compiled model for unit tests
   set(RESNET_MODEL ${CMAKE_CURRENT_BINARY_DIR}/resnet_v1_5_50)
   if(NOT IS_DIRECTORY ${RESNET_MODEL})
@@ -465,6 +475,23 @@ if(NOT(AAR_BUILD))
     file(REMOVE /tmp/xgboost_test.tar.gz)
   endif()
 
+  set(RELAYVM_MODEL ssd_mobilenet_v2.tar.gz)
+  set(RELAYVM_MODEL_DIR ${CMAKE_CURRENT_BINARY_DIR}/ssd_mobilenet_v2)
+  if(NOT IS_DIRECTORY ${RELAYVM_MODEL_DIR})
+    file(MAKE_DIRECTORY ${RELAYVM_MODEL_DIR})
+    download_file(
+      https://neo-ai-dlr-test-artifacts.s3-us-west-2.amazonaws.com/compiled-models/${RELAYVM_MODEL}
+      /tmp/${RELAYVM_MODEL}
+      SHA1
+      477a6479fdd510703de9c190bbf4b95cf5f1d22e
+    )
+    # this is OS-agnostic
+    execute_process(COMMAND ${CMAKE_COMMAND} -E tar -xf /tmp/${RELAYVM_MODEL}
+                    WORKING_DIRECTORY ${RELAYVM_MODEL_DIR})
+    file(REMOVE /tmp/${RELAYVM_MODEL})
+  endif()
+
+  
 
   if(WITH_TENSORFLOW_LITE_LIB)
       # Download Test TFLite model

--- a/include/dlr_common.h
+++ b/include/dlr_common.h
@@ -50,11 +50,14 @@ typedef struct {
   std::string model_json;
   std::string ver_json;
   std::string metadata;
+  std::string relay_executable;
 } ModelPath;
 
 void ListDir(const std::string& dirname, std::vector<std::string>& paths);
 
 std::string GetBasename(const std::string& path);
+
+bool IsFileEmpty(const std::string& filePath);
 
 std::string GetParentFolder(const std::string& path);
 
@@ -74,7 +77,7 @@ inline bool EndsWith(const std::string& mainStr, const std::string& toMatch) {
     return false;
 }
 
-enum class DLRBackend { kTVM, kTREELITE, kTFLITE, kTENSORFLOW, kHEXAGON };
+enum class DLRBackend { kTVM, kTREELITE, kTFLITE, kTENSORFLOW, kHEXAGON, kRELAYVM };
 
 /*! \brief Get the backend based on the contents of the model folder.
  */
@@ -123,7 +126,7 @@ class DLR_DLL DLRModel {
   virtual void GetOutputSizeDim(int index, int64_t* size, int* dim) = 0;
   virtual void GetOutput(int index, void* out) = 0;
   virtual void GetOutputByName(const char* name, void* out) {
-    LOG(ERROR) << "GetOutputByName is not supported yet!";
+    throw dmlc::Error("GetOutputByName is not supported yet!");
   }
   
   /* Weights releated functions */

--- a/include/dlr_relayvm.h
+++ b/include/dlr_relayvm.h
@@ -35,7 +35,7 @@ class RelayVMModel : public DLRModel {
   DLDataType GetInputDLDataType(int index);
 
  public:
-  explicit RelayVMModel(std::vector<std::string> paths, const DLContext &ctx)
+  explicit RelayVMModel(std::vector<std::string> paths, const DLContext& ctx)
       : DLRModel(ctx, DLRBackend::kRELAYVM) {
     InitModelPath(paths);
     LoadMetadata();
@@ -44,21 +44,20 @@ class RelayVMModel : public DLRModel {
     FetchOutputNodesData();
   }
 
-  int GetInputIndex(const char *name) const;
-  virtual const char *GetInputName(int index) const override;
-  virtual const char *GetInputType(int index) const override;
-  virtual const char *GetWeightName(int index) const override;
+  int GetInputIndex(const char* name) const;
+  virtual const char* GetInputName(int index) const override;
+  virtual const char* GetInputType(int index) const override;
+  virtual const char* GetWeightName(int index) const override;
   virtual std::vector<std::string> GetWeightNames() const override;
-  virtual void GetInput(const char *name, void *input) override;
-  virtual void SetInput(const char *name, const int64_t *shape, void *input,
-                        int dim) override;
+  virtual void GetInput(const char* name, void* input) override;
+  virtual void SetInput(const char* name, const int64_t* shape, void* input, int dim) override;
   virtual void Run() override;
   tvm::runtime::NDArray GetOutput(int index);
-  virtual void GetOutput(int index, void *out) override;
-  virtual void GetOutputShape(int index, int64_t *shape) const override;
-  virtual void GetOutputSizeDim(int index, int64_t *size, int *dim) override;
-  virtual const char *GetOutputType(int index) const override;
-  virtual const char *GetBackend() const override;
+  virtual void GetOutput(int index, void* out) override;
+  virtual void GetOutputShape(int index, int64_t* shape) const override;
+  virtual void GetOutputSizeDim(int index, int64_t* size, int* dim) override;
+  virtual const char* GetOutputType(int index) const override;
+  virtual const char* GetBackend() const override;
   virtual void SetNumThreads(int threads) override;
   virtual void UseCPUAffinity(bool use) override;
 
@@ -66,9 +65,9 @@ class RelayVMModel : public DLRModel {
     Following methods use metadata file to lookup input and output names.
   */
   virtual bool HasMetadata() const override;
-  virtual const char *GetOutputName(const int index) const override;
-  virtual int GetOutputIndex(const char *name) const override;
-  virtual void GetOutputByName(const char *name, void *out) override;
+  virtual const char* GetOutputName(const int index) const override;
+  virtual int GetOutputIndex(const char* name) const override;
+  virtual void GetOutputByName(const char* name, void* out) override;
 };
 
 }  // namespace dlr

--- a/include/dlr_relayvm.h
+++ b/include/dlr_relayvm.h
@@ -13,7 +13,6 @@
 
 namespace dlr {
 
-
 class RelayVMModel : public DLRModel {
  private:
   static const std::string ENTRY_FUNCTION;
@@ -36,7 +35,7 @@ class RelayVMModel : public DLRModel {
   DLDataType GetInputDLDataType(int index);
 
  public:
-  explicit RelayVMModel(std::vector<std::string> paths, const DLContext& ctx)
+  explicit RelayVMModel(std::vector<std::string> paths, const DLContext &ctx)
       : DLRModel(ctx, DLRBackend::kRELAYVM) {
     InitModelPath(paths);
     LoadMetadata();
@@ -45,21 +44,21 @@ class RelayVMModel : public DLRModel {
     FetchOutputNodesData();
   }
 
-  int GetInputIndex(const char* name) const;
-  virtual const char* GetInputName(int index) const override;
-  virtual const char* GetInputType(int index) const override;
-  virtual const char* GetWeightName(int index) const override;
+  int GetInputIndex(const char *name) const;
+  virtual const char *GetInputName(int index) const override;
+  virtual const char *GetInputType(int index) const override;
+  virtual const char *GetWeightName(int index) const override;
   virtual std::vector<std::string> GetWeightNames() const override;
-  virtual void GetInput(const char* name, void* input) override;
-  virtual void SetInput(const char* name, const int64_t* shape, void* input,
+  virtual void GetInput(const char *name, void *input) override;
+  virtual void SetInput(const char *name, const int64_t *shape, void *input,
                         int dim) override;
   virtual void Run() override;
   tvm::runtime::NDArray GetOutput(int index);
-  virtual void GetOutput(int index, void* out) override;
-  virtual void GetOutputShape(int index, int64_t* shape) const override;
-  virtual void GetOutputSizeDim(int index, int64_t* size, int* dim) override;
-  virtual const char* GetOutputType(int index) const override;
-  virtual const char* GetBackend() const override;
+  virtual void GetOutput(int index, void *out) override;
+  virtual void GetOutputShape(int index, int64_t *shape) const override;
+  virtual void GetOutputSizeDim(int index, int64_t *size, int *dim) override;
+  virtual const char *GetOutputType(int index) const override;
+  virtual const char *GetBackend() const override;
   virtual void SetNumThreads(int threads) override;
   virtual void UseCPUAffinity(bool use) override;
 
@@ -67,9 +66,9 @@ class RelayVMModel : public DLRModel {
     Following methods use metadata file to lookup input and output names.
   */
   virtual bool HasMetadata() const override;
-  virtual const char* GetOutputName(const int index) const override;
-  virtual int GetOutputIndex(const char* name) const override;
-  virtual void GetOutputByName(const char* name, void* out) override;
+  virtual const char *GetOutputName(const int index) const override;
+  virtual int GetOutputIndex(const char *name) const override;
+  virtual void GetOutputByName(const char *name, void *out) override;
 };
 
 }  // namespace dlr

--- a/include/dlr_relayvm.h
+++ b/include/dlr_relayvm.h
@@ -1,0 +1,77 @@
+#ifndef DLR_RELAYVM_H_
+#define DLR_RELAYVM_H_
+
+#include <dlpack/dlpack.h>
+#include <tvm/runtime/container.h>
+#include <tvm/runtime/module.h>
+#include <tvm/runtime/ndarray.h>
+#include <tvm/runtime/object.h>
+#include <tvm/runtime/packed_func.h>
+#include <tvm/runtime/registry.h>
+#include <tvm/runtime/vm.h>
+#include "dlr_common.h"
+
+namespace dlr {
+
+
+class RelayVMModel : public DLRModel {
+ private:
+  static const std::string ENTRY_FUNCTION;
+  std::vector<std::string> output_names_;
+  std::vector<std::string> output_types_;
+  nlohmann::json metadata_;
+  std::unique_ptr<ModelPath> path_;
+  std::shared_ptr<tvm::runtime::Module> vm_module_;
+  std::shared_ptr<tvm::runtime::Module> vm_executable_;
+  std::vector<tvm::runtime::NDArray> inputs_;
+  tvm::runtime::ObjectRef output_ref_;
+  std::vector<tvm::runtime::NDArray> outputs_;
+  void InitModelPath(std::vector<std::string> paths);
+  void SetupVMModule();
+  void FetchInputNodesData();
+  void LoadMetadata();
+  void FetchOutputNodesData();
+  void UpdateOutputs();
+  void UpdateInputs();
+  DLDataType GetInputDLDataType(int index);
+
+ public:
+  explicit RelayVMModel(std::vector<std::string> paths, const DLContext& ctx)
+      : DLRModel(ctx, DLRBackend::kRELAYVM) {
+    InitModelPath(paths);
+    LoadMetadata();
+    SetupVMModule();
+    FetchInputNodesData();
+    FetchOutputNodesData();
+  }
+
+  int GetInputIndex(const char* name) const;
+  virtual const char* GetInputName(int index) const override;
+  virtual const char* GetInputType(int index) const override;
+  virtual const char* GetWeightName(int index) const override;
+  virtual std::vector<std::string> GetWeightNames() const override;
+  virtual void GetInput(const char* name, void* input) override;
+  virtual void SetInput(const char* name, const int64_t* shape, void* input,
+                        int dim) override;
+  virtual void Run() override;
+  tvm::runtime::NDArray GetOutput(int index);
+  virtual void GetOutput(int index, void* out) override;
+  virtual void GetOutputShape(int index, int64_t* shape) const override;
+  virtual void GetOutputSizeDim(int index, int64_t* size, int* dim) override;
+  virtual const char* GetOutputType(int index) const override;
+  virtual const char* GetBackend() const override;
+  virtual void SetNumThreads(int threads) override;
+  virtual void UseCPUAffinity(bool use) override;
+
+  /*
+    Following methods use metadata file to lookup input and output names.
+  */
+  virtual bool HasMetadata() const override;
+  virtual const char* GetOutputName(const int index) const override;
+  virtual int GetOutputIndex(const char* name) const override;
+  virtual void GetOutputByName(const char* name, void* out) override;
+};
+
+}  // namespace dlr
+
+#endif  // DLR_RELAYVM_H_

--- a/python/dlr/dlr_model.py
+++ b/python/dlr/dlr_model.py
@@ -122,7 +122,8 @@ class DLRModelImpl(IDLRModel):
             self.weight_names.append(self._get_weight_name(i))
 
         self.num_outputs = self._get_num_outputs()
-        self._lazy_init_output_shape()
+        if self.backend != "relayvm":
+            self._lazy_init_output_shape()
         self._fetch_input_names()
         self._fetch_output_names()
         self._fetch_input_dtypes()
@@ -348,6 +349,8 @@ class DLRModelImpl(IDLRModel):
     def _run(self):
         """A light wrapper to call run in the DLR backend."""
         self._check_call(self._lib.RunDLRModel(byref(self.handle)))
+        if self.backend == "relayvm":
+            self._lazy_init_output_shape()
 
     def _get_num_outputs(self):
         """Get the number of outputs of a network"""

--- a/src/dlr.cc
+++ b/src/dlr.cc
@@ -3,6 +3,7 @@
 #include "dlr_common.h"
 #include "dlr_treelite.h"
 #include "dlr_tvm.h"
+#include "dlr_relayvm.h"
 #ifdef DLR_TFLITE
 #include "dlr_tflite/dlr_tflite.h"
 #endif  // DLR_TFLITE
@@ -260,6 +261,8 @@ extern "C" int CreateDLRModel(DLRModelHandle* handle, const char* model_path,
   DLRModel* model;
   if (backend == DLRBackend::kTVM) {
     model = new TVMModel(path_vec, ctx);
+  } else if (backend == DLRBackend::kRELAYVM) {
+    model = new RelayVMModel(path_vec, ctx);
   } else if (backend == DLRBackend::kTREELITE) {
     model = new TreeliteModel(path_vec, ctx);
 #ifdef DLR_TFLITE

--- a/src/dlr_common.cc
+++ b/src/dlr_common.cc
@@ -5,6 +5,12 @@
 #include <fstream>
 using namespace dlr;
 
+
+bool dlr::IsFileEmpty(const std::string& filePath) {
+  std::ifstream pFile(filePath);
+  return pFile.peek() == std::ifstream::traits_type::eof();
+}
+
 std::string dlr::GetParentFolder(const std::string& path) {
   size_t found = path.find_last_of("/\\");
   if (found >= 0) {
@@ -84,6 +90,8 @@ DLRBackend dlr::GetBackend(std::vector<std::string> dir_paths) {
   for (auto filename : paths) {
     if (EndsWith(filename, ".params")) {
       return DLRBackend::kTVM;
+    } else if (EndsWith(filename, ".ro")) {
+      return DLRBackend::kRELAYVM;
     } else if (EndsWith(filename, ".tflite")) {
       return DLRBackend::kTFLITE;
     } else if (EndsWith(filename, ".pb")) {

--- a/src/dlr_common.cc
+++ b/src/dlr_common.cc
@@ -5,7 +5,6 @@
 #include <fstream>
 using namespace dlr;
 
-
 bool dlr::IsFileEmpty(const std::string& filePath) {
   std::ifstream pFile(filePath);
   return pFile.peek() == std::ifstream::traits_type::eof();

--- a/src/dlr_relayvm.cc
+++ b/src/dlr_relayvm.cc
@@ -1,0 +1,283 @@
+#include "dlr_relayvm.h"
+
+
+#include <stdlib.h>
+#include <fstream>
+#include <iterator>
+#include <numeric>
+
+using namespace dlr;
+
+const std::string RelayVMModel::ENTRY_FUNCTION = "main";
+
+void RelayVMModel::InitModelPath(std::vector<std::string> paths) {
+  path_ = std::make_unique<ModelPath>();
+  std::vector<std::string> paths_vec;
+  for (auto path : paths) {
+    ListDir(path, paths_vec);
+  }
+
+  for(auto path: paths_vec) {
+    if (!EndsWith(path, LIBDLR) && EndsWith(path, ".so")) {
+      path_->model_lib = path;
+    } else if (EndsWith(path, ".ro")) {
+      path_->relay_executable = path;
+    } else if (EndsWith(path, ".meta")) {
+      path_->metadata = path;
+    }
+  }
+
+  if (path_->model_lib.empty() || path_->relay_executable.empty() || path_->metadata.empty()) {
+    LOG(FATAL) << "Invalid model artifact!";
+  }
+}
+
+void RelayVMModel::SetupVMModule() {
+    tvm::runtime::Module lib = tvm::runtime::Module::LoadFromFile(path_->model_lib);
+    std::ifstream relay_ob(path_->relay_executable, std::ios::binary);
+    std::string code_data((std::istreambuf_iterator<char>(relay_ob)), std::istreambuf_iterator<char>());
+
+    vm_executable_ = std::make_shared<tvm::runtime::Module>(tvm::runtime::vm::Executable::Load(code_data, lib));
+    auto vm = tvm::runtime::make_object<tvm::runtime::vm::VirtualMachine>();
+    vm->LoadExecutable(static_cast<tvm::runtime::vm::Executable*>(const_cast<tvm::runtime::Object*>(vm_executable_->get())));
+    vm_module_ = std::make_shared<tvm::runtime::Module>(tvm::runtime::Module(vm));
+
+    tvm::runtime::PackedFunc init = vm_module_->GetFunction("init");
+    init(static_cast<int>(ctx_.device_type), ctx_.device_id);
+}
+
+void RelayVMModel::LoadMetadata() {
+  LoadJsonFromFile(path_->metadata, metadata_);
+}
+
+void RelayVMModel::FetchInputNodesData() {
+  tvm::runtime::vm::Executable* exec = (tvm::runtime::vm::Executable*)vm_executable_->get();
+  num_inputs_ = exec->GetFunctionArity(ENTRY_FUNCTION);
+  input_names_.resize(num_inputs_);
+  input_types_.resize(num_inputs_);
+  inputs_.resize(num_inputs_);
+  for (int i = 0; i < num_inputs_; i++) {
+    input_names_[i] = exec->GetFunctionParameterName(ENTRY_FUNCTION, i);
+  }
+  try {
+    for (int i = 0; i < num_inputs_; i++) {
+      input_types_[i] = metadata_.at("Model").at("Inputs").at(i).at("dtype");
+    }
+  } catch (nlohmann::json::out_of_range& e) {
+    LOG(ERROR) << e.what();
+    throw dmlc::Error("No Input types metadata found!");
+  }
+}
+
+void RelayVMModel::FetchOutputNodesData() {
+  try {
+    num_outputs_ = metadata_.at("Model").at("Outputs").size();
+  } catch (nlohmann::json::out_of_range& e) {
+    LOG(ERROR) << e.what();
+    throw dmlc::Error("No Output metadata found!");
+  }
+  output_names_.resize(num_outputs_);
+  output_types_.resize(num_outputs_);
+  try {
+    for (int i = 0; i < num_outputs_; i++) {
+      output_names_[i] = metadata_.at("Model").at("Outputs").at(i).at("name");
+      output_types_[i] = metadata_.at("Model").at("Outputs").at(i).at("dtype");
+    }
+  } catch (nlohmann::json::out_of_range& e) {
+    LOG(ERROR) << e.what();
+    throw dmlc::Error("No Output metadata found!");
+  }
+}
+
+const char* RelayVMModel::GetInputName(int index) const {
+  CHECK_LT(index, num_inputs_) << "Input index is out of range.";
+  return input_names_[index].c_str();
+}
+
+const char* RelayVMModel::GetInputType(int index) const {
+  CHECK_LT(index, num_inputs_) << "Input index is out of range.";
+  return input_types_[index].c_str();
+}
+
+const char* RelayVMModel::GetWeightName(int index) const {
+  throw dmlc::Error("Not Implemented!");
+}
+
+std::vector<std::string> RelayVMModel::GetWeightNames() const {
+  throw dmlc::Error("Not Implemented!");
+}
+
+void RelayVMModel::GetInput(const char* name, void* input) {
+  int index = GetInputIndex(name);
+  auto in_array = inputs_[index];
+  DLTensor input_tensor;
+  input_tensor.data = input;
+  input_tensor.ctx = ctx_;
+  input_tensor.ndim = in_array->ndim;
+  input_tensor.dtype = in_array->dtype;
+  input_tensor.shape = in_array->shape;
+  input_tensor.strides = nullptr;
+  input_tensor.byte_offset = 0;
+  in_array.CopyTo(&input_tensor);
+}
+
+int RelayVMModel::GetInputIndex(const char* name) const {
+  std::string input_name(name);
+  for(auto i = 0; i < num_inputs_; i++) {
+    if (input_name == input_names_[i]) {
+      return i;
+    }
+  }
+  throw dmlc::Error("Invalid input node name!");
+}
+
+DLDataType RelayVMModel::GetInputDLDataType(int index) {
+  auto input_type = input_types_[index];
+  DLDataType dtype;
+  dtype.lanes = 1;
+  if (input_type == "uint8") {
+    dtype.code = kDLUInt;
+    dtype.bits = 8;
+  } else if (input_type == "int8") {
+    dtype.code = kDLInt;
+    dtype.bits = 8;
+  } else if (input_type == "float32") {
+    dtype.code = kDLFloat;
+    dtype.bits = 32;
+  } else if (input_type == "float64") {
+    dtype.code = kDLBfloat;
+    dtype.bits = 64;
+  } else {
+    throw dmlc::Error("Unknown input dtype!");
+  }
+  return dtype;
+}
+
+void RelayVMModel::SetInput(const char* name, const int64_t* shape, void* input, int dim) {
+  int index = GetInputIndex(name);
+  DLDataType dtype = GetInputDLDataType(index);
+  DLTensor input_tensor;
+  input_tensor.data = input;
+  input_tensor.ctx = ctx_;
+  input_tensor.ndim = dim;
+  input_tensor.shape = const_cast<int64_t*>(shape);
+  input_tensor.strides = nullptr;
+  input_tensor.byte_offset = 0;
+  input_tensor.dtype = dtype;
+  std::vector<int64_t> arr_shape(shape, shape + dim);
+
+  tvm::runtime::NDArray input_arr = tvm::runtime::NDArray::Empty(arr_shape, dtype, ctx_);
+  input_arr.CopyFrom(&input_tensor);
+  inputs_[index] = input_arr;
+}
+
+void RelayVMModel::UpdateInputs() {
+  const int kNumArgs = GetNumInputs() + 1;
+  TVMValue values[kNumArgs];
+  int type_codes[kNumArgs];
+  auto arg_setter = tvm::runtime::TVMArgsSetter(values, type_codes);
+  arg_setter(0, ENTRY_FUNCTION);
+  for (int i = 0; i < inputs_.size(); i++) {
+    arg_setter(i + 1, inputs_[i]);
+  }
+
+  tvm::runtime::PackedFunc set_input = vm_module_->GetFunction("set_input");
+  tvm::runtime::TVMRetValue rv;
+  set_input.CallPacked(tvm::runtime::TVMArgs(values, type_codes, kNumArgs), &rv);
+}
+
+void RelayVMModel::Run() {
+  // Invoke inference
+  UpdateInputs();
+  tvm::runtime::PackedFunc invoke = vm_module_->GetFunction("invoke");
+  output_ref_ = invoke(ENTRY_FUNCTION);
+  UpdateOutputs();
+}
+
+void RelayVMModel::UpdateOutputs() {
+  outputs_.resize(num_outputs_);
+  if (output_ref_->IsInstance<tvm::runtime::ADTObj>()) {
+    auto adt = tvm::runtime::Downcast<tvm::runtime::ADT>(output_ref_);
+    for (int i = 0; i < adt.size(); i++) {
+      outputs_[i] = tvm::runtime::Downcast<tvm::runtime::NDArray>(adt[i]);
+    }
+  } else if (output_ref_->IsInstance<tvm::runtime::NDArray::ContainerType>()) {
+    outputs_[0] = tvm::runtime::Downcast<tvm::runtime::NDArray>(output_ref_);
+  } else {
+    throw dmlc::Error("Invalid output_ref format!");
+  }
+}
+
+void RelayVMModel::GetOutput(int index, void* output) {
+  CHECK_LT(index, num_outputs_) << "Output index is out of range.";
+  auto out_array = outputs_[index];
+  DLTensor output_tensor;
+  output_tensor.data = output;
+  output_tensor.ctx = ctx_;
+  output_tensor.ndim = out_array->ndim;
+  output_tensor.dtype = out_array->dtype;
+  output_tensor.shape = out_array->shape;
+  output_tensor.strides = nullptr;
+  output_tensor.byte_offset = 0;
+  out_array.CopyTo(&output_tensor);
+}
+
+void RelayVMModel::GetOutputShape(int index, int64_t* shape) const {
+  CHECK_LT(index, num_outputs_) << "Output index is out of range.";
+  std::memcpy(shape, outputs_[index]->shape, sizeof(int64_t) * outputs_[index]->ndim);
+}
+
+void RelayVMModel::GetOutputSizeDim(int index, int64_t* size, int* dim) {
+  CHECK_LT(index, num_outputs_) << "Output index is out of range.";*size = 1;
+  auto arr = outputs_[index];
+  *size = std::accumulate(arr->shape, arr->shape + arr->ndim, 1, std::multiplies<int64_t>());
+  *dim = arr->ndim;
+}
+
+const char* RelayVMModel::GetOutputType(int index) const {
+  CHECK_LT(index, num_outputs_) << "Output index is out of range.";
+  return output_types_[index].c_str();
+}
+
+const char* RelayVMModel::GetBackend() const {
+  return "relayvm";
+}
+
+void RelayVMModel::SetNumThreads(int threads) {
+  throw dmlc::Error("Not Implemented!");
+}
+
+void RelayVMModel::UseCPUAffinity(bool use) {
+  throw dmlc::Error("Not Implemented!");
+}
+
+bool RelayVMModel::HasMetadata() const {
+  return !metadata_.is_null();
+}
+
+const char* RelayVMModel::GetOutputName(const int index) const {
+  CHECK_LT(index, num_outputs_) << "Output index is out of range.";
+  return output_names_[index].c_str();
+}
+
+int RelayVMModel::GetOutputIndex(const char* name) const {
+  if (!this->HasMetadata()) {
+    throw dmlc::Error("No metadata file was found!");
+  }
+  for (int i = 0; i < this->num_outputs_; i++) {
+    const char* output_name = GetOutputName(i);
+    if (output_name == nullptr) return -1;
+    if (strcmp(output_name, name) == 0) {
+      return i;
+    }
+  }
+
+  std::string msg = "Couldn't find index for output node";
+  msg += " " + std::string{name} + "!";
+  throw dmlc::Error(msg);
+}
+
+void RelayVMModel::GetOutputByName(const char* name, void* out) {
+  int output_index = this->GetOutputIndex(name);
+  this->GetOutput(output_index, out);
+}

--- a/src/dlr_relayvm.cc
+++ b/src/dlr_relayvm.cc
@@ -25,38 +25,33 @@ void RelayVMModel::InitModelPath(std::vector<std::string> paths) {
     }
   }
 
-  if (path_->model_lib.empty() || path_->relay_executable.empty() ||
-      path_->metadata.empty()) {
+  if (path_->model_lib.empty() || path_->relay_executable.empty() || path_->metadata.empty()) {
     LOG(FATAL) << "Invalid model artifact!";
   }
 }
 
 void RelayVMModel::SetupVMModule() {
-  tvm::runtime::Module lib =
-      tvm::runtime::Module::LoadFromFile(path_->model_lib);
+  tvm::runtime::Module lib = tvm::runtime::Module::LoadFromFile(path_->model_lib);
   std::ifstream relay_ob(path_->relay_executable, std::ios::binary);
   std::string code_data((std::istreambuf_iterator<char>(relay_ob)),
                         std::istreambuf_iterator<char>());
 
-  vm_executable_ = std::make_shared<tvm::runtime::Module>(
-      tvm::runtime::vm::Executable::Load(code_data, lib));
+  vm_executable_ =
+      std::make_shared<tvm::runtime::Module>(tvm::runtime::vm::Executable::Load(code_data, lib));
   auto vm = tvm::runtime::make_object<tvm::runtime::vm::VirtualMachine>();
-  vm->LoadExecutable(static_cast<tvm::runtime::vm::Executable *>(
-      const_cast<tvm::runtime::Object *>(vm_executable_->get())));
+  vm->LoadExecutable(static_cast<tvm::runtime::vm::Executable*>(
+      const_cast<tvm::runtime::Object*>(vm_executable_->get())));
   vm_module_ = std::make_shared<tvm::runtime::Module>(tvm::runtime::Module(vm));
 
   tvm::runtime::PackedFunc init = vm_module_->GetFunction("init");
   init(static_cast<int>(ctx_.device_type), ctx_.device_id);
 }
 
-void RelayVMModel::LoadMetadata() {
-  LoadJsonFromFile(path_->metadata, metadata_);
-}
+void RelayVMModel::LoadMetadata() { LoadJsonFromFile(path_->metadata, metadata_); }
 
 void RelayVMModel::FetchInputNodesData() {
-  tvm::runtime::vm::Executable *exec =
-      static_cast<tvm::runtime::vm::Executable *>(
-          const_cast<tvm::runtime::Object *>(vm_executable_->get()));
+  tvm::runtime::vm::Executable* exec = static_cast<tvm::runtime::vm::Executable*>(
+      const_cast<tvm::runtime::Object*>(vm_executable_->get()));
   num_inputs_ = exec->GetFunctionArity(ENTRY_FUNCTION);
   input_names_.resize(num_inputs_);
   input_types_.resize(num_inputs_);
@@ -68,7 +63,7 @@ void RelayVMModel::FetchInputNodesData() {
     for (int i = 0; i < num_inputs_; i++) {
       input_types_[i] = metadata_.at("Model").at("Inputs").at(i).at("dtype");
     }
-  } catch (nlohmann::json::out_of_range &e) {
+  } catch (nlohmann::json::out_of_range& e) {
     LOG(ERROR) << e.what();
     throw dmlc::Error("No Input types metadata found!");
   }
@@ -77,7 +72,7 @@ void RelayVMModel::FetchInputNodesData() {
 void RelayVMModel::FetchOutputNodesData() {
   try {
     num_outputs_ = metadata_.at("Model").at("Outputs").size();
-  } catch (nlohmann::json::out_of_range &e) {
+  } catch (nlohmann::json::out_of_range& e) {
     LOG(ERROR) << e.what();
     throw dmlc::Error("No Output metadata found!");
   }
@@ -88,31 +83,29 @@ void RelayVMModel::FetchOutputNodesData() {
       output_names_[i] = metadata_.at("Model").at("Outputs").at(i).at("name");
       output_types_[i] = metadata_.at("Model").at("Outputs").at(i).at("dtype");
     }
-  } catch (nlohmann::json::out_of_range &e) {
+  } catch (nlohmann::json::out_of_range& e) {
     LOG(ERROR) << e.what();
     throw dmlc::Error("No Output metadata found!");
   }
 }
 
-const char *RelayVMModel::GetInputName(int index) const {
+const char* RelayVMModel::GetInputName(int index) const {
   CHECK_LT(index, num_inputs_) << "Input index is out of range.";
   return input_names_[index].c_str();
 }
 
-const char *RelayVMModel::GetInputType(int index) const {
+const char* RelayVMModel::GetInputType(int index) const {
   CHECK_LT(index, num_inputs_) << "Input index is out of range.";
   return input_types_[index].c_str();
 }
 
-const char *RelayVMModel::GetWeightName(int index) const {
-  throw dmlc::Error("Not Implemented!");
-}
+const char* RelayVMModel::GetWeightName(int index) const { throw dmlc::Error("Not Implemented!"); }
 
 std::vector<std::string> RelayVMModel::GetWeightNames() const {
   throw dmlc::Error("Not Implemented!");
 }
 
-void RelayVMModel::GetInput(const char *name, void *input) {
+void RelayVMModel::GetInput(const char* name, void* input) {
   int index = GetInputIndex(name);
   auto in_array = inputs_[index];
   DLTensor input_tensor;
@@ -126,7 +119,7 @@ void RelayVMModel::GetInput(const char *name, void *input) {
   in_array.CopyTo(&input_tensor);
 }
 
-int RelayVMModel::GetInputIndex(const char *name) const {
+int RelayVMModel::GetInputIndex(const char* name) const {
   std::string input_name(name);
   for (auto i = 0; i < num_inputs_; i++) {
     if (input_name == input_names_[i]) {
@@ -158,22 +151,20 @@ DLDataType RelayVMModel::GetInputDLDataType(int index) {
   return dtype;
 }
 
-void RelayVMModel::SetInput(const char *name, const int64_t *shape, void *input,
-                            int dim) {
+void RelayVMModel::SetInput(const char* name, const int64_t* shape, void* input, int dim) {
   int index = GetInputIndex(name);
   DLDataType dtype = GetInputDLDataType(index);
   DLTensor input_tensor;
   input_tensor.data = input;
   input_tensor.ctx = ctx_;
   input_tensor.ndim = dim;
-  input_tensor.shape = const_cast<int64_t *>(shape);
+  input_tensor.shape = const_cast<int64_t*>(shape);
   input_tensor.strides = nullptr;
   input_tensor.byte_offset = 0;
   input_tensor.dtype = dtype;
   std::vector<int64_t> arr_shape(shape, shape + dim);
 
-  tvm::runtime::NDArray input_arr =
-      tvm::runtime::NDArray::Empty(arr_shape, dtype, ctx_);
+  tvm::runtime::NDArray input_arr = tvm::runtime::NDArray::Empty(arr_shape, dtype, ctx_);
   input_arr.CopyFrom(&input_tensor);
   inputs_[index] = input_arr;
 }
@@ -190,8 +181,7 @@ void RelayVMModel::UpdateInputs() {
 
   tvm::runtime::PackedFunc set_input = vm_module_->GetFunction("set_input");
   tvm::runtime::TVMRetValue rv;
-  set_input.CallPacked(tvm::runtime::TVMArgs(values, type_codes, kNumArgs),
-                       &rv);
+  set_input.CallPacked(tvm::runtime::TVMArgs(values, type_codes, kNumArgs), &rv);
 }
 
 void RelayVMModel::Run() {
@@ -216,7 +206,7 @@ void RelayVMModel::UpdateOutputs() {
   }
 }
 
-void RelayVMModel::GetOutput(int index, void *output) {
+void RelayVMModel::GetOutput(int index, void* output) {
   CHECK_LT(index, num_outputs_) << "Output index is out of range.";
   auto out_array = outputs_[index];
   DLTensor output_tensor;
@@ -230,49 +220,43 @@ void RelayVMModel::GetOutput(int index, void *output) {
   out_array.CopyTo(&output_tensor);
 }
 
-void RelayVMModel::GetOutputShape(int index, int64_t *shape) const {
+void RelayVMModel::GetOutputShape(int index, int64_t* shape) const {
   CHECK_LT(index, num_outputs_) << "Output index is out of range.";
-  std::memcpy(shape, outputs_[index]->shape,
-              sizeof(int64_t) * outputs_[index]->ndim);
+  std::memcpy(shape, outputs_[index]->shape, sizeof(int64_t) * outputs_[index]->ndim);
 }
 
-void RelayVMModel::GetOutputSizeDim(int index, int64_t *size, int *dim) {
+void RelayVMModel::GetOutputSizeDim(int index, int64_t* size, int* dim) {
   CHECK_LT(index, num_outputs_) << "Output index is out of range.";
   *size = 1;
   auto arr = outputs_[index];
-  *size = std::accumulate(arr->shape, arr->shape + arr->ndim, 1,
-                          std::multiplies<int64_t>());
+  *size = std::accumulate(arr->shape, arr->shape + arr->ndim, 1, std::multiplies<int64_t>());
   *dim = arr->ndim;
 }
 
-const char *RelayVMModel::GetOutputType(int index) const {
+const char* RelayVMModel::GetOutputType(int index) const {
   CHECK_LT(index, num_outputs_) << "Output index is out of range.";
   return output_types_[index].c_str();
 }
 
-const char *RelayVMModel::GetBackend() const { return "relayvm"; }
+const char* RelayVMModel::GetBackend() const { return "relayvm"; }
 
-void RelayVMModel::SetNumThreads(int threads) {
-  throw dmlc::Error("Not Implemented!");
-}
+void RelayVMModel::SetNumThreads(int threads) { throw dmlc::Error("Not Implemented!"); }
 
-void RelayVMModel::UseCPUAffinity(bool use) {
-  throw dmlc::Error("Not Implemented!");
-}
+void RelayVMModel::UseCPUAffinity(bool use) { throw dmlc::Error("Not Implemented!"); }
 
 bool RelayVMModel::HasMetadata() const { return !metadata_.is_null(); }
 
-const char *RelayVMModel::GetOutputName(const int index) const {
+const char* RelayVMModel::GetOutputName(const int index) const {
   CHECK_LT(index, num_outputs_) << "Output index is out of range.";
   return output_names_[index].c_str();
 }
 
-int RelayVMModel::GetOutputIndex(const char *name) const {
+int RelayVMModel::GetOutputIndex(const char* name) const {
   if (!this->HasMetadata()) {
     throw dmlc::Error("No metadata file was found!");
   }
   for (int i = 0; i < this->num_outputs_; i++) {
-    const char *output_name = GetOutputName(i);
+    const char* output_name = GetOutputName(i);
     if (output_name == nullptr) return -1;
     if (strcmp(output_name, name) == 0) {
       return i;
@@ -284,7 +268,7 @@ int RelayVMModel::GetOutputIndex(const char *name) const {
   throw dmlc::Error(msg);
 }
 
-void RelayVMModel::GetOutputByName(const char *name, void *out) {
+void RelayVMModel::GetOutputByName(const char* name, void* out) {
   int output_index = this->GetOutputIndex(name);
   this->GetOutput(output_index, out);
 }

--- a/src/dlr_tvm.cc
+++ b/src/dlr_tvm.cc
@@ -45,11 +45,6 @@ ModelPath dlr::GetTvmPaths(std::vector<std::string> dirname) {
   return paths;
 }
 
-bool IsFileEmpty(const std::string& filePath) {
-  std::ifstream pFile(filePath);
-  return pFile.peek() == std::ifstream::traits_type::eof();
-}
-
 void TVMModel::SetupTVMModule(std::vector<std::string> model_path) {
   ModelPath paths = GetTvmPaths(model_path);
   std::ifstream jstream(paths.model_json);

--- a/tests/cpp/dlr_relayvm_test.cc
+++ b/tests/cpp/dlr_relayvm_test.cc
@@ -13,7 +13,7 @@ int main(int argc, char **argv) {
 
 class RelayVMTest : public ::testing::Test {
  protected:
-  int8_t* img;
+  int8_t *img;
   const int batch_size = 1;
   size_t img_size = 512 * 512 * 3;
   const int64_t input_shape[4] = {1, 512, 512, 3};
@@ -39,11 +39,17 @@ class RelayVMTest : public ::testing::Test {
 
 TEST_F(RelayVMTest, TestGetNumInputs) { EXPECT_EQ(model->GetNumInputs(), 1); }
 
-TEST_F(RelayVMTest, TestGetInputName) { EXPECT_STREQ(model->GetInputName(0), "image_tensor"); }
+TEST_F(RelayVMTest, TestGetInputName) {
+  EXPECT_STREQ(model->GetInputName(0), "image_tensor");
+}
 
-TEST_F(RelayVMTest, TestGetInputType) { EXPECT_STREQ(model->GetInputType(0), "uint8"); }
+TEST_F(RelayVMTest, TestGetInputType) {
+  EXPECT_STREQ(model->GetInputType(0), "uint8");
+}
 
-TEST_F(RelayVMTest, TestSetInput) { EXPECT_NO_THROW(model->SetInput("image_tensor", input_shape, img, input_dim)); }
+TEST_F(RelayVMTest, TestSetInput) {
+  EXPECT_NO_THROW(model->SetInput("image_tensor", input_shape, img, input_dim));
+}
 
 TEST_F(RelayVMTest, TestGetNumOutputs) { EXPECT_EQ(model->GetNumOutputs(), 3); }
 

--- a/tests/cpp/dlr_relayvm_test.cc
+++ b/tests/cpp/dlr_relayvm_test.cc
@@ -1,0 +1,99 @@
+#include "dlr_relayvm.h"
+
+#include <gtest/gtest.h>
+#include "test_utils.hpp"
+
+int main(int argc, char **argv) {
+  testing::InitGoogleTest(&argc, argv);
+#ifndef _WIN32
+  testing::FLAGS_gtest_death_test_style = "threadsafe";
+#endif  // _WIN32
+  return RUN_ALL_TESTS();
+}
+
+class RelayVMTest : public ::testing::Test {
+ protected:
+  int8_t* img;
+  const int batch_size = 1;
+  size_t img_size = 512 * 512 * 3;
+  const int64_t input_shape[4] = {1, 512, 512, 3};
+  const int input_dim = 4;
+
+  dlr::RelayVMModel *model;
+
+  RelayVMTest() {
+    const int device_type = kDLCPU;
+    const int device_id = 0;
+    DLContext ctx = {static_cast<DLDeviceType>(device_type), device_id};
+    std::vector<std::string> paths = {"./ssd_mobilenet_v2"};
+    model = new dlr::RelayVMModel(paths, ctx);
+
+    img = new int8_t[img_size];
+  }
+
+  ~RelayVMTest() {
+    delete model;
+    delete img;
+  }
+};
+
+TEST_F(RelayVMTest, TestGetNumInputs) { EXPECT_EQ(model->GetNumInputs(), 1); }
+
+TEST_F(RelayVMTest, TestGetInputName) { EXPECT_STREQ(model->GetInputName(0), "image_tensor"); }
+
+TEST_F(RelayVMTest, TestGetInputType) { EXPECT_STREQ(model->GetInputType(0), "uint8"); }
+
+TEST_F(RelayVMTest, TestSetInput) { EXPECT_NO_THROW(model->SetInput("image_tensor", input_shape, img, input_dim)); }
+
+TEST_F(RelayVMTest, TestGetNumOutputs) { EXPECT_EQ(model->GetNumOutputs(), 3); }
+
+TEST_F(RelayVMTest, TestGetOutputName) {
+  EXPECT_STREQ(model->GetOutputName(0), "detection_scores:0");
+  EXPECT_STREQ(model->GetOutputName(1), "detection_classes:0");
+  EXPECT_STREQ(model->GetOutputName(2), "num_detections:0");
+}
+
+TEST_F(RelayVMTest, TestGetOutputType) {
+  EXPECT_STREQ(model->GetOutputType(0), "float32");
+  EXPECT_STREQ(model->GetOutputType(1), "float32");
+  EXPECT_STREQ(model->GetOutputType(2), "float32");
+}
+
+TEST_F(RelayVMTest, TestRun) {
+  EXPECT_NO_THROW(model->SetInput("image_tensor", input_shape, img, input_dim));
+  model->Run();
+}
+
+TEST_F(RelayVMTest, TestGetOutputShape) {
+  int64_t output_0_shape[3];
+  EXPECT_NO_THROW(model->SetInput("image_tensor", input_shape, img, input_dim));
+  EXPECT_NO_THROW(model->Run());
+  EXPECT_NO_THROW(model->GetOutputShape(0, output_0_shape));
+  EXPECT_EQ(output_0_shape[0], 1);
+  EXPECT_EQ(output_0_shape[1], 100);
+  EXPECT_EQ(output_0_shape[2], 4);
+  int64_t output_1_shape[2];
+  EXPECT_NO_THROW(model->GetOutputShape(1, output_1_shape));
+  EXPECT_EQ(output_1_shape[0], 1);
+  EXPECT_EQ(output_1_shape[1], 100);
+  int64_t output_2_shape[2];
+  EXPECT_NO_THROW(model->GetOutputShape(2, output_2_shape));
+  EXPECT_EQ(output_2_shape[0], 1);
+  EXPECT_EQ(output_2_shape[1], 100);
+}
+
+TEST_F(RelayVMTest, TestGetOutputSizeDim) {
+  int64_t size;
+  int dim;
+  EXPECT_NO_THROW(model->SetInput("image_tensor", input_shape, img, input_dim));
+  EXPECT_NO_THROW(model->Run());
+  EXPECT_NO_THROW(model->GetOutputSizeDim(0, &size, &dim));
+  EXPECT_EQ(size, 400);
+  EXPECT_EQ(dim, 3);
+  EXPECT_NO_THROW(model->GetOutputSizeDim(1, &size, &dim));
+  EXPECT_EQ(size, 100);
+  EXPECT_EQ(dim, 2);
+  EXPECT_NO_THROW(model->GetOutputSizeDim(2, &size, &dim));
+  EXPECT_EQ(size, 100);
+  EXPECT_EQ(dim, 2);
+}

--- a/tests/cpp/dlr_relayvm_test.cc
+++ b/tests/cpp/dlr_relayvm_test.cc
@@ -25,7 +25,7 @@ class RelayVMTest : public ::testing::Test {
     const int device_type = kDLCPU;
     const int device_id = 0;
     DLContext ctx = {static_cast<DLDeviceType>(device_type), device_id};
-    std::vector<std::string> paths = {"./ssd_mobilenet_v2"};
+    std::vector<std::string> paths = {"/home/ubuntu/TVM/neo-ai-dlr/build/ssd_mobilenet_v2"};
     model = new dlr::RelayVMModel(paths, ctx);
 
     img = new int8_t[img_size];

--- a/tests/cpp/dlr_tvm_test.cc
+++ b/tests/cpp/dlr_tvm_test.cc
@@ -1,18 +1,14 @@
-#include <gtest/gtest.h>
 #include "dlr_tvm.h"
+#include <gtest/gtest.h>
 #include "test_utils.hpp"
-
 
 TEST(TVM, TestTvmModelApisWithOutputMetadata) {
   const int device_type = 1;  // 1 - kDLCPU
   const int device_id = 0;
-  DLContext ctx  = {
-    static_cast<DLDeviceType>(device_type),
-    device_id
-  };
+  DLContext ctx = {static_cast<DLDeviceType>(device_type), device_id};
   std::vector<std::string> paths = {"./resnet_v1_5_50"};
   dlr::TVMModel model = dlr::TVMModel(paths, ctx);
-  
+
   EXPECT_EQ(model.GetNumInputs(), 1);
   EXPECT_EQ(model.GetNumOutputs(), 2);
   EXPECT_EQ(model.HasMetadata(), true);
@@ -22,7 +18,7 @@ TEST(TVM, TestTvmModelApisWithOutputMetadata) {
   EXPECT_STREQ(model.GetOutputType(1), "float32");
 
   const int batch_size = 1;
-  size_t img_size = 224*224*3;
+  size_t img_size = 224 * 224 * 3;
   float* img = LoadImageAndPreprocess("cat224-3.txt", img_size, batch_size);
   img_size *= batch_size;
   int64_t shape[4] = {1, 224, 224, 3};
@@ -31,7 +27,7 @@ TEST(TVM, TestTvmModelApisWithOutputMetadata) {
   int output_dim;
   int index = 0;
   EXPECT_NO_THROW(model.GetOutputSizeDim(index, &output_size, &output_dim));
-  
+
   EXPECT_NO_THROW(model.SetInput("input_tensor", shape, img, 4));
   EXPECT_NO_THROW(model.Run());
 
@@ -43,25 +39,24 @@ TEST(TVM, TestTvmModelApisWithOutputMetadata) {
 
   try {
     model.GetOutputIndex("blah");
-  } catch(const dmlc::Error& e) {
+  } catch (const dmlc::Error& e) {
     EXPECT_STREQ(e.what(), "Couldn't find index for output node blah!");
   }
-  
+
   try {
     model.GetOutputByName("blah", output1);
-  } catch(const dmlc::Error& e) {
+  } catch (const dmlc::Error& e) {
     EXPECT_STREQ(e.what(), "Couldn't find index for output node blah!");
   }
 
   try {
     model.GetOutputName(2);
-  } catch(const dmlc::Error& e) {
+  } catch (const dmlc::Error& e) {
     EXPECT_STREQ(e.what(), "Output node with index 2 was not found in metadata file!");
   }
   delete[] output1;
   delete[] output2;
 }
-
 
 TEST(TVM, TestTvmModelApisWithoutMetadata) {
   std::string model_path = "./resnet_v1_5_50";
@@ -73,72 +68,64 @@ TEST(TVM, TestTvmModelApisWithoutMetadata) {
 
   const int device_type = 1;  // 1 - kDLCPU
   const int device_id = 0;
-  DLContext ctx  = {
-    static_cast<DLDeviceType>(device_type),
-    device_id
-  };
+  DLContext ctx = {static_cast<DLDeviceType>(device_type), device_id};
   std::vector<std::string> paths = {model_path};
   dlr::TVMModel model = dlr::TVMModel(paths, ctx);
-  
+
   EXPECT_EQ(model.GetNumInputs(), 1);
   EXPECT_EQ(model.GetNumOutputs(), 2);
   EXPECT_EQ(model.HasMetadata(), false);
   try {
     model.GetOutputName(0);
-  } catch(const dmlc::Error& e) {
+  } catch (const dmlc::Error& e) {
     EXPECT_STREQ(e.what(), "No metadata file was found!");
   }
   try {
     model.GetOutputIndex("blah");
-  } catch(const dmlc::Error& e) {
+  } catch (const dmlc::Error& e) {
     EXPECT_STREQ(e.what(), "No metadata file was found!");
   }
 
   // put it back
   std::rename(metadata_file_bak.c_str(), metadata_file.c_str());
 }
-
 
 TEST(TVM, TestTvmModelApisWithoutOutputInMetadata) {
   // rename metadata file such that metadata file is not found.
   std::string model_path = "./resnet_v1_5_50";
   std::string metadata_file = model_path + "/compiled.meta";
   std::string metadata_file_bak = model_path + "/compiled.meta.bak";
-  
+
   std::rename(metadata_file.c_str(), metadata_file_bak.c_str());
   std::ofstream mocked_metadata;
   mocked_metadata.open(metadata_file.c_str());
   mocked_metadata << "{}\n";
   mocked_metadata.close();
-  
+
   const int device_type = 1;  // 1 - kDLCPU
   const int device_id = 0;
-  DLContext ctx  = {
-    static_cast<DLDeviceType>(device_type),
-    device_id
-  };
+  DLContext ctx = {static_cast<DLDeviceType>(device_type), device_id};
   std::vector<std::string> paths = {model_path};
   dlr::TVMModel model = dlr::TVMModel(paths, ctx);
-  
+
   EXPECT_EQ(model.GetNumInputs(), 1);
   EXPECT_EQ(model.GetNumOutputs(), 2);
   EXPECT_EQ(model.HasMetadata(), true);
 
   try {
     model.GetOutputName(0);
-  } catch(const dmlc::Error& e) {
+  } catch (const dmlc::Error& e) {
     EXPECT_STREQ(e.what(), "Output node with index 0 was not found in metadata file!");
   }
   try {
     model.GetOutputIndex("blah");
-  } catch(const dmlc::Error& e) {
+  } catch (const dmlc::Error& e) {
     EXPECT_STREQ(e.what(), "Output node with index 0 was not found in metadata file!");
   }
 
   // put it back
   std::rename(metadata_file_bak.c_str(), metadata_file.c_str());
 }
-
 
 int main(int argc, char** argv) {
   testing::InitGoogleTest(&argc, argv);

--- a/tests/python/integration/load_and_run_relayvm_model.py
+++ b/tests/python/integration/load_and_run_relayvm_model.py
@@ -17,6 +17,11 @@ def test_ssd_mobilenet_v2_model():
   assert outputs[0].shape == (1, 100, 4)
   assert outputs[1].shape == (1, 100)
   assert outputs[2].shape == (1, 100)
+  detections = np.multiply(np.ceil(outputs[1]), outputs[2])
+  expected = np.zeros(detections.shape)
+  expected[:,:6] = np.array([[1., 1., 1., 2., 3., 1]])
+  comparison = detections == expected
+  assert comparison.all()
 
 if __name__ == '__main__':
     test_ssd_mobilenet_v2_model()

--- a/tests/python/integration/load_and_run_relayvm_model.py
+++ b/tests/python/integration/load_and_run_relayvm_model.py
@@ -1,0 +1,23 @@
+from dlr import DLRModel
+import numpy as np
+import cv2
+from pathlib import Path
+
+MODEL_PATH = Path("../../../build/ssd_mobilenet_v2").resolve()
+DATA_PATH = Path("../../../build/street_small.npy").resolve()
+
+def test_ssd_mobilenet_v2_model():
+  model = DLRModel(MODEL_PATH.as_posix())
+  data = np.load(DATA_PATH)
+  assert model.get_input_names() == ['image_tensor']
+  assert model.get_output_names() == ['detection_scores:0', 'detection_classes:0', 'num_detections:0']
+  assert model.get_input_dtypes() == ['uint8']
+  assert model.get_output_dtypes() == ['float32', 'float32', 'float32']
+  outputs = model.run({"image_tensor": data})
+  assert outputs[0].shape == (1, 100, 4)
+  assert outputs[1].shape == (1, 100)
+  assert outputs[2].shape == (1, 100)
+
+if __name__ == '__main__':
+    test_ssd_mobilenet_v2_model()
+    print('All tests passed!')


### PR DESCRIPTION
Thanks for contributing to DLR! By submitting this pull request, you confirm that your contribution is made under the terms of the [Apache 2.0 license](https://github.com/neo-ai/neo-ai-dlr/blob/master/LICENSE).

Please refer to our [guideline](https://github.com/neo-ai/neo-ai-dlr/blob/master/CONTRIBUTING.md) for useful information and tips.


## Testing Unit Test
```bash
ubuntu@ip-172-31-29-195:~/TVM/neo-ai-dlr/build$ ./dlr_relayvm_test
[==========] Running 10 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 10 tests from RelayVMTest
[ RUN      ] RelayVMTest.TestGetNumInputs
[       OK ] RelayVMTest.TestGetNumInputs (166 ms)
[ RUN      ] RelayVMTest.TestGetInputName
[       OK ] RelayVMTest.TestGetInputName (146 ms)
[ RUN      ] RelayVMTest.TestGetInputType
[       OK ] RelayVMTest.TestGetInputType (145 ms)
[ RUN      ] RelayVMTest.TestSetInput
[       OK ] RelayVMTest.TestSetInput (145 ms)
[ RUN      ] RelayVMTest.TestGetNumOutputs
[       OK ] RelayVMTest.TestGetNumOutputs (145 ms)
[ RUN      ] RelayVMTest.TestGetOutputName
[       OK ] RelayVMTest.TestGetOutputName (145 ms)
[ RUN      ] RelayVMTest.TestGetOutputType
[       OK ] RelayVMTest.TestGetOutputType (144 ms)
[ RUN      ] RelayVMTest.TestRun
[       OK ] RelayVMTest.TestRun (166 ms)
[ RUN      ] RelayVMTest.TestGetOutputShape
[       OK ] RelayVMTest.TestGetOutputShape (149 ms)
[ RUN      ] RelayVMTest.TestGetOutputSizeDim
[       OK ] RelayVMTest.TestGetOutputSizeDim (137 ms)
[----------] 10 tests from RelayVMTest (1488 ms total)

[----------] Global test environment tear-down
[==========] 10 tests from 1 test case ran. (1488 ms total)
[  PASSED  ] 10 tests.
```