### PR TITLE
Add CreateDLRPipeline

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -441,6 +441,21 @@ if(NOT(AAR_BUILD))
     file(REMOVE /tmp/${ONEHOTENCODER_MODEL})
   endif()
 
+  set(PIPELINE_MODEL1 ${CMAKE_CURRENT_BINARY_DIR}/pipeline_model1)
+  if(NOT IS_DIRECTORY ${PIPELINE_MODEL1})
+    file(MAKE_DIRECTORY ${PIPELINE_MODEL1})
+    download_file(
+      https://neo-ai-dlr-test-artifacts.s3-us-west-2.amazonaws.com/compiled-models/pipeline_model1-LINUX_X86_64.tar.gz
+      /tmp/pipeline_model1-LINUX_X86_64.tar.gz
+      SHA1
+      b605cc76bb38b6462a1bd6881955cb5ae2de3218
+    )
+    # this is OS-agnostic
+    execute_process(COMMAND ${CMAKE_COMMAND} -E tar -xf /tmp/pipeline_model1-LINUX_X86_64.tar.gz
+                    WORKING_DIRECTORY ${PIPELINE_MODEL1})
+    file(REMOVE /tmp/pipeline_model1-LINUX_X86_64.tar.gz)
+  endif()
+
   if(WITH_HEXAGON)
       # Download Test Hexagon model for Android 64 aarch64
       file(MAKE_DIRECTORY dlr_hexagon_model)

--- a/include/dlr.h
+++ b/include/dlr.h
@@ -124,6 +124,22 @@ int CreateDLRModelFromHexagon(DLRModelHandle* handle, const char* model_path,
 #endif  // DLR_HEXAGON
 
 /*!
+ \brief Creates a DLR pipeline model.
+ \param handle The pointer to save the model handle.
+ \param num_models Number of items in model_paths array
+ \param model_paths Paths to the folders containing the models files,
+                    or colon-separated list of folders (or files) if model files
+                    stored in different locations
+ \param dev_type Device type. Valid values are in the DLDeviceType enum in dlpack.h.
+ \param dev_id Device ID.
+ \return 0 for success, -1 for error. Call DLRGetLastError() to get the error message.
+ */
+DLR_DLL
+int CreateDLRPipeline(DLRModelHandle* handle,
+                      int num_models, const char** model_paths,
+                      int dev_type, int dev_id);
+
+/*!
  \brief Deletes a DLR model.
  \param handle The model handle returned from CreateDLRModel().
  \return 0 for success, -1 for error. Call DLRGetLastError() to get the error

--- a/include/dlr_common.h
+++ b/include/dlr_common.h
@@ -77,7 +77,7 @@ inline bool EndsWith(const std::string& mainStr, const std::string& toMatch) {
     return false;
 }
 
-enum class DLRBackend { kTVM, kTREELITE, kHEXAGON, kRELAYVM };
+enum class DLRBackend { kTVM, kTREELITE, kHEXAGON, kRELAYVM, kPIPELINE };
 
 /*! \brief Get the backend based on the contents of the model folder.
  */
@@ -157,6 +157,8 @@ class DLR_DLL DLRModel {
   virtual void Run() = 0;
   
 };
+
+typedef std::shared_ptr<DLRModel> DLRModelPtr;
 
 }  // namespace dlr
 

