### PR TITLE
Fix description-content-type error when uploading pip package with twine

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # DLR
 
-DLR is a compact, common runtime for deep learning models and decision tree models compiled by [AWS SageMaker Neo](https://aws.amazon.com/sagemaker/neo/), [TVM](https://tvm.ai/), or [Treelite](https://treelite.readthedocs.io/en/latest/install.html). DLR uses the TVM runtime, Treelite runtime, NVIDIA TensorRT™, and can include other hardware-specific runtimes. DLR provides unified Python/C++ APIs for loading and running compiled models on various devices. DLR currently supports platforms from Intel, NVIDIA, and ARM, with support for Xilinx, Cadence, and Qualcomm coming soon.
+DLR is a compact, common runtime for deep learning models and decision tree models compiled by [AWS SageMaker Neo](https://aws.amazon.com/sagemaker/neo/), [TVM](https://github.com/neo-ai/tvm), or [Treelite](https://treelite.readthedocs.io/en/latest/install.html). DLR uses the TVM runtime, Treelite runtime, NVIDIA TensorRT™, and can include other hardware-specific runtimes. DLR provides unified Python/C++ APIs for loading and running compiled models on various devices. DLR currently supports platforms from Intel, NVIDIA, and ARM, with support for Xilinx, Cadence, and Qualcomm coming soon.
 
 ## Installation
-On X86_64 CPU targets running Linux, you can install latest release of DLR package via 
+On x86_64 CPU targets running Linux, you can install latest release of DLR package via 
 
 `pip install dlr`
 
@@ -28,6 +28,10 @@ y = model.run(x)
 
 ```
 
+## Release compatibility with different versions of TVM
+
+Each release of DLR is capable of executing models compiled with the same corresponding release of [neo-ai/tvm](https://github.com/neo-ai/tvm). For example, if you used the [release-1.2.0 branch of neo-ai/tvm](https://github.com/neo-ai/tvm/tree/release-1.2.0) to compile your model, then you should use the [release-1.2.0 branch of neo-ai/neo-ai-dlr](https://github.com/neo-ai/neo-ai-dlr/tree/release-1.2.0) to execute the compiled model. Please see [DLR Releases](https://github.com/neo-ai/neo-ai-dlr/releases) for more information.
+
 ## Documentation
 For instructions on using DLR, please refer to [Amazon SageMaker Neo – Train Your Machine Learning Models Once, Run Them Anywhere](https://aws.amazon.com/blogs/aws/amazon-sagemaker-neo-train-your-machine-learning-models-once-run-them-anywhere/)
 
@@ -36,9 +40,9 @@ Also check out the [API documentation](https://neo-ai-dlr.readthedocs.io/en/late
 ## Examples
 We prepared several examples demonstrating how to use DLR API on different platforms
 
-* [Neo AI DLR image classification Android example application](examples/android/image_classification)
-* [DL Model compiler for Android](examples/android/tvm_compiler)
-* [DL Model compiler for AWS EC2 instances](container/ec2_compilation_container)
+* [Neo AI DLR image classification Android example application](https://github.com/neo-ai/neo-ai-dlr/tree/master/examples/android/image_classification)
+* [DL Model compiler for Android](https://github.com/neo-ai/neo-ai-dlr/tree/master/examples/android/tvm_compiler)
+* [DL Model compiler for AWS EC2 instances](https://github.com/neo-ai/neo-ai-dlr/tree/master/container/ec2_compilation_container)
 
 ## License
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -40,6 +40,7 @@ setup(
     description = 'Common runtime for machine learning models compiled by \
         AWS SageMaker Neo, TVM, or TreeLite.',
     long_description=io.open(os.path.join(CURRENT_DIR, '../README.md'), encoding='utf-8').read(),
+    long_description_content_type="text/markdown",
     author = 'AWS Neo',
     author_email = 'aws-neo-ai@amazon.com',
     url='https://github.com/neo-ai/neo-ai-dlr',

--- a/tests/ci_build/Dockerfile.cpu_bare
+++ b/tests/ci_build/Dockerfile.cpu_bare
@@ -24,8 +24,8 @@ ENV CXX=/opt/rh/devtoolset-7/root/usr/bin/c++
 ENV CPP=/opt/rh/devtoolset-7/root/usr/bin/cpp
 
 # Install Python packages
-RUN \
-    pip install numpy pytest scipy scikit-learn wheel
+RUN pip install --upgrade pip
+RUN pip install --upgrade numpy pytest scipy scikit-learn setuptools wheel
 
 ENV GOSU_VERSION 1.10
 


### PR DESCRIPTION
We use markdown for the long_description in the wheel, however the default is rst. This was causing an error when trying to upload the package to pypi using twine.

https://pypi.org/help/#description-content-type