### PR TITLE
Exclude libdlr.so from treelite path

### DIFF
--- a/src/dlr_treelite.cc
+++ b/src/dlr_treelite.cc
@@ -34,7 +34,7 @@ ModelPath dlr::GetTreelitePaths(std::vector<std::string> dirname) {
     ListDir(dir, paths_vec);
   }
   for (auto filename : paths_vec) {
-    if (filename != LIBDLR && EndsWith(filename, LIBEXT)) {
+    if (!EndsWith(filename, LIBDLR) && EndsWith(filename, LIBEXT)) {
       paths.model_lib = filename;
     } else if (filename == "version.json") {
       paths.ver_json = filename;


### PR DESCRIPTION
Same fix as https://github.com/neo-ai/neo-ai-dlr/commit/650539dfa75de12db0b24dd09f76a3d899f16eb0 but for treelite.
