### PR TITLE
Add more dlr.h functions to dlr_test

### DIFF
--- a/include/dlr_common.h
+++ b/include/dlr_common.h
@@ -123,7 +123,7 @@ class DLR_DLL DLRModel {
   virtual void GetInput(const char* name, void* input) = 0;
   virtual void SetInput(const char* name, const int64_t* shape, void* input, int dim) = 0;
 
-  /* Ouput related functions */
+  /* Output related functions */
   virtual int GetNumOutputs() { return num_outputs_; }
   virtual const char* GetOutputName(const int index) const { 
     LOG(ERROR) << "GetOutputName is not supported yet!";
@@ -141,7 +141,7 @@ class DLR_DLL DLRModel {
     throw dmlc::Error("GetOutputByName is not supported yet!");
   }
   
-  /* Weights releated functions */
+  /* Weights related functions */
   virtual int GetNumWeights() const { return num_weights_; }
   virtual const char* GetWeightName(int index) const = 0;
   virtual std::vector<std::string> GetWeightNames() const = 0;

--- a/tests/cpp/dlr_test.cc
+++ b/tests/cpp/dlr_test.cc
@@ -24,6 +24,7 @@ TEST(DLR, TestGetDLRNumInputs) {
   int num_inputs;
   EXPECT_EQ(GetDLRNumInputs(&model, &num_inputs), 0);
   EXPECT_EQ(num_inputs, 1);
+  DeleteDLRModel(&model);
 }
 
 TEST(DLR, TestGetDLRNumWeights) {
@@ -31,6 +32,7 @@ TEST(DLR, TestGetDLRNumWeights) {
   int num_weights;
   EXPECT_EQ(GetDLRNumWeights(&model, &num_weights), 0);
   EXPECT_EQ(num_weights, 108);
+  DeleteDLRModel(&model);
 }
 
 TEST(DLR, TestGetDLRInputName) {
@@ -38,6 +40,7 @@ TEST(DLR, TestGetDLRInputName) {
   const char* input_name;
   EXPECT_EQ(GetDLRInputName(&model, 0, &input_name), 0);
   EXPECT_STREQ(input_name, "input_tensor");
+  DeleteDLRModel(&model);
 }
 
 TEST(DLR, TestGetDLRInputType) {
@@ -45,6 +48,7 @@ TEST(DLR, TestGetDLRInputType) {
   const char* input_type;
   EXPECT_EQ(GetDLRInputType(&model, 0, &input_type), 0);
   EXPECT_STREQ(input_type, "float32");
+  DeleteDLRModel(&model);
 }
 
 TEST(DLR, TestGetDLRWeightName) {
@@ -54,6 +58,7 @@ TEST(DLR, TestGetDLRWeightName) {
   EXPECT_STREQ(weight_name, "p0");
   EXPECT_EQ(GetDLRWeightName(&model, 107, &weight_name), 0);
   EXPECT_STREQ(weight_name, "p99");
+  DeleteDLRModel(&model);
 }
 
 TEST(DLR, TestSetDLRInput) {
@@ -69,31 +74,49 @@ TEST(DLR, TestSetDLRInput) {
   EXPECT_EQ(*(img + 224*224), *(in_img + 224*224));
   EXPECT_EQ(*(img + 224*224*3 - 1), *(in_img + 224*224*3 - 1));
   free(in_img);
+  delete [] img;
+  DeleteDLRModel(&model);
 }
 
 
 TEST(DLR, TestGetDLRInputShape) {
   auto model = GetDLRModel();
-
   int64_t input_size;
   int input_dim;
   int index = 0;
   EXPECT_EQ(GetDLRInputSizeDim(&model, 0, &input_size, &input_dim), 0);
   EXPECT_EQ(input_dim, 4);
   EXPECT_EQ(input_size, 1*224*224*3);
+  std::vector<int64_t> shape(input_dim);
+  EXPECT_EQ(GetDLRInputShape(&model, 0, shape.data()), 0);
+  EXPECT_EQ(shape[0], 1);
+  EXPECT_EQ(shape[1], 224);
+  EXPECT_EQ(shape[2], 224);
+  EXPECT_EQ(shape[3], 3);
+  DeleteDLRModel(&model);
 }
 
 TEST(DLR, TestGetDLROutputShape) {
   auto model = GetDLRModel();
-
   int64_t output_size;
   int output_dim;
   int index = 0;
+  // output 0
   EXPECT_EQ(GetDLROutputSizeDim(&model, 0, &output_size, &output_dim), 0);
   EXPECT_EQ(output_dim, 1);
-  
+  EXPECT_EQ(output_size, 1);
+  std::vector<int64_t> shape0(output_dim);
+  EXPECT_EQ(GetDLROutputShape(&model, 0, shape0.data()), 0);
+  EXPECT_EQ(shape0[0], 1);
+  // output 1
   EXPECT_EQ(GetDLROutputSizeDim(&model, 1, &output_size, &output_dim), 0);
   EXPECT_EQ(output_dim, 2);
+  EXPECT_EQ(output_size, 1001);
+  std::vector<int64_t> shape1(output_dim);
+  EXPECT_EQ(GetDLROutputShape(&model, 1, shape1.data()), 0);
+  EXPECT_EQ(shape1[0], 1);
+  EXPECT_EQ(shape1[1], 1001);
+  DeleteDLRModel(&model);
 }
 
 TEST(DLR, TestGetDLRNumOutputs) {
@@ -101,6 +124,85 @@ TEST(DLR, TestGetDLRNumOutputs) {
   int num_outputs;
   EXPECT_EQ(GetDLRNumOutputs(&model, &num_outputs), 0);
   EXPECT_EQ(num_outputs, 2);
+}
+
+TEST(DLR, TestGetDLROutputType) {
+  auto model = GetDLRModel();
+  // output 0
+  const char* output_type0;
+  EXPECT_EQ(GetDLROutputType(&model, 0, &output_type0), 0);
+  EXPECT_STREQ(output_type0, "int32");
+  // output 1
+  const char* output_type1;
+  EXPECT_EQ(GetDLROutputType(&model, 1, &output_type1), 0);
+  EXPECT_STREQ(output_type1, "float32");
+  DeleteDLRModel(&model);
+}
+
+TEST(DLR, GetDLRHasMetadata) {
+  auto model = GetDLRModel();
+  bool has_metadata;
+  EXPECT_EQ(GetDLRHasMetadata(&model, &has_metadata), 0);
+  EXPECT_TRUE(has_metadata);
+  DeleteDLRModel(&model);
+}
+
+TEST(DLR, TestGetDLROutputName) {
+  auto model = GetDLRModel();
+  // output 0
+  const char* output_name0;
+  EXPECT_EQ(GetDLROutputName(&model, 0, &output_name0), 0);
+  EXPECT_STREQ(output_name0, "ArgMax:0");
+  // output 1
+  const char* output_name1;
+  EXPECT_EQ(GetDLROutputName(&model, 1, &output_name1), 0);
+  EXPECT_STREQ(output_name1, "softmax_tensor:0");
+  DeleteDLRModel(&model);
+}
+
+TEST(DLR, TestGetDLROutputIndex) {
+  auto model = GetDLRModel();
+  // output 0
+  int output_index0;
+  EXPECT_EQ(GetDLROutputIndex(&model, "ArgMax:0", &output_index0), 0);
+  EXPECT_EQ(output_index0, 0);
+  // output 1
+  int output_index1;
+  EXPECT_EQ(GetDLROutputIndex(&model, "softmax_tensor:0", &output_index1), 0);
+  EXPECT_EQ(output_index1, 1);
+  DeleteDLRModel(&model);
+}
+
+TEST(DLR, TestGetDLRBackend) {
+  auto model = GetDLRModel();
+  const char* backend;
+  EXPECT_EQ(GetDLRBackend(&model, &backend), 0);
+  EXPECT_STREQ(backend, "tvm");
+  DeleteDLRModel(&model);
+}
+
+TEST(DLR, TestRunDLRModel_GetDLROutput) {
+  auto model = GetDLRModel();
+  size_t img_size = 224*224*3;
+  float* img = LoadImageAndPreprocess("cat224-3.txt", img_size, 1);
+  int64_t shape[4] = {1, 224, 224, 3};
+  const char* input_name = "input_tensor";
+  EXPECT_EQ(SetDLRInput(&model, input_name, shape, img, 4), 0);
+  EXPECT_EQ(RunDLRModel(&model), 0);
+  // output 0
+  int output0[1];
+  EXPECT_EQ(GetDLROutput(&model, 0, output0), 0);
+  EXPECT_EQ(output0[0], 112);
+  EXPECT_EQ(GetDLROutputByName(&model, "ArgMax:0", output0), 0);
+  EXPECT_EQ(output0[0], 112);
+  // output 1
+  float output1[1001];
+  EXPECT_EQ(GetDLROutput(&model, 1, output1), 0);
+  EXPECT_GT(output1[112], 0.01);
+  EXPECT_EQ(GetDLROutputByName(&model, "softmax_tensor:0", output1), 0);
+  EXPECT_GT(output1[112], 0.01);
+  delete [] img;
+  DeleteDLRModel(&model);
 }
 
 


### PR DESCRIPTION
Add more `dlr.h` functions to `dlr_test`
### Test output
```
[       OK ] DLR.TestRunDLRModel_GetDLROutput (268 ms)
[----------] 16 tests from DLR (3832 ms total)

[----------] Global test environment tear-down
[==========] 16 tests from 1 test case ran. (3832 ms total)
[  PASSED  ] 16 tests.
```