### PR TITLE
[Docs] Fix python-api docs

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -18,6 +18,9 @@ from subprocess import call
 import guzzle_sphinx_theme
 sys.path.insert(0, os.path.abspath('../python'))
 os.environ['DLR_BUILD_DOC'] = '1'  # Do not load libdlr.so when building doc
+# Disable phone home
+with open('../python/dlr/counter/ccm_config.json', 'w') as f:
+    f.write('{"enable_phone_home" : false}')
 
 # -- Project information -----------------------------------------------------
 

--- a/python/dlr/counter/system.py
+++ b/python/dlr/counter/system.py
@@ -3,7 +3,6 @@ import platform
 import uuid
 import logging
 import abc
-import distro
 
 
 from .deviceinfo import DeviceInfo
@@ -29,6 +28,7 @@ class Linux:
             _md5uuid = get_hash_string(_uuid.encode())
             self._device.uuid = str(_md5uuid.hexdigest())
             self._device.osname = platform.system()
+            import distro
             dist = distro.linux_distribution()
             self._device.dist = " ".join(x for x in dist)
             self._device.name = platform.node()


### PR DESCRIPTION
Python API docs fail to build due to `WARNING: autodoc: failed to import module 'dlr'; the following exception was raised:
No module named 'distro'`.

This PR changes DLR to import distro when needed and also disables phone home feature for building docs.