### PR TITLE
Start reducing misleading/unnecessary logs and messages

### DIFF
--- a/include/dlr_common.h
+++ b/include/dlr_common.h
@@ -83,11 +83,13 @@ enum class DLRBackend { kTVM, kTREELITE, kHEXAGON, kRELAYVM };
  */
 DLRBackend GetBackend(std::vector<std::string> dirname);
 
-const std::string GetMetadataFile(const std::string& dirname);
+std::string GetMetadataFile(const std::string& dirname);
 
-const DLDeviceType GetDeviceTypeFromString(const std::string& target_backend);
+DLDeviceType GetDeviceTypeFromString(const std::string& target_backend);
 
-const DLDeviceType GetDeviceTypeFromMetadata(const std::vector<std::string>& model_paths);
+std::string GetStringFromDeviceType(DLDeviceType device_type);
+
+DLDeviceType GetDeviceTypeFromMetadata(const std::vector<std::string>& model_paths);
 
 #define CHECK_SHAPE(msg, value, expected) \
   CHECK_EQ(value, expected)               \
@@ -125,12 +127,12 @@ class DLR_DLL DLRModel {
 
   /* Output related functions */
   virtual int GetNumOutputs() { return num_outputs_; }
-  virtual const char* GetOutputName(const int index) const { 
-    LOG(ERROR) << "GetOutputName is not supported yet!";
-    return NULL;
+  virtual const char* GetOutputName(const int index) const {
+    throw dmlc::Error("GetOutputName is not supported for this model.");
+    return nullptr;
   }
-  virtual int GetOutputIndex(const char* name) const { 
-    LOG(ERROR) << "GetOutputName is not supported yet!";
+  virtual int GetOutputIndex(const char* name) const {
+    throw dmlc::Error("GetOutputIndex is not supported for this model.");
     return -1;
   }
   virtual const char* GetOutputType(int index) const = 0;
@@ -146,7 +148,7 @@ class DLR_DLL DLRModel {
   virtual const char* GetWeightName(int index) const = 0;
   virtual std::vector<std::string> GetWeightNames() const = 0;
 
-  virtual const DLDeviceType GetDeviceTypeFromMetadata() const;  
+  virtual DLDeviceType GetDeviceTypeFromMetadata() const;  
   virtual const char* GetBackend() const = 0;
   virtual void SetNumThreads(int threads) = 0;
   virtual bool HasMetadata() const;

--- a/python/dlr/dlr_model.py
+++ b/python/dlr/dlr_model.py
@@ -125,7 +125,6 @@ class DLRModelImpl(IDLRModel):
         if self.backend != "relayvm":
             self._lazy_init_output_shape()
         self._fetch_input_names()
-        self._fetch_output_names()
         self._fetch_input_dtypes()
         self._fetch_output_dtypes()
 
@@ -249,7 +248,7 @@ class DLRModelImpl(IDLRModel):
 
     def get_output_names(self):
         if not self.output_names:
-            raise NotImplementedError
+            self._fetch_output_names()
         return self.output_names
 
     def get_input_dtypes(self):

--- a/python/dlr/neologger.py
+++ b/python/dlr/neologger.py
@@ -23,6 +23,9 @@ def create_logger(log_level=logging.DEBUG, log_to_console=True, log_file=None):
     logger = logging.getLogger(__name__ + "_logger")
     formatter = logging.Formatter('%(asctime)s %(levelname)s %(message)s')
 
+    if logger.hasHandlers():
+        logger.handlers.clear()
+
     if log_file is not None:
         file_handler = logging.FileHandler(log_file)
         file_handler.setFormatter(formatter)

--- a/src/dlr_relayvm.cc
+++ b/src/dlr_relayvm.cc
@@ -26,7 +26,7 @@ void RelayVMModel::InitModelPath(std::vector<std::string> paths) {
   }
 
   if (path_->model_lib.empty() || path_->relay_executable.empty() || path_->metadata.empty()) {
-    LOG(FATAL) << "Invalid model artifact!";
+    throw dmlc::Error("Invalid RelayVM model artifact. Must have .so, .ro, and .meta files.");
   }
 }
 
@@ -76,8 +76,7 @@ void RelayVMModel::FetchInputNodesData() {
       input_types_[i] = metadata_.at("Model").at("Inputs").at(i).at("dtype");
     }
   } catch (nlohmann::json::out_of_range& e) {
-    LOG(ERROR) << e.what();
-    throw dmlc::Error("No Input types metadata found!");
+    throw dmlc::Error("No input types metadata found.");
   }
 }
 
@@ -85,8 +84,7 @@ void RelayVMModel::FetchOutputNodesData() {
   try {
     num_outputs_ = metadata_.at("Model").at("Outputs").size();
   } catch (nlohmann::json::out_of_range& e) {
-    LOG(ERROR) << e.what();
-    throw dmlc::Error("No Output metadata found!");
+    throw dmlc::Error("No output metadata found.");
   }
   output_names_.resize(num_outputs_);
   output_types_.resize(num_outputs_);
@@ -104,8 +102,7 @@ void RelayVMModel::FetchOutputNodesData() {
       };
     }
   } catch (nlohmann::json::out_of_range& e) {
-    LOG(ERROR) << e.what();
-    throw dmlc::Error("No Output metadata found!");
+    throw dmlc::Error("No output metadata found.");
   }
 }
 

