### PR TITLE
Treelite output size should be -1 if input is not set

### DIFF
--- a/demo/cpp/model_peeker.cc
+++ b/demo/cpp/model_peeker.cc
@@ -51,20 +51,19 @@ void peek_model(DLRModelHandle model) {
   }
   std::cout << std::endl;
 
-  std::vector<std::vector<int64_t>> input_shapes(num_inputs);
   std::cout << "input shapes: " << std::endl;
   for (int i = 0; i < num_inputs; i++) {
     int64_t size = 0;
     int dim = 0;
     GetDLRInputSizeDim(&model, i, &size, &dim);
-    input_shapes[i].resize(dim);
-    GetDLRInputShape(&model, i, input_shapes[i].data());
+    std::vector<int64_t> input_shape(dim);
+    GetDLRInputShape(&model, i, input_shape.data());
     std::cout << "[";
     for (int id = 0; id < dim; id++) {
       if (id > 0) std::cout << ", ";
-      std::cout << std::to_string(input_shapes[i][id]);
+      std::cout << std::to_string(input_shape[id]);
     }
-    std::cout << "]" << std::endl;
+    std::cout << "], size: " << size << std::endl;
   }
 
   // weight_names.resize(num_weights);
@@ -101,20 +100,19 @@ void peek_model(DLRModelHandle model) {
   }
   std::cout << std::endl;
 
-  std::vector<std::vector<int64_t>> output_shapes(num_outputs);
   std::cout << "output shapes: " << std::endl;
   for (int i = 0; i < num_outputs; i++) {
     int64_t size = 0;
     int dim = 0;
     GetDLROutputSizeDim(&model, i, &size, &dim);
-    output_shapes[i].resize(dim);
-    GetDLROutputShape(&model, i, output_shapes[i].data());
+    std::vector<int64_t> output_shape(dim);
+    GetDLROutputShape(&model, i, output_shape.data());
     std::cout << "[";
     for (int id = 0; id < dim; id++) {
       if (id > 0) std::cout << ", ";
-      std::cout << std::to_string(output_shapes[i][id]);
+      std::cout << std::to_string(output_shape[id]);
     }
-    std::cout << "]" << std::endl;
+    std::cout << "], size: " << size << std::endl;
   }
 }
 

--- a/src/dlr_relayvm.cc
+++ b/src/dlr_relayvm.cc
@@ -292,8 +292,12 @@ void RelayVMModel::GetOutputSizeDim(int index, int64_t* size, int* dim) {
     }
     *dim = arr->ndim;
   } else {
-    *size = std::accumulate(output_shapes_[index].begin(), output_shapes_[index].end(), 1,
-                            std::multiplies<int64_t>());
+    if (dlr::HasNegative(output_shapes_[index].data(), output_shapes_[index].size())) {
+      *size = -1;
+    } else {
+      *size = std::accumulate(output_shapes_[index].begin(), output_shapes_[index].end(), 1,
+                              std::multiplies<int64_t>());
+    }
     *dim = output_shapes_[index].size();
   }
 }

--- a/src/dlr_treelite.cc
+++ b/src/dlr_treelite.cc
@@ -122,6 +122,7 @@ const int TreeliteModel::GetInputDim(int index) const { return kInputDim; }
 const int64_t TreeliteModel::GetInputSize(int index) const {
   CHECK_LT(index, num_inputs_) << "Input index is out of range.";
   const std::vector<int64_t>& shape = GetInputShape(index);
+  if (dlr::HasNegative(shape.data(), shape.size())) return -1;
   return abs(std::accumulate(shape.begin(), shape.end(), 1,
                          std::multiplies<int64_t>()));
 }
@@ -212,7 +213,7 @@ void TreeliteModel::GetOutputSizeDim(int index, int64_t* size, int* dim) {
         static_cast<int64_t>(treelite_input_->num_row * treelite_output_size_);
   } else {
     // Input is yet unspecified and batch is not known
-    *size = treelite_output_size_;
+    *size = -1;
   }
   *dim = 2;
 }

--- a/tests/cpp/dlr_treelite_test.cc
+++ b/tests/cpp/dlr_treelite_test.cc
@@ -89,8 +89,14 @@ TEST_F(TreeliteTest, TestGetOutputType) {
 }
 
 TEST_F(TreeliteTest, TestGetOutputShape) {
-  EXPECT_NO_THROW(model->SetInput("data", in_shape, data, in_dim));
   int64_t out_shape[2];
+  // input is not set - output batch and size are unknown.
+  EXPECT_NO_THROW(model->GetOutputShape(0, out_shape));
+  EXPECT_EQ(out_shape[0], -1);
+  EXPECT_EQ(out_shape[1], 1);
+  // Set input
+  EXPECT_NO_THROW(model->SetInput("data", in_shape, data, in_dim));
+  // Check OutputShape again
   EXPECT_NO_THROW(model->GetOutputShape(0, out_shape));
   EXPECT_EQ(out_shape[0], 1);
   EXPECT_EQ(out_shape[1], 1);
@@ -99,6 +105,13 @@ TEST_F(TreeliteTest, TestGetOutputShape) {
 TEST_F(TreeliteTest, TestGetOutputSizeDim) {
   int64_t output_size;
   int output_dim;
+  EXPECT_NO_THROW(model->GetOutputSizeDim(0, &output_size, &output_dim));
+  // input is not set - output batch and size are unknown.
+  EXPECT_EQ(output_size, -1);
+  EXPECT_EQ(output_dim, out_dim);
+  // Set input
+  EXPECT_NO_THROW(model->SetInput("data", in_shape, data, in_dim));
+  // Check OutputSizeDim again
   EXPECT_NO_THROW(model->GetOutputSizeDim(0, &output_size, &output_dim));
   EXPECT_EQ(output_size, out_size);
   EXPECT_EQ(output_dim, out_dim);


### PR DESCRIPTION
Changes:
- Treelite input size should be -1 if input shape has negative elements
- Treelite output size should be -1 if input is not set
- Relayvm OutputSize should be -1 if output shape has negative elements. (Relayvm has special if block to calculate output size if number of outputs is exactly 1.)
- Add input/output size info to model_peeker output
```
# bin/model_peeker sklearn-preproc/
backend is relayvm
num_inputs = 1
num_weights = 0
num_outputs = 1
input_names: input, 
input_types: json, 
input shapes: 
[-1, -1], size: -1
output_names: output (index: 0), 
output_types: float32, 
output shapes: 
[-1, 2], size: -1

# bin/model_peeker xgboost-sm/     
backend is treelite
num_inputs = 1
num_weights = 0
num_outputs = 1
input_names: data, 
input_types: float32, 
input shapes: 
[-1, 2], size: -1
output_names: [03:37:14] /root/workplace/neo-ai-dlr/src/dlr.cc:166: GetOutputName is not supported for this model.
<unknown> (index: 0), 
output_types: float32, 
output shapes: 
[-1, 1], size: -1
```