### PR TITLE
[Docs] Move DLR wheels links to releases page

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ On x86_64 CPU targets running Linux, you can install latest release of DLR packa
 
 `pip install dlr`
 
-For installation of DLR on GPU targets, non-x86 edge devices, or building DLR from source, please refer to [Installing DLR](https://neo-ai-dlr.readthedocs.io/en/latest/install.html)
+For installation of DLR on GPU targets or non-x86 edge devices, please refer to [Releases](https://github.com/neo-ai/neo-ai-dlr/releases) for prebuilt binaries, or [Installing DLR](https://neo-ai-dlr.readthedocs.io/en/latest/install.html) for building DLR from source.
 
 ## Usage
 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -10,52 +10,13 @@ Installing DLR
 Installing Pre-built DLR Wheels for Your Device
 ***********************************************
 
-DLR has been built and tested against devices in table 1. If you find your device(s) listed below, you can install DLR with the corresponding S3 link via 
+DLR has been built and tested against many devices. You can install DLR with the corresponding S3 link via
 
   .. code-block:: bash
 
     pip install  link-to-matching-wheel
 
-Table 1: List of Supported Devices
-----------------------------------
-
-+--------------+---------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+
-| Manufacturer | Device Name               |  Wheel URL                                                                                                                                                |
-+==============+===========================+===========================================================================================================================================================+
-| Acer         | TV AISage                 |  https://neo-ai-dlr-release.s3-us-west-2.amazonaws.com/v1.2.0/acer-aarch64-linaro4_4_154-glibc2_24-libstdcpp3_4/dlr-1.2.0-py2.py3-none-any.whl            |
-+--------------+---------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+
-| Amazon       | AWS a1                    |  https://neo-ai-dlr-release.s3-us-west-2.amazonaws.com/v1.2.0/a1-aarch64-ubuntu18_04-glibc2_27-libstdcpp3_4/dlr-1.2.0-py2.py3-none-any.whl                |
-+--------------+---------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+
-| Amazon       | AWS p2/p3/g4              |  https://neo-ai-dlr-release.s3-us-west-2.amazonaws.com/v1.2.0/p3-x86_64-cu10-ubuntu18_04-glibc2_27-libstdpp3_4/dlr-1.2.0-py2.py3-none-any.whl             |
-+--------------+---------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+
-| Amazon       | Deeplens                  |  https://neo-ai-dlr-release.s3-us-west-2.amazonaws.com/v1.1.0/deeplens-x86_64-igp-ubuntu16_04-glibc2_23-libstdcpp3_4/dlr-1.1.0-py2.py3-none-any.whl       |
-+--------------+---------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+
-| Rockchips    | RK3399                    |  https://neo-ai-dlr-release.s3-us-west-2.amazonaws.com/v1.2.0/firefly-aarch64-mali-ubuntu16_04-glibc2_23-libstdcpp3_4/dlr-1.2.0-py2.py3-none-any.whl      |
-+--------------+---------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+
-| NVIDIA       | Jetson TX1 (JetPack 4.3)  |  https://neo-ai-dlr-release.s3-us-west-2.amazonaws.com/v1.2.0/jetsontx1-aarch64-cu10-ubuntu18_04-glibc2_27-libstdcpp3_4/dlr-1.2.0-py2.py3-none-any.whl    |
-+--------------+---------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+
-| NVIDIA       | Jetson TX2 (JetPack 4.3)  |  https://neo-ai-dlr-release.s3-us-west-2.amazonaws.com/v1.2.0/jetsontx2-aarch64-cu10-ubuntu18_04-glibc2_27-libstdcpp3_4/dlr-1.2.0-py2.py3-none-any.whl    |
-+--------------+---------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+
-| NVIDIA       | Jetson Nano (JetPack 4.3) |  https://neo-ai-dlr-release.s3-us-west-2.amazonaws.com/v1.2.0/jetsonnano-aarch64-cu10-ubuntu18_04-glibc2_27-libstdcpp3_4/dlr-1.2.0-py2.py3-none-any.whl   |
-+--------------+---------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+
-| NVIDIA       |Jetson Xavier (JetPack 4.3)|  https://neo-ai-dlr-release.s3-us-west-2.amazonaws.com/v1.2.0/jetsonxavier-aarch64-cu10-ubuntu18_04-glibc2_27-libstdcpp3_4/dlr-1.2.0-py2.py3-none-any.whl |
-+--------------+---------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+
-| Raspberry    | Rasp3b                    |  https://neo-ai-dlr-release.s3-us-west-2.amazonaws.com/v1.2.0/pi-armv7l-raspbian4.14.71-glibc2_24-libstdcpp3_4/dlr-1.2.0-py2.py3-none-any.whl             |
-+--------------+---------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+
-
-If your device is not listed in the table, use table2. You will identify your device by the processor architecture, operating system, and versions of GLIBC and LIBSTDC++. Of note, DLR installation may depend on other configuration differences or even location of dependency libraries; if the provided wheel URL does not work, please consider compiling DLR from source (see `Building DLR from source`_ section).
-
-Table2: List of Supported Architectures (Incomplete)
-----------------------------------------------------
-
-+------------------------+--------------+---------------+-------------------+--------------------------------------------------------------------------------------------------------------------------------------------+ 
-| Processor architecture | OS           | GLIBC version | LIBSTDC++ version | Wheel URL                                                                                                                                  | 
-+========================+==============+===============+===================+============================================================================================================================================+ 
-| aarch64                | Ubuntu 18.04 | 2.27+         | 3.4+              |  https://neo-ai-dlr-release.s3-us-west-2.amazonaws.com/v1.2.0/a1-aarch64-ubuntu18_04-glibc2_27-libstdcpp3_4/dlr-1.2.0-py2.py3-none-any.whl | 
-+------------------------+--------------+---------------+-------------------+--------------------------------------------------------------------------------------------------------------------------------------------+ 
-| armv7l                 | Debian 9.0   | 2.24+         | 3.4+              |https://neo-ai-dlr-release.s3-us-west-2.amazonaws.com/v1.2.0/pi-armv7l-raspbian4.14.71-glibc2_24-libstdcpp3_4/dlr-1.2.0-py2.py3-none-any.whl| 
-+------------------------+--------------+---------------+-------------------+--------------------------------------------------------------------------------------------------------------------------------------------+ 
-
+Please see [Releases](https://github.com/neo-ai/neo-ai-dlr/releases) to download DLR wheels for each DLR release.
 
 ************************
 Building DLR from source


### PR DESCRIPTION
Prebuilt DLR wheels will now be in the releases notes for each release to make maintenance of the documentation pages easier. Update docs to direct users to release notes to get the binaries.