### PR TITLE
Add SetDLRCustomAllocator API.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -75,7 +75,7 @@ pipeline {
             mkdir -p build
             cd build
             cmake .. && make -j16
-            make test
+            CTEST_OUTPUT_ON_FAILURE=TRUE make test
             cd ..
             tests/ci_build/create_wheel.sh manylinux1_x86_64
             """

--- a/include/dlr.h
+++ b/include/dlr.h
@@ -42,8 +42,6 @@ typedef void* DLRModelHandle;
 #define DLR_ALLOC_TYPEDEF
 /*! \brief A pointer to a malloc-like function. */
 typedef void* (*DLRMallocFunctionPtr)(size_t);
-/*! \brief A pointer to a realloc-like function. */
-typedef void* (*DLRReallocFunctionPtr)(void*, size_t);
 /*! \brief A pointer to a free-like function. */
 typedef void (*DLRFreeFunctionPtr)(void*);
 /*! \brief A pointer to a memalign-like function. */
@@ -430,19 +428,34 @@ DLR_DLL
 int UseDLRCPUAffinity(DLRModelHandle* handle, int use);
 
 /*!
- * \brief Set custom allocator functions. This must be called before CreateDLRModel or
- *        CreateDLRPipeline.
- * \param custom_malloc_fn Function pointer to malloc-like function.
- * \param custom_realloc_fn Function pointer to realloc-like function. Can be null.
- * \param custom_free_fn Function pointer to free-like function.
+ * \brief Set custom allocator malloc function. Must be called before CreateDLRModel or
+ *        CreateDLRPipeline. It is recommended to use with SetDLRCustomAllocatorFree and
+ *        SetDLRCustomAllocatorMemalign.
  * \param custom_memalign_fn Function pointer to memalign-like function.
  * \return 0 for success, -1 for error. Call DLRGetLastError() to get the error message.
  */
 DLR_DLL
-int SetDLRCustomAllocator(DLRMallocFunctionPtr custom_malloc_fn,
-                          DLRReallocFunctionPtr custom_realloc_fn,
-                          DLRFreeFunctionPtr custom_free_fn,
-                          DLRMemalignFunctionPtr custom_memalign_fn);
+int SetDLRCustomAllocatorMalloc(DLRMallocFunctionPtr custom_malloc_fn);
+
+/*!
+ * \brief Set custom allocator free function. Must be called before CreateDLRModel or
+ *        CreateDLRPipeline. It is recommended to use with SetDLRCustomAllocatorMalloc and
+ *        SetDLRCustomAllocatorMemalign.
+ * \param custom_free_fn Function pointer to free-like function.
+ * \return 0 for success, -1 for error. Call DLRGetLastError() to get the error message.
+ */
+DLR_DLL
+int SetDLRCustomAllocatorFree(DLRFreeFunctionPtr custom_free_fn);
+
+/*!
+ * \brief Set custom allocator memalign function. memalign is used heavily by the TVM and RelayVM
+ *        backends. Must be called before CreateDLRModel or CreateDLRPipeline. It is recommended
+ *        to use with SetDLRCustomAllocatorMalloc and  SetDLRCustomAllocatorFree.
+ * \param custom_memalign_fn Function pointer to memalign-like function.
+ * \return 0 for success, -1 for error. Call DLRGetLastError() to get the error message.
+ */
+DLR_DLL
+int SetDLRCustomAllocatorMemalign(DLRMemalignFunctionPtr custom_memalign_fn);
 
 /*! \} */
 

--- a/include/dlr.h
+++ b/include/dlr.h
@@ -1,6 +1,7 @@
 #ifndef DLR_H_
 #define DLR_H_
 
+#include <stddef.h>
 #include <stdint.h>
 
 /* special symbols for DLL library on Windows */
@@ -36,6 +37,18 @@ extern "C" {  // Open extern "C" block
  \brief Handle for DLRModel.
  */
 typedef void* DLRModelHandle;
+
+#ifndef DLR_ALLOC_TYPEDEF
+#define DLR_ALLOC_TYPEDEF
+/*! \brief A pointer to a malloc-like function. */
+typedef void* (*DLRMallocFunctionPtr)(size_t);
+/*! \brief A pointer to a realloc-like function. */
+typedef void* (*DLRReallocFunctionPtr)(void*, size_t);
+/*! \brief A pointer to a free-like function. */
+typedef void (*DLRFreeFunctionPtr)(void*);
+/*! \brief A pointer to a memalign-like function. */
+typedef void* (*DLRMemalignFunctionPtr)(size_t, size_t);
+#endif
 
 /*!
  \brief Creates a DLR model.
@@ -415,6 +428,21 @@ int SetDLRNumThreads(DLRModelHandle* handle, int threads);
  */
 DLR_DLL
 int UseDLRCPUAffinity(DLRModelHandle* handle, int use);
+
+/*!
+ * \brief Set custom allocator functions. This must be called before CreateDLRModel or
+ *        CreateDLRPipeline.
+ * \param custom_malloc_fn Function pointer to malloc-like function.
+ * \param custom_realloc_fn Function pointer to realloc-like function. Can be null.
+ * \param custom_free_fn Function pointer to free-like function.
+ * \param custom_memalign_fn Function pointer to memalign-like function.
+ * \return 0 for success, -1 for error. Call DLRGetLastError() to get the error message.
+ */
+DLR_DLL
+int SetDLRCustomAllocator(DLRMallocFunctionPtr custom_malloc_fn,
+                          DLRReallocFunctionPtr custom_realloc_fn,
+                          DLRFreeFunctionPtr custom_free_fn,
+                          DLRMemalignFunctionPtr custom_memalign_fn);
 
 /*! \} */
 

--- a/include/dlr_allocator.h
+++ b/include/dlr_allocator.h
@@ -1,8 +1,7 @@
 #ifndef DLR_ALLOCATOR_H_
 #define DLR_ALLOCATOR_H_
 
-#include <dmlc/common.h>
-#include <dmlc/logging.h>
+#include <memory>
 
 #ifndef DLR_ALLOC_TYPEDEF
 #define DLR_ALLOC_TYPEDEF

--- a/include/dlr_allocator.h
+++ b/include/dlr_allocator.h
@@ -1,0 +1,106 @@
+#ifndef DLR_ALLOCATOR_H_
+#define DLR_ALLOCATOR_H_
+
+#include <dmlc/common.h>
+#include <dmlc/logging.h>
+
+#ifndef DLR_ALLOC_TYPEDEF
+#define DLR_ALLOC_TYPEDEF
+/*! \brief A pointer to a malloc-like function. */
+typedef void* (*DLRMallocFunctionPtr)(size_t);
+/*! \brief A pointer to a realloc-like function. */
+typedef void* (*DLRReallocFunctionPtr)(void*, size_t);
+/*! \brief A pointer to a free-like function. */
+typedef void (*DLRFreeFunctionPtr)(void*);
+/*! \brief A pointer to a memalign-like function. */
+typedef void* (*DLRMemalignFunctionPtr)(size_t, size_t);
+#endif
+
+namespace dlr {
+
+/*! \brief Stores custom allocation functions. */
+class DLRAllocatorFunctions {
+ private:
+  /*! \brief Custom malloc-like function, nullptr if not set. */
+  static DLRMallocFunctionPtr malloc_fn_;
+
+  /*! \brief Custom realloac-like function, nullptr if not set. Not currently used. */
+  static DLRReallocFunctionPtr realloc_fn_;
+
+  /*! \brief Custom free-like function, nullptr if not set. */
+  static DLRFreeFunctionPtr free_fn_;
+
+  /*! \brief Custom memalign-like function, nullptr if not set. */
+  static DLRMemalignFunctionPtr memalign_fn_;
+
+ public:
+  /*! \brief Set global allocator functions. */
+  static void Set(DLRMallocFunctionPtr malloc_fn, DLRReallocFunctionPtr realloc_fn,
+                  DLRFreeFunctionPtr free_fn, DLRMemalignFunctionPtr memalign_fn);
+
+  /*! \brief Get current malloc function pointer, returns nullptr if not set. */
+  static DLRMallocFunctionPtr GetMallocFunction();
+
+  /*! \brief Get current realloc function pointer, returns nullptr if not set. */
+  static DLRReallocFunctionPtr GetReallocFunction();
+
+  /*! \brief Get current free function pointer, returns nullptr if not set. */
+  static DLRFreeFunctionPtr GetFreeFunction();
+
+  /*! \brief Get current memalign function pointer, returns nullptr if not set. */
+  static DLRMemalignFunctionPtr GetMemalignFunction();
+
+  /*! \brief Clear global allocator functions. */
+  static void Clear();
+
+  /*! \brief Check if global allocator functions are set. */
+  static bool IsSet();
+
+  /*! \brief Allocate data, using custom allocator if set, otherwise use malloc. */
+  static void* Malloc(size_t size);
+
+  /*! \brief Free data, using custom free if set, otherwise use free. */
+  static void Free(void* ptr);
+};
+
+/*! \brief STL-compatible allocator using allocator functions from DLRAllocatorFunctions. */
+template <typename T>
+class DLRAllocator : public std::allocator<T> {
+ private:
+  using Base = std::allocator<T>;
+  using Pointer = typename std::allocator_traits<Base>::pointer;
+  using SizeType = typename std::allocator_traits<Base>::size_type;
+
+ public:
+  DLRAllocator() = default;
+
+  template <typename U>
+  DLRAllocator(const DLRAllocator<U>& a) : Base(a) {}
+
+  template <typename U>
+  struct rebind {
+    using other = DLRAllocator<U>;
+  };
+
+  Pointer allocate(SizeType n) {
+    if (DLRAllocatorFunctions::IsSet()) {
+      return static_cast<T*>(DLRAllocatorFunctions::Malloc(n * sizeof(T)));
+    }
+    return Base::allocate(n);
+  }
+
+  void deallocate(Pointer p, SizeType n) {
+    if (DLRAllocatorFunctions::IsSet()) {
+      DLRAllocatorFunctions::Free(p);
+      return;
+    }
+    Base::deallocate(p, n);
+  }
+};
+
+/*! \brief ostringstream which uses the custom allocators. */
+typedef std::basic_ostringstream<char, std::char_traits<char>, DLRAllocator<char>> DLRStringStream;
+
+}  // namespace dlr
+
+#endif  // DLR_ALLOCATOR_H_

--- a/include/dlr_common.h
+++ b/include/dlr_common.h
@@ -10,6 +10,8 @@
 #include <string>
 #include <vector>
 
+#include "dlr_allocator.h"
+
 #define LINE_SIZE 256
 
 #ifndef _WIN32

--- a/include/dlr_common.h
+++ b/include/dlr_common.h
@@ -5,8 +5,8 @@
 #include <dmlc/logging.h>
 #include <runtime_base.h>
 #include <sys/types.h>
-#include <nlohmann/json.hpp>
 
+#include <nlohmann/json.hpp>
 #include <string>
 #include <vector>
 

--- a/include/dlr_treelite.h
+++ b/include/dlr_treelite.h
@@ -3,8 +3,8 @@
 
 #include <treelite/c_api_runtime.h>
 
-#include "dlr_common.h"
 #include "dlr_allocator.h"
+#include "dlr_common.h"
 
 #if defined(_MSC_VER) || defined(_WIN32)
 #define DLR_DLL __declspec(dllexport)

--- a/include/dlr_treelite.h
+++ b/include/dlr_treelite.h
@@ -4,6 +4,7 @@
 #include <treelite/c_api_runtime.h>
 
 #include "dlr_common.h"
+#include "dlr_allocator.h"
 
 #if defined(_MSC_VER) || defined(_WIN32)
 #define DLR_DLL __declspec(dllexport)
@@ -16,9 +17,9 @@ namespace dlr {
 /*! \brief Structure to hold Treelite Input.
  */
 struct TreeliteInput {
-  std::vector<float> data;
-  std::vector<uint32_t> col_ind;
-  std::vector<size_t> row_ptr;
+  std::vector<float, DLRAllocator<float>> data;
+  std::vector<uint32_t, DLRAllocator<uint32_t>> col_ind;
+  std::vector<size_t, DLRAllocator<size_t>> row_ptr;
   size_t num_row;
   size_t num_col;
   CSRBatchHandle handle;
@@ -44,7 +45,7 @@ class DLR_DLL TreeliteModel : public DLRModel {
   // size of output per instance
   size_t treelite_output_size_;
   std::unique_ptr<TreeliteInput> treelite_input_;
-  std::vector<float> treelite_output_;
+  std::vector<float, DLRAllocator<float>> treelite_output_;
   void SetupTreeliteModule(std::vector<std::string> model_path);
   void UpdateInputShapes();
 

--- a/src/dlr.cc
+++ b/src/dlr.cc
@@ -376,12 +376,20 @@ extern "C" int UseDLRCPUAffinity(DLRModelHandle* handle, int use) {
   API_END();
 }
 
-extern "C" int SetDLRCustomAllocator(DLRMallocFunctionPtr custom_malloc_fn,
-                                     DLRReallocFunctionPtr custom_realloc_fn,
-                                     DLRFreeFunctionPtr custom_free_fn,
-                                     DLRMemalignFunctionPtr custom_memalign_fn) {
+extern "C" int SetDLRCustomAllocatorMalloc(DLRMallocFunctionPtr custom_malloc_fn) {
   API_BEGIN();
-  DLRAllocatorFunctions::Set(custom_malloc_fn, custom_realloc_fn, custom_free_fn,
-                             custom_memalign_fn);
+  DLRAllocatorFunctions::SetMallocFunction(custom_malloc_fn);
+  API_END();
+}
+
+extern "C" int SetDLRCustomAllocatorFree(DLRFreeFunctionPtr custom_free_fn) {
+  API_BEGIN();
+  DLRAllocatorFunctions::SetFreeFunction(custom_free_fn);
+  API_END();
+}
+
+extern "C" int SetDLRCustomAllocatorMemalign(DLRMemalignFunctionPtr custom_memalign_fn) {
+  API_BEGIN();
+  DLRAllocatorFunctions::SetMemalignFunction(custom_memalign_fn);
   API_END();
 }

--- a/src/dlr.cc
+++ b/src/dlr.cc
@@ -375,3 +375,13 @@ extern "C" int UseDLRCPUAffinity(DLRModelHandle* handle, int use) {
   model->UseCPUAffinity(use);
   API_END();
 }
+
+extern "C" int SetDLRCustomAllocator(DLRMallocFunctionPtr custom_malloc_fn,
+                                     DLRReallocFunctionPtr custom_realloc_fn,
+                                     DLRFreeFunctionPtr custom_free_fn,
+                                     DLRMemalignFunctionPtr custom_memalign_fn) {
+  API_BEGIN();
+  DLRAllocatorFunctions::Set(custom_malloc_fn, custom_realloc_fn, custom_free_fn,
+                             custom_memalign_fn);
+  API_END();
+}

--- a/src/dlr_allocator.cc
+++ b/src/dlr_allocator.cc
@@ -3,25 +3,20 @@
 namespace dlr {
 
 DLRMallocFunctionPtr DLRAllocatorFunctions::malloc_fn_ = nullptr;
-DLRReallocFunctionPtr DLRAllocatorFunctions::realloc_fn_ = nullptr;
 DLRFreeFunctionPtr DLRAllocatorFunctions::free_fn_ = nullptr;
 DLRMemalignFunctionPtr DLRAllocatorFunctions::memalign_fn_ = nullptr;
 
-void DLRAllocatorFunctions::Set(DLRMallocFunctionPtr malloc_fn, DLRReallocFunctionPtr realloc_fn,
-                                DLRFreeFunctionPtr free_fn, DLRMemalignFunctionPtr memalign_fn) {
-  // realloc is not used yet, so it is not checked.
-  if (!malloc_fn) throw dmlc::Error("Custom malloc was not set.");
-  if (!free_fn) throw dmlc::Error("Custom free was not set.");
-  if (!memalign_fn) throw dmlc::Error("Custom memalign was not set.");
+void DLRAllocatorFunctions::SetMallocFunction(DLRMallocFunctionPtr malloc_fn) {
   malloc_fn_ = malloc_fn;
-  realloc_fn_ = realloc_fn;
-  free_fn_ = free_fn;
+}
+
+void DLRAllocatorFunctions::SetFreeFunction(DLRFreeFunctionPtr free_fn) { free_fn_ = free_fn; }
+
+void DLRAllocatorFunctions::SetMemalignFunction(DLRMemalignFunctionPtr memalign_fn) {
   memalign_fn_ = memalign_fn;
 }
 
 DLRMallocFunctionPtr DLRAllocatorFunctions::GetMallocFunction() { return malloc_fn_; }
-
-DLRReallocFunctionPtr DLRAllocatorFunctions::GetReallocFunction() { return realloc_fn_; }
 
 DLRFreeFunctionPtr DLRAllocatorFunctions::GetFreeFunction() { return free_fn_; }
 
@@ -29,21 +24,24 @@ DLRMemalignFunctionPtr DLRAllocatorFunctions::GetMemalignFunction() { return mem
 
 void DLRAllocatorFunctions::Clear() {
   malloc_fn_ = nullptr;
-  realloc_fn_ = nullptr;
   free_fn_ = nullptr;
   memalign_fn_ = nullptr;
 }
 
-bool DLRAllocatorFunctions::IsSet() {
+bool DLRAllocatorFunctions::AllSet() {
   return malloc_fn_ != nullptr && free_fn_ != nullptr && memalign_fn_ != nullptr;
 }
 
+bool DLRAllocatorFunctions::AnySet() {
+  return malloc_fn_ != nullptr || free_fn_ != nullptr || memalign_fn_ != nullptr;
+}
+
 void* DLRAllocatorFunctions::Malloc(size_t size) {
-  return IsSet() ? (*malloc_fn_)(size) : malloc(size);
+  return malloc_fn_ ? (*malloc_fn_)(size) : malloc(size);
 }
 
 void DLRAllocatorFunctions::Free(void* ptr) {
-  if (IsSet()) {
+  if (free_fn_) {
     (*free_fn_)(ptr);
   } else {
     free(ptr);

--- a/src/dlr_allocator.cc
+++ b/src/dlr_allocator.cc
@@ -1,0 +1,53 @@
+#include "dlr_allocator.h"
+
+namespace dlr {
+
+DLRMallocFunctionPtr DLRAllocatorFunctions::malloc_fn_ = nullptr;
+DLRReallocFunctionPtr DLRAllocatorFunctions::realloc_fn_ = nullptr;
+DLRFreeFunctionPtr DLRAllocatorFunctions::free_fn_ = nullptr;
+DLRMemalignFunctionPtr DLRAllocatorFunctions::memalign_fn_ = nullptr;
+
+void DLRAllocatorFunctions::Set(DLRMallocFunctionPtr malloc_fn, DLRReallocFunctionPtr realloc_fn,
+                                DLRFreeFunctionPtr free_fn, DLRMemalignFunctionPtr memalign_fn) {
+  // realloc is not used yet, so it is not checked.
+  if (!malloc_fn) throw dmlc::Error("Custom malloc was not set.");
+  if (!free_fn) throw dmlc::Error("Custom free was not set.");
+  if (!memalign_fn) throw dmlc::Error("Custom memalign was not set.");
+  malloc_fn_ = malloc_fn;
+  realloc_fn_ = realloc_fn;
+  free_fn_ = free_fn;
+  memalign_fn_ = memalign_fn;
+}
+
+DLRMallocFunctionPtr DLRAllocatorFunctions::GetMallocFunction() { return malloc_fn_; }
+
+DLRReallocFunctionPtr DLRAllocatorFunctions::GetReallocFunction() { return realloc_fn_; }
+
+DLRFreeFunctionPtr DLRAllocatorFunctions::GetFreeFunction() { return free_fn_; }
+
+DLRMemalignFunctionPtr DLRAllocatorFunctions::GetMemalignFunction() { return memalign_fn_; }
+
+void DLRAllocatorFunctions::Clear() {
+  malloc_fn_ = nullptr;
+  realloc_fn_ = nullptr;
+  free_fn_ = nullptr;
+  memalign_fn_ = nullptr;
+}
+
+bool DLRAllocatorFunctions::IsSet() {
+  return malloc_fn_ != nullptr && free_fn_ != nullptr && memalign_fn_ != nullptr;
+}
+
+void* DLRAllocatorFunctions::Malloc(size_t size) {
+  return IsSet() ? (*malloc_fn_)(size) : malloc(size);
+}
+
+void DLRAllocatorFunctions::Free(void* ptr) {
+  if (IsSet()) {
+    (*free_fn_)(ptr);
+  } else {
+    free(ptr);
+  }
+}
+
+}  // namespace dlr

--- a/src/dlr_relayvm.cc
+++ b/src/dlr_relayvm.cc
@@ -33,6 +33,17 @@ void RelayVMModel::InitModelPath(std::vector<std::string> paths) {
 }
 
 void RelayVMModel::SetupVMModule() {
+  // Set custom allocators in TVM.
+  if (dlr::DLRAllocatorFunctions::IsSet()) {
+    auto* pf = tvm::runtime::Registry::Get("runtime.contrib.set_custom_cpu_allocator");
+    if (pf) {
+      (*pf)(reinterpret_cast<void*>(dlr::DLRAllocatorFunctions::GetMemalignFunction()),
+            reinterpret_cast<void*>(dlr::DLRAllocatorFunctions::GetFreeFunction()));
+    } else {
+      LOG(WARNING) << "Custom allocator functions are not available. Using default allocators.";
+    }
+  }
+
   tvm::runtime::Module lib = tvm::runtime::Module::LoadFromFile(path_->model_lib);
   std::ifstream relay_ob(path_->relay_executable, std::ios::binary);
   std::string code_data((std::istreambuf_iterator<char>(relay_ob)),

--- a/src/dlr_treelite.cc
+++ b/src/dlr_treelite.cc
@@ -156,6 +156,9 @@ void TreeliteModel::SetInput(const char* name, const int64_t* shape,
   float* input_f = (float*) input;
 
   // NOTE: Assume row-major (C) layout
+  treelite_input_->data.reserve(batch_size * num_col);
+  treelite_input_->col_ind.reserve(batch_size * num_col);
+  treelite_input_->row_ptr.reserve(batch_size);
   for (size_t i = 0; i < batch_size; ++i) {
     for (uint32_t j = 0; j < num_col; ++j) {
       if (!std::isnan(input_f[i * num_col + j])) {

--- a/src/dlr_tvm.cc
+++ b/src/dlr_tvm.cc
@@ -1,8 +1,8 @@
 #include "dlr_tvm.h"
 
+#include <stdlib.h>
 #include <tvm/runtime/registry.h>
 
-#include <stdlib.h>
 #include <fstream>
 #include <iterator>
 #include <numeric>
@@ -76,7 +76,6 @@ void TVMModel::SetupTVMModule(std::vector<std::string> model_path) {
     LoadJsonFromFile(paths.metadata, this->metadata_);
     ValidateDeviceTypeIfExists();
   }
-
 
   tvm_graph_runtime_ = tvm::runtime::make_object<tvm::runtime::GraphRuntime>();
   tvm_graph_runtime_->Init(json_blob.str(), module, {ctx_});

--- a/src/dlr_tvm.cc
+++ b/src/dlr_tvm.cc
@@ -45,7 +45,8 @@ ModelPath dlr::GetTvmPaths(std::vector<std::string> dirname) {
 
 void TVMModel::SetupTVMModule(std::vector<std::string> model_path) {
   // Set custom allocators in TVM.
-  if (dlr::DLRAllocatorFunctions::IsSet()) {
+  if (dlr::DLRAllocatorFunctions::GetMemalignFunction() &&
+      dlr::DLRAllocatorFunctions::GetFreeFunction()) {
     auto* pf = tvm::runtime::Registry::Get("runtime.contrib.set_custom_cpu_allocator");
     if (pf) {
       (*pf)(reinterpret_cast<void*>(dlr::DLRAllocatorFunctions::GetMemalignFunction()),
@@ -53,6 +54,9 @@ void TVMModel::SetupTVMModule(std::vector<std::string> model_path) {
     } else {
       LOG(WARNING) << "Custom allocator functions are not available. Using default allocators.";
     }
+  } else if (dlr::DLRAllocatorFunctions::AnySet()) {
+    LOG(WARNING) << "SetDLRCustomAllocatorFree() and SetDLRCustomAllocatorMemalign() must be set "
+                    "to override TVM allocations. Using default allocators.";
   }
 
   ModelPath paths = GetTvmPaths(model_path);

--- a/tests/cpp/dlr_allocator_test.cc
+++ b/tests/cpp/dlr_allocator_test.cc
@@ -1,9 +1,9 @@
 #include "dlr_allocator.h"
-#include "dlr.h"
-#include "dlr_tvm.h"
 
 #include <gtest/gtest.h>
 
+#include "dlr.h"
+#include "dlr_tvm.h"
 #include "test_utils.hpp"
 
 int main(int argc, char** argv) {

--- a/tests/cpp/dlr_allocator_test.cc
+++ b/tests/cpp/dlr_allocator_test.cc
@@ -1,0 +1,204 @@
+#include "dlr_allocator.h"
+#include "dlr.h"
+#include "dlr_tvm.h"
+
+#include <gtest/gtest.h>
+
+#include "test_utils.hpp"
+
+int main(int argc, char** argv) {
+  testing::InitGoogleTest(&argc, argv);
+#ifndef _WIN32
+  testing::FLAGS_gtest_death_test_style = "threadsafe";
+#endif  // _WIN32
+  return RUN_ALL_TESTS();
+}
+
+class CustomAllocatorTest : public ::testing::Test {
+ protected:
+  CustomAllocatorTest() { dlr::DLRAllocatorFunctions::Clear(); }
+};
+
+void* test_malloc(size_t size) { throw dmlc::Error("Using custom alloc"); }
+
+void test_free(void* ptr) { throw dmlc::Error("Using custom free"); }
+
+void* test_memalign(size_t alignment, size_t size) { throw dmlc::Error("Using custom memalign"); }
+
+TEST_F(CustomAllocatorTest, CustomAllocatorsUnused) {
+  EXPECT_FALSE(dlr::DLRAllocatorFunctions::IsSet());
+  EXPECT_EQ(dlr::DLRAllocatorFunctions::GetMallocFunction(), nullptr);
+  EXPECT_EQ(dlr::DLRAllocatorFunctions::GetReallocFunction(), nullptr);
+  EXPECT_EQ(dlr::DLRAllocatorFunctions::GetFreeFunction(), nullptr);
+  EXPECT_EQ(dlr::DLRAllocatorFunctions::GetMemalignFunction(), nullptr);
+  void* p = nullptr;
+  EXPECT_NO_THROW(p = dlr::DLRAllocatorFunctions::Malloc(1));
+  EXPECT_NO_THROW(dlr::DLRAllocatorFunctions::Free(p));
+}
+
+TEST_F(CustomAllocatorTest, CustomAllocatorsMissingFunctions) {
+  EXPECT_FALSE(dlr::DLRAllocatorFunctions::IsSet());
+  EXPECT_THROW(dlr::DLRAllocatorFunctions::Set(test_malloc, nullptr, nullptr, nullptr),
+               dmlc::Error);
+  EXPECT_FALSE(dlr::DLRAllocatorFunctions::IsSet());
+  EXPECT_EQ(dlr::DLRAllocatorFunctions::GetMallocFunction(), nullptr);
+  EXPECT_EQ(dlr::DLRAllocatorFunctions::GetReallocFunction(), nullptr);
+  EXPECT_EQ(dlr::DLRAllocatorFunctions::GetFreeFunction(), nullptr);
+  EXPECT_EQ(dlr::DLRAllocatorFunctions::GetMemalignFunction(), nullptr);
+}
+
+TEST_F(CustomAllocatorTest, CustomAllocatorsUsed) {
+  EXPECT_NO_THROW(dlr::DLRAllocatorFunctions::Set(test_malloc, nullptr, test_free, test_memalign));
+  EXPECT_TRUE(dlr::DLRAllocatorFunctions::IsSet());
+  EXPECT_EQ(dlr::DLRAllocatorFunctions::GetMallocFunction(), test_malloc);
+  EXPECT_EQ(dlr::DLRAllocatorFunctions::GetReallocFunction(), nullptr);
+  EXPECT_EQ(dlr::DLRAllocatorFunctions::GetFreeFunction(), test_free);
+  EXPECT_EQ(dlr::DLRAllocatorFunctions::GetMemalignFunction(), test_memalign);
+  EXPECT_THROW(
+      {
+        try {
+          dlr::DLRAllocatorFunctions::Malloc(4);
+        } catch (const dmlc::Error& e) {
+          EXPECT_STREQ(e.what(), "Using custom alloc");
+          throw;
+        }
+      },
+      dmlc::Error);
+  EXPECT_THROW(
+      {
+        try {
+          dlr::DLRAllocatorFunctions::Free(nullptr);
+        } catch (const dmlc::Error& e) {
+          EXPECT_STREQ(e.what(), "Using custom free");
+          throw;
+        }
+      },
+      dmlc::Error);
+}
+
+TEST_F(CustomAllocatorTest, CustomAllocatorsSTLUnset) {
+  EXPECT_FALSE(dlr::DLRAllocatorFunctions::IsSet());
+  std::vector<int, dlr::DLRAllocator<int>>* data;
+  EXPECT_NO_THROW((data = new std::vector<int, dlr::DLRAllocator<int>>(1024)));
+  EXPECT_NO_THROW((delete data));
+}
+
+TEST_F(CustomAllocatorTest, CustomAllocatorsSTLSet) {
+  EXPECT_FALSE(dlr::DLRAllocatorFunctions::IsSet());
+  EXPECT_NO_THROW(dlr::DLRAllocatorFunctions::Set(test_malloc, nullptr, test_free, test_memalign));
+  EXPECT_TRUE(dlr::DLRAllocatorFunctions::IsSet());
+
+  EXPECT_THROW(({
+                 std::vector<int, dlr::DLRAllocator<int>>* data;
+                 try {
+                   data = new std::vector<int, dlr::DLRAllocator<int>>(1024);
+                 } catch (const dmlc::Error& e) {
+                   EXPECT_STREQ(e.what(), "Using custom alloc");
+                   throw;
+                 }
+               }),
+               dmlc::Error);
+
+  EXPECT_THROW(({
+                 std::vector<int, dlr::DLRAllocator<int>>* data =
+                     new std::vector<int, dlr::DLRAllocator<int>>(256);
+                 try {
+                   delete data;
+                 } catch (const dmlc::Error& e) {
+                   EXPECT_STREQ(e.what(), "Using custom free");
+                   throw;
+                 }
+               }),
+               dmlc::Error);
+}
+
+class CustomAllocatorTrackingTest : public CustomAllocatorTest {
+ protected:
+  ~CustomAllocatorTrackingTest() {
+    malloc_calls_.clear();
+    free_calls_.clear();
+    memalign_calls_.clear();
+  }
+
+  size_t TotalBytesAllocated() {
+    size_t sum = 0;
+    for (auto& pair : malloc_calls_) {
+      sum += pair.first;
+    }
+    for (auto& tuple : memalign_calls_) {
+      sum += std::get<1>(tuple);
+    }
+    return sum;
+  }
+
+ public:
+  static std::vector<std::pair<size_t, void*>> malloc_calls_;
+  static std::vector<void*> free_calls_;
+  static std::vector<std::tuple<size_t, size_t, void*>> memalign_calls_;
+};
+
+std::vector<std::pair<size_t, void*>> CustomAllocatorTrackingTest::malloc_calls_;
+std::vector<void*> CustomAllocatorTrackingTest::free_calls_;
+std::vector<std::tuple<size_t, size_t, void*>> CustomAllocatorTrackingTest::memalign_calls_;
+
+void* tracking_malloc(size_t size) {
+  void* ptr = malloc(size);
+  CustomAllocatorTrackingTest::malloc_calls_.push_back({size, ptr});
+  return ptr;
+}
+
+void tracking_free(void* ptr) {
+  CustomAllocatorTrackingTest::free_calls_.push_back(ptr);
+  free(ptr);
+}
+
+void* tracking_memalign(size_t alignment, size_t size) {
+  void* ptr;
+#if _MSC_VER
+  ptr = _aligned_malloc(size, alignment);
+  if (ptr == nullptr) throw std::bad_alloc();
+#else
+  // posix_memalign is available in android ndk since __ANDROID_API__ >= 17
+  int ret = posix_memalign(&ptr, alignment, size);
+  if (ret != 0) throw std::bad_alloc();
+#endif
+  CustomAllocatorTrackingTest::memalign_calls_.push_back({alignment, size, ptr});
+  return ptr;
+}
+
+TEST_F(CustomAllocatorTrackingTest, CustomAllocatorsTvm) {
+  SetDLRCustomAllocator(tracking_malloc, nullptr, tracking_free, tracking_memalign);
+  DLRModelHandle model = nullptr;
+  EXPECT_EQ(CustomAllocatorTrackingTest::malloc_calls_.size(), 0);
+  EXPECT_EQ(CustomAllocatorTrackingTest::free_calls_.size(), 0);
+  EXPECT_EQ(CustomAllocatorTrackingTest::memalign_calls_.size(), 0);
+  EXPECT_EQ(TotalBytesAllocated(), 0);
+
+  // Test that memalign, free, malloc have been called after loading the model.
+  EXPECT_EQ(CreateDLRModel(&model, "./resnet_v1_5_50", /*device_type=*/1, 0), 0);
+  EXPECT_GT(CustomAllocatorTrackingTest::malloc_calls_.size(), 0);
+  EXPECT_GT(CustomAllocatorTrackingTest::free_calls_.size(), 0);
+  EXPECT_GT(CustomAllocatorTrackingTest::memalign_calls_.size(), 0);
+  // Giving some tolerance for platform differences.
+  EXPECT_NEAR(TotalBytesAllocated(), 585280062, 100000);
+
+  size_t img_size = 224 * 224 * 3;
+  std::vector<float> img = LoadImageAndPreprocess("cat224-3.txt", img_size, 1);
+  int64_t shape[4] = {1, 224, 224, 3};
+  const char* input_name = "input_tensor";
+  EXPECT_EQ(SetDLRInput(&model, input_name, shape, img.data(), 4), 0);
+  EXPECT_EQ(RunDLRModel(&model), 0);
+  // Input/output buffer was allocated.
+  EXPECT_NEAR(TotalBytesAllocated(), 586181182, 100000);
+
+  // Check output is correct.
+  int output[1];
+  EXPECT_EQ(GetDLROutput(&model, 0, output), 0);
+  EXPECT_EQ(output[0], 112);
+
+  // Free should be called.
+  size_t free_count_before = CustomAllocatorTrackingTest::free_calls_.size();
+  EXPECT_EQ(DeleteDLRModel(&model), 0);
+  size_t free_count_after = CustomAllocatorTrackingTest::free_calls_.size();
+  EXPECT_GT(free_count_after, free_count_before);
+}

--- a/tests/cpp/dlr_allocator_test.cc
+++ b/tests/cpp/dlr_allocator_test.cc
@@ -174,9 +174,9 @@ void* tracking_memalign(size_t alignment, size_t size) {
 }
 
 TEST_F(CustomAllocatorTrackingTest, CustomAllocatorsTvm) {
-  EXPECT_NO_THROW(dlr::DLRAllocatorFunctions::SetMallocFunction(tracking_malloc));
-  EXPECT_NO_THROW(dlr::DLRAllocatorFunctions::SetFreeFunction(tracking_free));
-  EXPECT_NO_THROW(dlr::DLRAllocatorFunctions::SetMemalignFunction(tracking_memalign));
+  EXPECT_EQ(SetDLRCustomAllocatorMalloc(tracking_malloc), 0);
+  EXPECT_EQ(SetDLRCustomAllocatorFree(tracking_free), 0);
+  EXPECT_EQ(SetDLRCustomAllocatorMemalign(tracking_memalign), 0);
   DLRModelHandle model = nullptr;
   EXPECT_EQ(CustomAllocatorTrackingTest::malloc_calls_.size(), 0);
   EXPECT_EQ(CustomAllocatorTrackingTest::free_calls_.size(), 0);

--- a/tests/cpp/dlr_allocator_test.cc
+++ b/tests/cpp/dlr_allocator_test.cc
@@ -189,7 +189,7 @@ TEST_F(CustomAllocatorTrackingTest, CustomAllocatorsTvm) {
   EXPECT_GT(CustomAllocatorTrackingTest::free_calls_.size(), 0);
   EXPECT_GT(CustomAllocatorTrackingTest::memalign_calls_.size(), 0);
   // Giving some tolerance for platform differences.
-  EXPECT_NEAR(TotalBytesAllocated(), 585280062, 100000);
+  EXPECT_NEAR(TotalBytesAllocated(), 585280062, 200000);
 
   size_t img_size = 224 * 224 * 3;
   std::vector<float> img = LoadImageAndPreprocess("cat224-3.txt", img_size, 1);
@@ -198,7 +198,7 @@ TEST_F(CustomAllocatorTrackingTest, CustomAllocatorsTvm) {
   EXPECT_EQ(SetDLRInput(&model, input_name, shape, img.data(), 4), 0);
   EXPECT_EQ(RunDLRModel(&model), 0);
   // Input/output buffer was allocated.
-  EXPECT_NEAR(TotalBytesAllocated(), 586181182, 100000);
+  EXPECT_NEAR(TotalBytesAllocated(), 586181182, 200000);
 
   // Check output is correct.
   int output[1];


### PR DESCRIPTION
Supports custom allocation functions in DLR using `SetDLRCustomAllocator*()` functions.

Must be called before the model is loaded.
```
SetDLRCustomAllocatorMalloc(my_malloc);
SetDLRCustomAllocatorFree(my_free);
SetDLRCustomAllocatorMemalign(my_memalign);
CreateDLRModel(/* ... */);
```