### PR TITLE
[DataTransform] Use kBadValue for invalid input float values

### DIFF
--- a/include/dlr_data_transform.h
+++ b/include/dlr_data_transform.h
@@ -14,6 +14,8 @@ class DLR_DLL DataTransform {
  private:
   /*! \brief When there is no mapping entry for TransformInput, this value is used. */
   const float kMissingValue = -1.0f;
+  /*! \brief When there is an invalid float value given to TransformInput, this value is used. */
+  const float kBadValue = std::numeric_limits<float>::quiet_NaN();
 
   /*! \brief Helper function for TransformInput. Interpets 1-D char input as JSON. */
   nlohmann::json GetAsJson(const int64_t* shape, void* input, int dim) const;

--- a/src/dlr_data_transform.cc
+++ b/src/dlr_data_transform.cc
@@ -69,7 +69,7 @@ void DataTransform::MapToNDArray(const nlohmann::json& input_json,
     CHECK_EQ(input_json[r].size(), mapping.size()) << "Inconsistent number of columns";
     for (size_t c = 0; c < input_json[r].size(); ++c) {
       const int out_index = r * input_json[r].size() + c;
-      if (mapping[c].size()) {
+      if (!mapping[c].empty()) {
         // Look up in map. If not found, use kMissingValue.
         try {
           const std::string& data_str = input_json[r][c].get_ref<const std::string&>();

--- a/src/dlr_data_transform.cc
+++ b/src/dlr_data_transform.cc
@@ -92,6 +92,7 @@ void DataTransform::MapToNDArray(const nlohmann::json& input_json,
           data[r * input_json.size() + c] = kBadValue;
         }
       }
+      LOG(INFO) <<  data[r * input_json.size() + c];
     }
   }
 }

--- a/src/dlr_data_transform.cc
+++ b/src/dlr_data_transform.cc
@@ -68,31 +68,28 @@ void DataTransform::MapToNDArray(const nlohmann::json& input_json,
   for (size_t r = 0; r < input_json.size(); ++r) {
     CHECK_EQ(input_json[r].size(), mapping.size()) << "Inconsistent number of columns";
     for (size_t c = 0; c < input_json[r].size(); ++c) {
+      const int out_index = r * input_json[r].size() + c;
       if (mapping[c].size()) {
         // Look up in map. If not found, use kMissingValue.
         try {
-          std::string data_str;
-          input_json[r][c].get_to(data_str);
+          const std::string& data_str = input_json[r][c].get_ref<const std::string&>();
           auto it = mapping[c].find(data_str);
-          data[r * input_json.size() + c] =
-              it != mapping[c].end() ? it->operator float() : kMissingValue;
+          data[out_index] = it != mapping[c].end() ? it->operator float() : kMissingValue;
         } catch (const std::exception& ex) {
           // Any error will fallback safely to kMissingValue.
-          data[r * input_json.size() + c] = kMissingValue;
+          data[out_index] = kMissingValue;
         }
       } else {
         // Data is numeric, pass through. Attempt to convert string to float.
         try {
-          data[r * input_json.size() + c] =
-              input_json[r][c].is_number()
-                  ? input_json[r][c].get<float>()
-                  : std::stof(input_json[r][c].get_ref<const std::string&>());
+          data[out_index] = input_json[r][c].is_number()
+                                ? input_json[r][c].get<float>()
+                                : std::stof(input_json[r][c].get_ref<const std::string&>());
         } catch (const std::exception& ex) {
           // Any error will fallback safely to kBadValue.
-          data[r * input_json.size() + c] = kBadValue;
+          data[out_index] = kBadValue;
         }
       }
-      LOG(INFO) <<  data[r * input_json.size() + c];
     }
   }
 }

--- a/tests/cpp/dlr_data_transform_test.cc
+++ b/tests/cpp/dlr_data_transform_test.cc
@@ -1,4 +1,5 @@
 #include "dlr_relayvm.h"
+#include "dlr_data_transform.h"
 
 #include <gtest/gtest.h>
 #include "test_utils.hpp"
@@ -9,6 +10,60 @@ int main(int argc, char** argv) {
   testing::FLAGS_gtest_death_test_style = "threadsafe";
 #endif  // _WIN32
   return RUN_ALL_TESTS();
+}
+
+TEST(DLR, DataTransformCategoricalString) {
+  dlr::DataTransform transform;
+  nlohmann::json metadata = R"(
+    {
+      "DataTransform": {
+        "Input": {
+          "0": {
+            "CategoricalString": [
+              { "apple": 0, "banana": 1, "7": 2 }
+            ]
+          }
+        }
+      }
+    })"_json;
+  EXPECT_TRUE(transform.HasInputTransform(metadata, 0));
+  EXPECT_FALSE(transform.HasInputTransform(metadata, 1));
+
+  // User input
+  const char* data = R"([["apple"], ["banana"], ["7"], [7], ["walrus"], [-5]])";
+  std::vector<int64_t> shape = {static_cast<int64_t>(std::strlen(data))};
+  // Model input
+  DLDataType dtype = DLDataType{kDLFloat, 32, 1};
+  DLContext ctx = DLContext{kDLCPU, 0};
+  tvm::runtime::NDArray transformed_data;
+  EXPECT_NO_THROW(transformed_data = transform.TransformInput(metadata, 0, shape.data(), const_cast<char*>(data), shape.size(), dtype, ctx));
+
+  std::vector<float> expected_output = {0, 1, 2, 2, -1, -1};
+  EXPECT_EQ(transformed_data->ndim, 2);
+  EXPECT_EQ(transformed_data->shape[0], 6);
+  EXPECT_EQ(transformed_data->shape[1], 1);
+  for (size_t i = 0; i < expected_output.size(); ++i) {
+    CHECK_EQ(static_cast<float*>(transformed_data->data)[i], expected_output[i]) << i;
+  }
+}
+
+TEST(DLR, DataTransformCategoricalStringNumericColumn) {
+  dlr::DataTransform transform;
+  nlohmann::json metadata = R"(
+    {
+      "DataTransform": {
+        "Input": {
+          "0": {
+            "CategoricalString": [
+              {}
+            ]
+          }
+        }
+      }
+    })"_json;
+  EXPECT_TRUE(transform.HasInputTransform(metadata, 0));
+  // tvm::runtime::NDArray transformed;
+  // EXPECT_NO_THROW(transformed, transform.TransformInput());
 }
 
 TEST(DLR, RelayVMDataTransformInput) {


### PR DESCRIPTION
For string input columns, unknown input strings are mapped to kMissingValue (-1).
For float input columns, invalid float inputs are now mapped to kBadValue (NaN) instead of -1, because -1 was a valid float.