### PR TITLE
Support string inputs for RelayVM via InputMappingCategoricalString

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -433,7 +433,7 @@ if(NOT(AAR_BUILD))
       https://neo-ai-dlr-test-artifacts.s3-us-west-2.amazonaws.com/compiled-models/release-1.4.0/${ONEHOTENCODER_MODEL}
       /tmp/${ONEHOTENCODER_MODEL}
       SHA1
-      87fe203deea1c1ef58a735d12962d96d1c6c64b9
+      d9490ca854fd89280c84646ab3a8e6f558c0ff6a
     )
     # this is OS-agnostic
     execute_process(COMMAND ${CMAKE_COMMAND} -E tar -xf /tmp/${ONEHOTENCODER_MODEL}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -433,7 +433,7 @@ if(NOT(AAR_BUILD))
       https://neo-ai-dlr-test-artifacts.s3-us-west-2.amazonaws.com/compiled-models/release-1.4.0/${ONEHOTENCODER_MODEL}
       /tmp/${ONEHOTENCODER_MODEL}
       SHA1
-      90adc410cf5d9fa591dbbc4e22d0caa04419a787
+      87fe203deea1c1ef58a735d12962d96d1c6c64b9
     )
     # this is OS-agnostic
     execute_process(COMMAND ${CMAKE_COMMAND} -E tar -xf /tmp/${ONEHOTENCODER_MODEL}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -425,6 +425,22 @@ if(NOT(AAR_BUILD))
     file(REMOVE /tmp/${RELAYVM_MODEL})
   endif()
 
+  set(ONEHOTENCODER_MODEL onehotencoder-ml_m4.tar.gz)
+  set(ONEHOTENCODER_MODEL_DIR ${CMAKE_CURRENT_BINARY_DIR}/onehotencoder)
+  if(NOT IS_DIRECTORY ${ONEHOTENCODER_MODEL_DIR})
+    file(MAKE_DIRECTORY ${ONEHOTENCODER_MODEL_DIR})
+    download_file(
+      https://neo-ai-dlr-test-artifacts.s3-us-west-2.amazonaws.com/compiled-models/release-1.4.0/${ONEHOTENCODER_MODEL}
+      /tmp/${ONEHOTENCODER_MODEL}
+      SHA1
+      90adc410cf5d9fa591dbbc4e22d0caa04419a787
+    )
+    # this is OS-agnostic
+    execute_process(COMMAND ${CMAKE_COMMAND} -E tar -xf /tmp/${ONEHOTENCODER_MODEL}
+                    WORKING_DIRECTORY ${ONEHOTENCODER_MODEL_DIR})
+    file(REMOVE /tmp/${ONEHOTENCODER_MODEL})
+  endif()
+
   if(WITH_HEXAGON)
       # Download Test Hexagon model for Android 64 aarch64
       file(MAKE_DIRECTORY dlr_hexagon_model)

--- a/include/dlr_data_transform.h
+++ b/include/dlr_data_transform.h
@@ -1,0 +1,47 @@
+#ifndef DLR_DATA_TRANSFORM_H_
+#define DLR_DATA_TRANSFORM_H_
+
+#include <tvm/runtime/ndarray.h>
+
+#include <nlohmann/json.hpp>
+
+#include "dlr_common.h"
+
+namespace dlr {
+
+/*! \brief Handles transformations of input and output data. */
+class DLR_DLL DataTransform {
+ private:
+  /*! \brief Helper function for TransformInput. Interpets 1-D char input as JSON. */
+  nlohmann::json GetAsJson(const int64_t* shape, void* input, int dim);
+
+  /*! \brief Helper function for TransformInput. Allocates NDArray to store mapped input data. */
+  tvm::runtime::NDArray InitNDArray(int index, const nlohmann::json& input_json,
+                                    const nlohmann::json& mapping, DLDataType dtype, DLContext ctx);
+
+  /*! \brief Helper function for TransformInput. Applies mapping and writes transformed input data
+   * to input_array. */
+  void MapToNDArray(const nlohmann::json& input_json, tvm::runtime::NDArray& input_array,
+                    const nlohmann::json& mapping);
+
+ public:
+  /*! \brief Returns true if the input requires a data transform */
+  bool HasInputTransform(const nlohmann::json& metadata, int index);
+
+  /*! \brief Returns true if the output requires a data transform */
+  bool HasOutputTransform(const nlohmann::json& metadata, int index);
+
+  /*! \brief Transform string input using CategoricalString input DataTransform. When
+   * this map is present in the metadata file, the user is expected to provide string inputs to
+   * SetDLRInput as 1-D vector. This function will interpret the user's input as JSON, apply the
+   * mapping to convert strings to numbers, and produce a numeric NDArray which can be given to TVM
+   * for the model input.
+   */
+  tvm::runtime::NDArray TransformInput(const nlohmann::json& metadata, int index,
+                                       const int64_t* shape, void* input, int dim, DLDataType dtype,
+                                       DLContext ctx);
+};
+
+}  // namespace dlr
+
+#endif  // DLR_DATA_TRANSFORM_H_

--- a/include/dlr_relayvm.h
+++ b/include/dlr_relayvm.h
@@ -52,6 +52,7 @@ class DLR_DLL RelayVMModel : public DLRModel {
   void UpdateOutputs();
   void UpdateInputs();
   DLDataType GetInputDLDataType(int index);
+  void SetStringInput(int index, const int64_t* shape, void* input, int dim);
 
  public:
   explicit RelayVMModel(std::vector<std::string> paths, const DLContext& ctx)

--- a/include/dlr_relayvm.h
+++ b/include/dlr_relayvm.h
@@ -11,7 +11,6 @@
 #include <tvm/runtime/vm/vm.h>
 #include "dlr_common.h"
 
-
 #ifdef _WIN32
 #define LIBEXT ".dll"
 #define LIBDLR "dlr.dll"
@@ -28,7 +27,6 @@
 #else
 #define DLR_DLL
 #endif  // defined(_MSC_VER) || defined(_WIN32)
-
 
 namespace dlr {
 
@@ -53,6 +51,13 @@ class DLR_DLL RelayVMModel : public DLRModel {
   void UpdateInputs();
   DLDataType GetInputDLDataType(int index);
   void SetStringInput(int index, const int64_t* shape, void* input, int dim);
+
+  /*! \brief Helper functions for SetStringInput */
+  nlohmann::json StringInputGetAsJson(const int64_t* shape, void* input, int dim);
+  tvm::runtime::NDArray StringInputInitNDArray(int index, const nlohmann::json& input_json,
+                                               const nlohmann::json& mapping);
+  void StringInputMapToNDArray(const nlohmann::json& input_json, tvm::runtime::NDArray& input_array,
+                               const nlohmann::json& mapping);
 
  public:
   explicit RelayVMModel(std::vector<std::string> paths, const DLContext& ctx)

--- a/include/dlr_relayvm.h
+++ b/include/dlr_relayvm.h
@@ -10,6 +10,7 @@
 #include <tvm/runtime/registry.h>
 #include <tvm/runtime/vm/vm.h>
 #include "dlr_common.h"
+#include "dlr_data_transform.h"
 
 #ifdef _WIN32
 #define LIBEXT ".dll"
@@ -42,6 +43,7 @@ class DLR_DLL RelayVMModel : public DLRModel {
   tvm::runtime::ObjectRef output_ref_;
   std::vector<tvm::runtime::NDArray> outputs_;
   std::vector<std::vector<int64_t>> output_shapes_;
+  DataTransform data_transform_;
   void InitModelPath(std::vector<std::string> paths);
   void SetupVMModule();
   void FetchInputNodesData();
@@ -50,14 +52,6 @@ class DLR_DLL RelayVMModel : public DLRModel {
   void UpdateOutputs();
   void UpdateInputs();
   DLDataType GetInputDLDataType(int index);
-  void SetStringInput(int index, const int64_t* shape, void* input, int dim);
-
-  /*! \brief Helper functions for SetStringInput */
-  nlohmann::json StringInputGetAsJson(const int64_t* shape, void* input, int dim);
-  tvm::runtime::NDArray StringInputInitNDArray(int index, const nlohmann::json& input_json,
-                                               const nlohmann::json& mapping);
-  void StringInputMapToNDArray(const nlohmann::json& input_json, tvm::runtime::NDArray& input_array,
-                               const nlohmann::json& mapping);
 
  public:
   explicit RelayVMModel(std::vector<std::string> paths, const DLContext& ctx)

--- a/src/dlr_data_transform.cc
+++ b/src/dlr_data_transform.cc
@@ -1,0 +1,85 @@
+#include "dlr_data_transform.h"
+
+using namespace dlr;
+
+bool DataTransform::HasInputTransform(const nlohmann::json& metadata, int index) {
+  auto index_str = std::to_string(index);
+  return metadata.count("DataTransform") && metadata["DataTransform"].count("Input") &&
+         metadata["DataTransform"]["Input"].count(index_str) &&
+         metadata["DataTransform"]["Input"][index_str].count("CategoricalString");
+}
+
+bool DataTransform::HasOutputTransform(const nlohmann::json& metadata, int index) {
+  auto index_str = std::to_string(index);
+  return metadata.count("DataTransform") && metadata["DataTransform"].count("Output") &&
+         metadata["DataTransform"]["Output"].count(index_str) &&
+         metadata["DataTransform"]["Output"][index_str].count("CategoricalString");
+}
+
+tvm::runtime::NDArray DataTransform::TransformInput(const nlohmann::json& metadata, int index,
+                                                    const int64_t* shape, void* input, int dim,
+                                                    DLDataType dtype, DLContext ctx) {
+  auto& mapping = metadata["DataTransform"]["Input"][std::to_string(index)]["CategoricalString"];
+  nlohmann::json input_json = GetAsJson(shape, input, dim);
+  tvm::runtime::NDArray input_array = InitNDArray(index, input_json, mapping, dtype, ctx);
+  MapToNDArray(input_json, input_array, mapping);
+  return input_array;
+}
+
+nlohmann::json DataTransform::GetAsJson(const int64_t* shape, void* input, int dim) {
+  CHECK_EQ(dim, 1) << "String input must be 1-D vector.";
+  // Interpret input as json
+  const char* input_str = static_cast<char*>(input);
+  nlohmann::json input_json;
+  try {
+    input_json = nlohmann::json::parse(input_str, input_str + shape[0]);
+  } catch (nlohmann::json::parse_error& e) {
+    LOG(ERROR) << "Invalid JSON input: " << e.what();
+  }
+  CHECK(input_json.is_array() && input_json.size() > 0 && input_json[0].is_array())
+      << "Invalid JSON input: Must be 2-D array.";
+  return input_json;
+}
+
+tvm::runtime::NDArray DataTransform::InitNDArray(int index, const nlohmann::json& input_json,
+                                                 const nlohmann::json& mapping, DLDataType dtype,
+                                                 DLContext ctx) {
+  // Create NDArray for transformed input which will be passed to TVM.
+  std::vector<int64_t> arr_shape = {static_cast<int64_t>(input_json.size()),
+                                    static_cast<int64_t>(input_json[0].size())};
+  CHECK(dtype.code == kDLFloat && dtype.bits == 32 && dtype.lanes == 1)
+      << "DataTransform CategoricalString is only supported for float32 inputs.";
+  return tvm::runtime::NDArray::Empty(arr_shape, dtype, ctx);
+}
+
+void DataTransform::MapToNDArray(const nlohmann::json& input_json,
+                                 tvm::runtime::NDArray& input_array,
+                                 const nlohmann::json& mapping) {
+  DLTensor* input_tensor = const_cast<DLTensor*>(input_array.operator->());
+  // Writing directly to the DLTensor will only work for CPU context. For other contexts, we would
+  // need to create an intermediate buffer on CPU and copy that to the context.
+  CHECK_EQ(input_tensor->ctx.device_type, DLDeviceType::kDLCPU)
+      << "DataTransform CategoricalString is only supported for CPU.";
+  float* data = static_cast<float*>(input_tensor->data);
+  CHECK_EQ(input_json[0].size(), mapping.size())
+      << "Number of columns should match, got " << input_json[0].size() << " but expected "
+      << mapping.size();
+  // Copy data into data, mapping strings to float along the way.
+  for (size_t r = 0; r < input_json.size(); ++r) {
+    CHECK_EQ(input_json[r].size(), mapping.size()) << "Inconsistent number of columns";
+    for (size_t c = 0; c < input_json[r].size(); ++c) {
+      if (mapping[c].size()) {
+        // Look up in map. If not found, use -1.0f.
+        auto data_str = input_json[r][c].get<std::string>();
+        data[r * input_json.size() + c] =
+            mapping[c].count(data_str) ? mapping[c][data_str].get<float>() : -1.0f;
+      } else {
+        // Data is numeric, pass through.
+        CHECK(input_json[r][c].is_number())
+            << "No mapping present in DataTransform CategoricalString for column " << c
+            << ", so the input must be numeric.";
+        data[r * input_json.size() + c] = input_json[r][c].get<float>();
+      }
+    }
+  }
+}

--- a/src/dlr_relayvm.cc
+++ b/src/dlr_relayvm.cc
@@ -181,9 +181,12 @@ DLDataType RelayVMModel::GetInputDLDataType(int index) {
 
 void RelayVMModel::SetInput(const char* name, const int64_t* shape, void* input, int dim) {
   int index = GetInputIndex(name);
+  auto index_str = std::to_string(index);
   // Handle string input.
   if (HasMetadata() && metadata_.count("DataTransform") &&
-      metadata_["DataTransform"].count("InputMappingCategoricalString")) {
+      metadata_["DataTransform"].count("Input") &&
+      metadata_["DataTransform"]["Input"].count(index_str) &&
+      metadata_["DataTransform"]["Input"][index_str].count("CategoricalString")) {
     SetStringInput(index, shape, input, dim);
     return;
   }
@@ -331,7 +334,7 @@ void RelayVMModel::GetOutputByName(const char* name, void* out) {
  * mapping to convert strings to numbers, and produce a numeric NDArray which is given to TVM for
  * the model input.*/
 void RelayVMModel::SetStringInput(int index, const int64_t* shape, void* input, int dim) {
-  auto& mapping = metadata_["DataTransform"]["InputMappingCategoricalString"];
+  auto& mapping = metadata_["DataTransform"]["Input"][std::to_string(index)]["CategoricalString"];
   CHECK_EQ(dim, 1) << "String input must be 1-D vector.";
   // Interpret input as json
   const char* input_str = static_cast<char*>(input);

--- a/tests/cpp/dlr_data_transform_test.cc
+++ b/tests/cpp/dlr_data_transform_test.cc
@@ -1,0 +1,42 @@
+#include "dlr_relayvm.h"
+
+#include <gtest/gtest.h>
+#include "test_utils.hpp"
+
+int main(int argc, char** argv) {
+  testing::InitGoogleTest(&argc, argv);
+#ifndef _WIN32
+  testing::FLAGS_gtest_death_test_style = "threadsafe";
+#endif  // _WIN32
+  return RUN_ALL_TESTS();
+}
+
+TEST(DLR, RelayVMDataTransform) {
+  DLContext ctx = {kDLCPU, 0};
+  std::vector<std::string> paths = {"./onehotencoder"};
+  dlr::RelayVMModel* model = new dlr::RelayVMModel(paths, ctx);
+
+  const char* data = "[[\"apple\", 1, 7], [\"banana\", 3, 8], [\"squash\", 2, 9]]";
+  std::vector<int64_t> shape = {static_cast<int64_t>(std::strlen(data))};
+  model->SetInput("input", shape.data(), const_cast<char*>(data), 1);
+  model->Run();
+
+  int64_t size;
+  int dim;
+  EXPECT_NO_THROW(model->GetOutputSizeDim(0, &size, &dim));
+  EXPECT_EQ(size, 3 * 8);
+  EXPECT_EQ(dim, 2);
+  int64_t output_shape[2];
+  EXPECT_NO_THROW(model->GetOutputShape(0, output_shape));
+  EXPECT_EQ(output_shape[0], 3);
+  EXPECT_EQ(output_shape[1], 8);
+
+  std::vector<float> expected_output = {1, 0, 1, 0, 0, 1, 0, 0, 0, 1, 0, 0,
+                                        1, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 1};
+  std::vector<float> output(size, 0);
+  EXPECT_NO_THROW(model->GetOutput(0, output.data()));
+  for (size_t i = 0; i < expected_output.size(); ++i) {
+    EXPECT_EQ(output[i], expected_output[i]) << "Output at index " << i;
+  }
+  delete model;
+}


### PR DESCRIPTION
Some SKLearn compiled models will expect input in a string format (encoded as JSON). For those models, Neo will add `InputMappingCategoricalString` field to the metadata file. This PR gives DLR the ability to read that key to detect when string inputs are expected, and will apply the mapping to convert the string values to numeric values.

The metadata file entry would look like this:
```
    "DataTransform": {
        "Input": {
            "0": {
                "CategoricalString": [
                    {"apple": 10, "banana": 11},
                    {},
                    {}
                ]
            }
        }
    }
```