--- a/src/dlr_treelite.cc
+++ b/src/dlr_treelite.cc
@@ -47,11 +47,7 @@ ModelPath dlr::GetTreelitePaths(std::vector<std::string> dirname) {
     }
   }
   if (paths.model_lib.empty()) {
-    LOG(INFO) << "No valid Treelite model files found under folder(s):";
-    for (auto dir : dirname) {
-      LOG(INFO) << dir;
-    }
-    LOG(FATAL);
+    throw dmlc::Error("Invalid treelite model artifact. Must have .so file.");
   }
   return paths;
 }
@@ -98,11 +94,8 @@ void TreeliteModel::SetupTreeliteModule(std::vector<std::string> model_path) {
   // version_ = GetVersion(paths.ver_json);
   UpdateInputShapes();
   if (!paths.metadata.empty() && !IsFileEmpty(paths.metadata)) {
-    LOG(INFO) << "Loading metadata file: " << paths.metadata;
     LoadJsonFromFile(paths.metadata, this->metadata_);
     ValidateDeviceTypeIfExists();
-  } else {
-    LOG(INFO) << "No metadata found";
   }
 }
 
@@ -116,7 +109,7 @@ void TreeliteModel::UpdateInputShapes() {
 
 
 std::vector<std::string> TreeliteModel::GetWeightNames() const {
-  LOG(FATAL) << "GetWeightNames is not supported by Treelite backend";
+  throw dmlc::Error("GetWeightNames is not supported by Treelite backend.");
   return std::vector<std::string>();  // unreachable
 }
 
@@ -139,7 +132,7 @@ const char* TreeliteModel::GetInputType(int index) const {
 }
 
 const char* TreeliteModel::GetWeightName(int index) const {
-  LOG(FATAL) << "GetWeightName is not supported by Treelite backend";
+  throw dmlc::Error("GetWeightName is not supported by Treelite backend.");
   return ""; // unreachable
 }
 
@@ -191,7 +184,7 @@ void TreeliteModel::SetInput(const char* name, const int64_t* shape,
 }
 
 void TreeliteModel::GetInput(const char* name, void* input) {
-  LOG(FATAL) << "GetInput is not supported by Treelite backend";
+  throw dmlc::Error("GetInput is not supported by Treelite backend.");
 }
 
 void TreeliteModel::GetOutputShape(int index, int64_t* shape) const {
@@ -239,9 +232,9 @@ void TreeliteModel::Run() {
 const char* TreeliteModel::GetBackend() const { return "treelite"; }
 
 void TreeliteModel::SetNumThreads(int threads) {
-  LOG(FATAL) << "SetNumThreads is not supported by Treelite backend";
+  throw dmlc::Error("SetNumThreads is not supported by Treelite backend.");
 }
 
 void TreeliteModel::UseCPUAffinity(bool use) {
-  LOG(FATAL) << "UseCPUAffinity is not supported by Treelite backend";
+  throw dmlc::Error("UseCPUAffinity is not supported by Treelite backend.");
 }

--- a/tests/cpp/dlr_treelite_test.cc
+++ b/tests/cpp/dlr_treelite_test.cc
@@ -75,9 +75,8 @@ TEST_F(TreeliteTest, TestGetInput) {
     float* observed_input_data = new float[in_size];
     model->GetInput("data", observed_input_data);
     delete[] observed_input_data;
-  } catch (std::exception &e) {
-    std::string err_msg{e.what()};
-    EXPECT_TRUE(err_msg.find("GetInput is not supported by Treelite backend"));
+  } catch (const dmlc::Error& e) {
+    EXPECT_STREQ(e.what(), "GetInput is not supported by Treelite backend.");
   }
 }
 


### PR DESCRIPTION
In many places in DLR, we were logging errors for things that are not errors, and logging additional errors instead of throwing exceptions.

Going forward, we should aim to only throw exceptions in DLR implementation code. Only at the highest level which is the DLR C API wrappers (`src/dlr.cc`) should we actually log the exception message.

It was creating a lot of spam which looks like something bad happened when in fact things are working fine.

Before with no metadata file:
```
$ python3 -c "import dlr; model = dlr.DLRModel('.', 'gpu', 0)"
2020-10-14 20:39:32,687 INFO Could not find libdlr.so in model artifact. Using dlr from /home/ubuntu/.local/lib/python3.6/site-packages/dlr-1.4.0-py3.6.egg/dlr/libdlr.so
2020-10-14 20:39:32,687 INFO Could not find libdlr.so in model artifact. Using dlr from /home/ubuntu/.local/lib/python3.6/site-packages/dlr-1.4.0-py3.6.egg/dlr/libdlr.so
[20:39:33] /data/neo-ai-dlr/src/dlr_tvm.cc:66: No metadata found
[20:39:33] /data/neo-ai-dlr/src/dlr.cc:156: No metadata file was found!
```

After with no metadata file:
```
>>> model = dlr.DLRModel('/opt/ml/model', 'gpu', 0)
2020-10-14 18:20:17,869 INFO Could not find libdlr.so in model artifact. Using dlr from /root/.local/lib/python3.6/site-packages/dlr-1.4.0-py3.6.egg/dlr/libdlr.so
```


Before with empty metadata file:
```
$ python3 -c "import dlr; model = dlr.DLRModel('.', 'gpu', 0)"
2020-10-14 20:40:40,236 INFO Could not find libdlr.so in model artifact. Using dlr from /home/ubuntu/.local/lib/python3.6/site-packages/dlr-1.4.0-py3.6.egg/dlr/libdlr.so
2020-10-14 20:40:40,236 INFO Could not find libdlr.so in model artifact. Using dlr from /home/ubuntu/.local/lib/python3.6/site-packages/dlr-1.4.0-py3.6.egg/dlr/libdlr.so
[20:40:40] /data/neo-ai-dlr/src/dlr_tvm.cc:62: Loading metadata file: ./compiled.meta
[20:40:40] /data/neo-ai-dlr/src/dlr_common.cc:133: [json.exception.out_of_range.403] key 'Requirements' not found
[20:40:40] /data/neo-ai-dlr/src/dlr_common.cc:114: TargetDeviceType was not found in metadata!
[20:40:41] /data/neo-ai-dlr/src/dlr_tvm.cc:259: [json.exception.out_of_range.403] key 'Model' not found
[20:40:41] /data/neo-ai-dlr/src/dlr.cc:156: Output node with index 0 was not found in metadata file!
```

After with empty metadata file:
```
$ python3 -c "import dlr; model = dlr.DLRModel('.', 'gpu', 0)"
2020-10-14 20:40:40,236 INFO Could not find libdlr.so in model artifact. Using dlr from /home/ubuntu/.local/lib/python3.6/site-packages/dlr-1.4.0-py3.6.egg/dlr/libdlr.so
```