--- a/include/dlr_pipeline.h
+++ b/include/dlr_pipeline.h
@@ -1,0 +1,66 @@
+#ifndef DLR_PIPELINE_H_
+#define DLR_PIPELINE_H_
+
+#include <graph/graph_runtime.h>
+#include <tvm/runtime/memory.h>
+#include "dlr_common.h"
+
+#if defined(_MSC_VER) || defined(_WIN32)
+#define DLR_DLL __declspec(dllexport)
+#else
+#define DLR_DLL
+#endif  // defined(_MSC_VER) || defined(_WIN32)
+
+namespace dlr {
+
+/*! \brief class PipelineModel
+ */
+class DLR_DLL PipelineModel : public DLRModel {
+ private:
+  int count_;
+  const std::vector<DLRModelPtr> dlr_models_;
+  void CheckModelsCompatibility(const DLRModelPtr& m0, const DLRModelPtr& m1,
+                                const int m1_id, const bool is_runtime_check);
+  void SetupPipelineModel();
+
+ public:
+  /*! \brief Load model files from given folder path.
+   */
+  explicit PipelineModel(const std::vector<DLRModelPtr>& dlr_models, const DLContext& ctx)
+      : DLRModel(ctx, DLRBackend::kPIPELINE), dlr_models_(dlr_models) {
+    SetupPipelineModel();
+  }
+
+  virtual const int GetInputDim(int index) const override;
+  virtual const int64_t GetInputSize(int index) const override;
+  virtual const char* GetInputName(int index) const override;
+  virtual const char* GetInputType(int index) const override;
+  virtual void GetInput(const char* name, void* input) override;
+  virtual void SetInput(const char* name, const int64_t* shape, void* input,
+                        int dim) override;
+
+  virtual void GetOutput(int index, void* out) override;
+  virtual const void* GetOutputPtr(int index) const override;
+  virtual void GetOutputShape(int index, int64_t* shape) const override;
+  virtual void GetOutputSizeDim(int index, int64_t* size, int* dim) override;
+  virtual const char* GetOutputType(int index) const override;
+
+  virtual const char* GetWeightName(int index) const override;
+  virtual std::vector<std::string> GetWeightNames() const override;
+
+  virtual void Run() override;
+  virtual const char* GetBackend() const override;
+  virtual void SetNumThreads(int threads) override;
+  virtual void UseCPUAffinity(bool use) override;
+
+  /*
+    Following methods use metadata file to lookup input and output names.
+  */
+  virtual const char* GetOutputName(const int index) const override;
+  virtual int GetOutputIndex(const char* name) const override;
+  virtual void GetOutputByName(const char* name, void* out) override;
+};
+
+}  // namespace dlr
+
+#endif  // DLR_PIPELINE_H_

