### PR TITLE
Don't use system paths for libdlr when building wheel

### DIFF
--- a/python/dlr/libpath.py
+++ b/python/dlr/libpath.py
@@ -10,20 +10,24 @@ class DLRLibraryNotFound(Exception):
     pass
 
 
-def find_lib_path(model_path=None, use_default_dlr=True, logger=None):
+def find_lib_path(model_path=None, use_default_dlr=True, logger=None, setup=False):
     """Find the path to DLR dynamic library files."""
-    
+
     curr_path = os.path.dirname(os.path.abspath(os.path.expanduser(__file__)))
-    # Prioritize library in system path over the current_path.
-    dll_paths = [os.path.join(sys.prefix, 'dlr'),
-                os.path.join(sys.prefix, 'local', 'dlr'),
-                os.path.join(sys.exec_prefix, 'local', 'dlr'),
-                os.path.join(os.path.expanduser('~'), '.local', 'dlr'),
-                os.path.join(curr_path, '../../lib/'),
-                os.path.join(curr_path, '../../build/lib/'),
-                os.path.join(curr_path, './lib/'),
-                os.path.join(curr_path, './build/lib/'), 
-                curr_path]
+    if setup:
+        # Only look in build directory when installing or building wheel.
+        dll_paths = [os.path.join(curr_path, '../../build/lib/')]
+    else:
+        # Prioritize library in system path over the current_path.
+        dll_paths = [os.path.join(sys.prefix, 'dlr'),
+                     os.path.join(sys.prefix, 'local', 'dlr'),
+                     os.path.join(sys.exec_prefix, 'local', 'dlr'),
+                     os.path.join(os.path.expanduser('~'), '.local', 'dlr'),
+                     os.path.join(curr_path, '../../lib/'),
+                     os.path.join(curr_path, '../../build/lib/'),
+                     os.path.join(curr_path, './lib/'),
+                     os.path.join(curr_path, './build/lib/'), 
+                     curr_path]
     
     if sys.platform == 'win32':
         if platform.architecture()[0] == '64bit':

--- a/python/setup.py
+++ b/python/setup.py
@@ -17,8 +17,8 @@ LIBPATH = {'__file__': LIBPATH_PY}
 exec(compile(open(LIBPATH_PY, "rb").read(), LIBPATH_PY, 'exec'),
      LIBPATH, LIBPATH)
 
-CURRENT_DIR = os.path.dirname(__file__)
-LIB_PATH = [os.path.relpath(LIBPATH['find_lib_path'](), CURRENT_DIR)]
+CURRENT_DIR = os.path.dirname(os.path.abspath(os.path.expanduser(__file__)))
+LIB_PATH = [os.path.relpath(LIBPATH['find_lib_path'](setup=True), CURRENT_DIR)]
 
 if not LIB_PATH:
     raise RuntimeError('libdlr.so missing. Please compile first using CMake')


### PR DESCRIPTION
Currently when building the wheel or installing DLR, setup.py calls `find_lib_path` to locate the `libdlr.so` to include. However, `find_lib_path` prioritizes system directories over the build folder. This can cause the wrong dlr lib to be included in the wheel.