### PR TITLE
Fix invalid device type error in ValidateDeviceTypeIfExists (expected and given values were reversed)

### DIFF
--- a/src/dlr_common.cc
+++ b/src/dlr_common.cc
@@ -111,8 +111,8 @@ void DLRModel::ValidateDeviceTypeIfExists() {
   }
   if (device_type != 0 && ctx_.device_type != device_type) {
     std::string msg = "Compiled model requires device type \"";
-    msg += GetStringFromDeviceType(ctx_.device_type) + "\" but user gave \"";
-    msg += GetStringFromDeviceType(device_type) + "\".";
+    msg += GetStringFromDeviceType(device_type) + "\" but user gave \"";
+    msg += GetStringFromDeviceType(ctx_.device_type) + "\".";
     throw dmlc::Error(msg);
   }
 }

--- a/tests/cpp/dlr_tvm_test.cc
+++ b/tests/cpp/dlr_tvm_test.cc
@@ -208,7 +208,17 @@ TEST(TVM, TestTvmModelGetDeviceTypeFromMetadata) {
   mocked_metadata << "{\"Requirements\": { \"TargetDevice\": \"ML_C4\", \"TargetDeviceType\": \"gpu\"}}\n";
   mocked_metadata.close();
 
-  EXPECT_THROW(dlr::TVMModel(paths, ctx), dmlc::Error);
+  EXPECT_THROW(
+      ({
+        try {
+          dlr::TVMModel(paths, ctx);
+        } catch (const dmlc::Error& e) {
+          EXPECT_STREQ(e.what(),
+                       "Compiled model requires device type \"gpu\" but user gave \"cpu\".");
+          throw;
+        }
+      }),
+      dmlc::Error);
 
   // put it back
   std::rename(metadata_file_bak.c_str(), metadata_file.c_str());


### PR DESCRIPTION
* ValidateDeviceTypeIfExists had the wrong values for expected value and given value in the error message. I.e. cpu and gpu were swapped in `Compiled model requires device type "gpu" but user gave "cpu".`
* Updated unit test to check exception message