--- a/src/dlr_pipeline.cc
+++ b/src/dlr_pipeline.cc
@@ -1,0 +1,182 @@
+#include "dlr_pipeline.h"
+
+#include <stdlib.h>
+#include <cstring>
+#include <fstream>
+#include <iterator>
+#include <numeric>
+
+using namespace dlr;
+
+
+void PipelineModel::CheckModelsCompatibility(const DLRModelPtr& m0, const DLRModelPtr& m1,
+                                             const int m1_id, const bool is_runtime_check) {
+  if (!is_runtime_check) {
+    CHECK_EQ(m0->GetNumOutputs(), m1->GetNumInputs())
+      << "Number of outputs/inputs mismatch between models"
+      << m1_id - 1 << " and " << m1_id << std::endl;
+  }
+  // Check each model input
+  for (int j = 0; j < m1->GetNumInputs(); j++) {
+    int64_t out_size;
+    int out_dim;
+    m0->GetOutputSizeDim(j, &out_size, &out_dim);
+    if (!is_runtime_check) {
+      CHECK_EQ(out_dim, m1->GetInputDim(j))
+        << "Number of dimensions mismatch between output/input #" << j << ", models "
+        << m1_id - 1 << " and " << m1_id << std::endl;
+    }
+    const int64_t in_size = m1->GetInputSize(j);
+    // Skip the check for dynamic sizes (negative size)
+    if (out_size >= 0 && in_size >= 0) {
+      CHECK_EQ(out_size, m1->GetInputSize(j))
+        << "Size mismatch between output/input #" << j << ", models "
+        << m1_id - 1 << " and " << m1_id << std::endl;
+    }
+    if (!is_runtime_check) {
+      CHECK_EQ(strcmp(m0->GetOutputType(j), m1->GetInputType(j)), 0)
+        << "Type mismatch between output/input #" << j << ", models "
+        << m1_id - 1 << " and " << m1_id << std::endl;
+    }
+    std::vector<int64_t> in_shape = m1->GetInputShape(j);
+    std::vector<int64_t> out_shape(in_shape.size());
+    m0->GetOutputShape(j, out_shape.data());
+    for (int k = 0; k < in_shape.size(); k++) {
+      int64_t in_shape_elem = in_shape[k];
+      int64_t out_shape_elem = out_shape[k];
+      // Skip the check for dynamic shape elements (-1)
+      if (in_shape_elem >= 0 && out_shape_elem >= 0) {
+        CHECK_EQ(in_shape_elem, out_shape_elem)
+          << "Shape mismatch between output/input #" << j << ", models "
+          << m1_id - 1 << " and " << m1_id << std::endl;
+      }
+    }
+  }
+}
+
+void PipelineModel::SetupPipelineModel() {
+  CHECK_GT(dlr_models_.size(), 0) << "List of models is empty";
+  count_ = dlr_models_.size();
+  num_inputs_ = dlr_models_[0]->GetNumInputs();
+  num_weights_ = dlr_models_[0]->GetNumWeights();
+  num_outputs_ = dlr_models_.back()->GetNumOutputs();
+  for (int i = 0; i < num_inputs_; i++) {
+    input_names_.push_back(dlr_models_[0]->GetInputName(i));
+    input_types_.push_back(dlr_models_[0]->GetInputType(i));
+    input_shapes_.push_back(dlr_models_[0]->GetInputShape(i));
+  }
+  // Check previous model outputs and current model inputs compatibility
+  for (int i = 1; i < count_; i++) {
+    const DLRModelPtr prev_model = dlr_models_[i - 1];
+    const DLRModelPtr curr_model = dlr_models_[i];
+    CheckModelsCompatibility(prev_model, curr_model, i /*m1_id*/, false /*is_runtime_check*/);
+  }
+}
+
+std::vector<std::string> PipelineModel::GetWeightNames() const {
+  return dlr_models_[0]->GetWeightNames();
+}
+
+const char* PipelineModel::GetInputName(int index) const {
+  return dlr_models_[0]->GetInputName(index);
+}
+
+const char* PipelineModel::GetInputType(int index) const {
+  return dlr_models_[0]->GetInputType(index);
+}
+
+const int PipelineModel::GetInputDim(int index) const {
+  return dlr_models_[0]->GetInputDim(index);
+}
+
+const int64_t PipelineModel::GetInputSize(int index) const {
+  return dlr_models_[0]->GetInputSize(index);
+}
+
+const char* PipelineModel::GetWeightName(int index) const {
+  return dlr_models_[0]->GetWeightName(index);
+}
+
+void PipelineModel::SetInput(const char* name, const int64_t* shape, void* input, int dim) {
+  dlr_models_[0]->SetInput(name, shape, input, dim);
+}
+
+void PipelineModel::GetInput(const char* name, void* input) {
+  dlr_models_[0]->GetInput(name, input);
+}
+
+void PipelineModel::GetOutputShape(int index, int64_t* shape) const {
+  dlr_models_.back()->GetOutputShape(index, shape);
+}
+
+void PipelineModel::GetOutput(int index, void* out) {
+  dlr_models_.back()->GetOutput(index, out);
+}
+
+const void* PipelineModel::GetOutputPtr(int index) const {
+  return dlr_models_.back()->GetOutputPtr(index);
+}
+
+void PipelineModel::GetOutputSizeDim(int index, int64_t* size, int* dim) {
+  dlr_models_.back()->GetOutputSizeDim(index, size, dim);
+}
+
+const char* PipelineModel::GetOutputType(int index) const {
+  return dlr_models_.back()->GetOutputType(index);
+}
+
+void PipelineModel::Run() {
+  dlr_models_[0]->Run();
+  for (int i = 1; i < count_; i++) {
+    const DLRModelPtr prev_model = dlr_models_[i - 1];
+    const DLRModelPtr curr_model = dlr_models_[i];
+    CheckModelsCompatibility(prev_model, curr_model, i /*m1_id*/, true /*is_runtime_check*/);
+    // for each model input
+    for (int j = 0; j < curr_model->GetNumInputs(); j++) {
+      const char* input_name = curr_model->GetInputName(j);
+      const std::vector<int64_t> input_shape = curr_model->GetInputShape(j);
+      const int input_dim = curr_model->GetInputDim(j);
+      const void* prev_model_output = prev_model->GetOutputPtr(j);
+      curr_model->SetInput(input_name, input_shape.data(), (void*)prev_model_output, input_dim);
+    }
+    curr_model->Run();
+  }
+}
+
+const char* PipelineModel::GetBackend() const { return "pipeline"; }
+
+void PipelineModel::SetNumThreads(int threads) {
+  // Try to set Number of Threads to pipeline models
+  // Ignore the errors in case some of the models do not support this feature.
+  for (DLRModelPtr m : dlr_models_) {
+    try {
+      m->SetNumThreads(threads);
+    } catch (dmlc::Error& e) {
+      // ignore
+    }
+  }
+}
+
+void PipelineModel::UseCPUAffinity(bool use) {
+  // Try to set UseCPUAffinity to pipeline models.
+  // Ignore the errors in case some of the models do not support this feature.
+  for (DLRModelPtr m : dlr_models_) {
+    try {
+      m->UseCPUAffinity(use);
+    } catch (dmlc::Error& e) {
+      // ignore
+    }
+  }
+}
+
+const char* PipelineModel::GetOutputName(const int index) const {
+  return dlr_models_.back()->GetOutputName(index);
+}
+
+int PipelineModel::GetOutputIndex(const char* name) const {
+  return dlr_models_.back()->GetOutputIndex(name);
+}
+
+void PipelineModel::GetOutputByName(const char* name, void* out) {
+  return dlr_models_.back()->GetOutputByName(name, out);
+}

--- a/tests/cpp/dlr_pipeline_test.cc
+++ b/tests/cpp/dlr_pipeline_test.cc
@@ -1,0 +1,216 @@
+#include <gtest/gtest.h>
+#include "dlr.h"
+#include "test_utils.hpp"
+
+DLRModelHandle GetDLRModel() {
+  DLRModelHandle model = NULL;
+/*
+                        --== Test Model Summary ==--
+________________________________________________________________________________
+Layer (type)                    Output Shape         Param #     Connected to
+================================================================================
+input_0 (InputLayer)            [(None, 4, 4, 1)]    0
+________________________________________________________________________________
+input_1 (InputLayer)            [(None, 4, 4, 1)]    0
+________________________________________________________________________________
+output_0 (Add)                  (None, 4, 4, 1)      0           input_0[0][0]
+                                                                 input_1[0][0]
+________________________________________________________________________________
+output_1 (Multiply)             (None, 4, 4, 1)      0           input_0[0][0]
+                                                                 input_1[0][0]
+================================================================================
+*/
+  const char* model_path0  = "./pipeline_model1";
+  const char* model_path1  = "./pipeline_model1";
+  const char* model_path2  = "./pipeline_model1";
+  int device_type = 1; // cpu;
+  const char* model_paths[3] = {model_path0, model_path1, model_path2};
+  if (CreateDLRPipeline(&model, 3 /*count*/, model_paths, device_type, 0) != 0) {
+    LOG(INFO) << DLRGetLastError() << std::endl;
+    throw std::runtime_error("Could not load DLR Model");
+  }
+  return model;
+}
+
+
+TEST(PipelineTest, TestGetDLRDeviceType) {
+  const char* model_path  = "./pipeline_model1";
+  EXPECT_EQ(GetDLRDeviceType(model_path), -1);
+}
+
+TEST(PipelineTest, TestGetDLRNumInputs) {
+  auto model = GetDLRModel();
+  int num_inputs;
+  EXPECT_EQ(GetDLRNumInputs(&model, &num_inputs), 0);
+  EXPECT_EQ(num_inputs, 2);
+  DeleteDLRModel(&model);
+}
+
+TEST(PipelineTest, TestGetDLRNumWeights) {
+  auto model = GetDLRModel();
+  int num_weights;
+  EXPECT_EQ(GetDLRNumWeights(&model, &num_weights), 0);
+  EXPECT_EQ(num_weights, 0);
+  DeleteDLRModel(&model);
+}
+
+TEST(PipelineTest, TestGetDLRInputName) {
+  auto model = GetDLRModel();
+  const char* input_name;
+  EXPECT_EQ(GetDLRInputName(&model, 0, &input_name), 0);
+  EXPECT_STREQ(input_name, "input_0");
+  EXPECT_EQ(GetDLRInputName(&model, 1, &input_name), 0);
+  EXPECT_STREQ(input_name, "input_1");
+  DeleteDLRModel(&model);
+}
+
+TEST(PipelineTest, TestGetDLRInputType) {
+  auto model = GetDLRModel();
+  const char* input_type;
+  EXPECT_EQ(GetDLRInputType(&model, 0, &input_type), 0);
+  EXPECT_STREQ(input_type, "float32");
+  EXPECT_EQ(GetDLRInputType(&model, 1, &input_type), 0);
+  EXPECT_STREQ(input_type, "float32");
+  DeleteDLRModel(&model);
+}
+
+TEST(PipelineTest, TestSetDLRInput) {
+  auto model = GetDLRModel();
+  size_t img_size = 4*4;
+  std::vector<float> img(img_size, 0.1);
+  int64_t shape[4] = {1, 1, 4, 4};
+  const char* input_name = "input_0";
+  float* in_img = (float*) malloc(sizeof(float) * img_size);
+  EXPECT_EQ(SetDLRInput(&model, input_name, shape, img.data(), 4), 0);
+  EXPECT_EQ(GetDLRInput(&model, input_name, in_img), 0);
+  EXPECT_EQ(img[0], *in_img);
+  EXPECT_EQ(img[4], *(in_img + 4));
+  EXPECT_EQ(img[img_size - 1], *(in_img + img_size - 1));
+  free(in_img);
+  DeleteDLRModel(&model);
+}
+
+
+TEST(PipelineTest, TestGetDLRInputShape) {
+  auto model = GetDLRModel();
+  int64_t input_size;
+  int input_dim;
+  int index = 0;
+  EXPECT_EQ(GetDLRInputSizeDim(&model, 0, &input_size, &input_dim), 0);
+  EXPECT_EQ(input_dim, 4);
+  EXPECT_EQ(input_size, 16);
+  std::vector<int64_t> shape(input_dim);
+  EXPECT_EQ(GetDLRInputShape(&model, 0, shape.data()), 0);
+  EXPECT_EQ(shape[0], 1);
+  EXPECT_EQ(shape[1], 1);
+  EXPECT_EQ(shape[2], 4);
+  EXPECT_EQ(shape[3], 4);
+  DeleteDLRModel(&model);
+}
+
+TEST(PipelineTest, TestGetDLROutputShape) {
+  auto model = GetDLRModel();
+  int64_t output_size;
+  int output_dim;
+  int index = 0;
+  // output 0
+  EXPECT_EQ(GetDLROutputSizeDim(&model, 0, &output_size, &output_dim), 0);
+  EXPECT_EQ(output_dim, 4);
+  EXPECT_EQ(output_size, 16);
+  std::vector<int64_t> shape0(output_dim);
+  EXPECT_EQ(GetDLROutputShape(&model, 0, shape0.data()), 0);
+  EXPECT_EQ(shape0[0], 1);
+  EXPECT_EQ(shape0[1], 1);
+  EXPECT_EQ(shape0[2], 4);
+  EXPECT_EQ(shape0[3], 4);
+  // output 1
+  EXPECT_EQ(GetDLROutputSizeDim(&model, 1, &output_size, &output_dim), 0);
+  EXPECT_EQ(output_dim, 4);
+  EXPECT_EQ(output_size, 16);
+  std::vector<int64_t> shape1(output_dim);
+  EXPECT_EQ(GetDLROutputShape(&model, 1, shape1.data()), 0);
+  EXPECT_EQ(shape1[0], 1);
+  EXPECT_EQ(shape1[1], 1);
+  EXPECT_EQ(shape1[2], 4);
+  EXPECT_EQ(shape1[3], 4);
+  DeleteDLRModel(&model);
+}
+
+TEST(PipelineTest, TestGetDLRNumOutputs) {
+  auto model = GetDLRModel();
+  int num_outputs;
+  EXPECT_EQ(GetDLRNumOutputs(&model, &num_outputs), 0);
+  EXPECT_EQ(num_outputs, 2);
+}
+
+TEST(PipelineTest, TestGetDLROutputType) {
+  auto model = GetDLRModel();
+  // output 0
+  const char* output_type0;
+  EXPECT_EQ(GetDLROutputType(&model, 0, &output_type0), 0);
+  EXPECT_STREQ(output_type0, "float32");
+  // output 1
+  const char* output_type1;
+  EXPECT_EQ(GetDLROutputType(&model, 1, &output_type1), 0);
+  EXPECT_STREQ(output_type1, "float32");
+  DeleteDLRModel(&model);
+}
+
+TEST(PipelineTest, GetDLRHasMetadata) {
+  auto model = GetDLRModel();
+  bool has_metadata;
+  EXPECT_EQ(GetDLRHasMetadata(&model, &has_metadata), 0);
+  EXPECT_FALSE(has_metadata);
+  DeleteDLRModel(&model);
+}
+
+TEST(PipelineTest, TestGetDLRBackend) {
+  auto model = GetDLRModel();
+  const char* backend;
+  EXPECT_EQ(GetDLRBackend(&model, &backend), 0);
+  EXPECT_STREQ(backend, "pipeline");
+  DeleteDLRModel(&model);
+}
+
+TEST(PipelineTest, TestRunDLRModel_GetDLROutput) {
+  auto model = GetDLRModel();
+  size_t img_size = 4*4;
+  std::vector<float> img0(img_size, 0.1);
+  std::vector<float> img1(img_size, 0.3);
+  int64_t shape[4] = {1, 1, 4, 4};
+  const char* input_name0 = "input_0";
+  const char* input_name1 = "input_1";
+  EXPECT_EQ(SetDLRInput(&model, input_name0, shape, img0.data(), 4), 0);
+  EXPECT_EQ(SetDLRInput(&model, input_name1, shape, img1.data(), 4), 0);
+  EXPECT_EQ(RunDLRModel(&model), 0);
+  // output 0
+  float output0[16];
+  EXPECT_EQ(GetDLROutput(&model, 0, output0), 0);
+  EXPECT_LE(output0[0] - 0.442, 1e-6);
+  float* output0_p;
+  EXPECT_EQ(GetDLROutputPtr(&model, 0, (const void**) &output0_p), 0);
+  EXPECT_LE(output0_p[0] - 0.442, 1e-6);
+  for (int i = 0; i < 16; i++) {
+    EXPECT_EQ(output0_p[i], output0[i]);
+  }
+  // output 1
+  float output1[16];
+  EXPECT_EQ(GetDLROutput(&model, 1, output1), 0);
+  EXPECT_LE(output1[0] - 0.00516, 1e-6);
+  float* output1_p;
+  EXPECT_EQ(GetDLROutputPtr(&model, 1, (const void**) &output1_p), 0);
+  EXPECT_LE(output1_p[0] - 0.00516, 1e-6);
+  for (int i = 0; i < 16; i++) {
+    EXPECT_EQ(output1_p[i], output1[i]);
+  }
+  DeleteDLRModel(&model);
+}
+
+
+int main(int argc, char** argv) {
+  testing::InitGoogleTest(&argc, argv);
+#ifndef _WIN32
+  testing::FLAGS_gtest_death_test_style = "threadsafe";
+#endif  // _WIN32
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
This PR adds `CreateDLRPipeline` to `dlr.h`

```
int CreateDLRPipeline(DLRModelHandle* handle,
                      int num_models,
                      const char** model_paths,
                      int dev_type,
                      int dev_id;
```

Resulting DLR model will execute its underlying models one after another