### PR TITLE
Use const void* for input

### DIFF
--- a/include/dlr.h
+++ b/include/dlr.h
@@ -223,7 +223,7 @@ int GetDLRWeightName(DLRModelHandle* handle, int index,
  */
 DLR_DLL
 int SetDLRInput(DLRModelHandle* handle, const char* name, const int64_t* shape,
-                void* input, int dim);
+                const void* input, int dim);
 /*!
  \brief Gets the current value of the input according the node name.
  \param handle The model handle returned from CreateDLRModel().

--- a/include/dlr_common.h
+++ b/include/dlr_common.h
@@ -125,7 +125,7 @@ class DLR_DLL DLRModel {
   virtual const int64_t GetInputSize(int index) const = 0;
   virtual const std::vector<int64_t>& GetInputShape(int index) const;
   virtual void GetInput(const char* name, void* input) = 0;
-  virtual void SetInput(const char* name, const int64_t* shape, void* input, int dim) = 0;
+  virtual void SetInput(const char* name, const int64_t* shape, const void* input, int dim) = 0;
 
   /* Output related functions */
   virtual int GetNumOutputs() { return num_outputs_; }

--- a/include/dlr_data_transform.h
+++ b/include/dlr_data_transform.h
@@ -18,7 +18,7 @@ class DLR_DLL DataTransform {
   const float kBadValue = std::numeric_limits<float>::quiet_NaN();
 
   /*! \brief Helper function for TransformInput. Interpets 1-D char input as JSON. */
-  nlohmann::json GetAsJson(const int64_t* shape, void* input, int dim) const;
+  nlohmann::json GetAsJson(const int64_t* shape, const void* input, int dim) const;
 
   /*! \brief Helper function for TransformInput. Allocates NDArray to store mapped input data. */
   tvm::runtime::NDArray InitNDArray(int index, const nlohmann::json& input_json,
@@ -44,7 +44,7 @@ class DLR_DLL DataTransform {
    * for the model input.
    */
   tvm::runtime::NDArray TransformInput(const nlohmann::json& metadata, int index,
-                                       const int64_t* shape, void* input, int dim, DLDataType dtype,
+                                       const int64_t* shape, const void* input, int dim, DLDataType dtype,
                                        DLContext ctx) const;
 };
 

--- a/include/dlr_hexagon/dlr_hexagon.h
+++ b/include/dlr_hexagon/dlr_hexagon.h
@@ -57,7 +57,7 @@ class HexagonModel : public DLRModel {
   virtual const char* GetWeightName(int index) const override;
   virtual std::vector<std::string> GetWeightNames() const override;
   virtual void GetInput(const char* name, void* input) override;
-  virtual void SetInput(const char* name, const int64_t* shape, void* input,
+  virtual void SetInput(const char* name, const int64_t* shape, const void* input,
                         int dim) override;
   virtual void Run() override;
   virtual void GetOutput(int index, void* out) override;

--- a/include/dlr_pipeline.h
+++ b/include/dlr_pipeline.h
@@ -36,7 +36,7 @@ class DLR_DLL PipelineModel : public DLRModel {
   virtual const char* GetInputName(int index) const override;
   virtual const char* GetInputType(int index) const override;
   virtual void GetInput(const char* name, void* input) override;
-  virtual void SetInput(const char* name, const int64_t* shape, void* input,
+  virtual void SetInput(const char* name, const int64_t* shape, const void* input,
                         int dim) override;
 
   virtual void GetOutput(int index, void* out) override;

--- a/include/dlr_relayvm.h
+++ b/include/dlr_relayvm.h
@@ -71,7 +71,8 @@ class DLR_DLL RelayVMModel : public DLRModel {
   virtual const char* GetWeightName(int index) const override;
   virtual std::vector<std::string> GetWeightNames() const override;
   virtual void GetInput(const char* name, void* input) override;
-  virtual void SetInput(const char* name, const int64_t* shape, void* input, int dim) override;
+  virtual void SetInput(const char* name, const int64_t* shape, const void* input,
+                        int dim) override;
   virtual void Run() override;
   tvm::runtime::NDArray GetOutput(int index);
   virtual void GetOutput(int index, void* out) override;

--- a/include/dlr_treelite.h
+++ b/include/dlr_treelite.h
@@ -62,7 +62,7 @@ class DLR_DLL TreeliteModel : public DLRModel {
   virtual const char* GetInputName(int index) const override;
   virtual const char* GetInputType(int index) const override;
   virtual void GetInput(const char* name, void* input) override;
-  virtual void SetInput(const char* name, const int64_t* shape, void* input,
+  virtual void SetInput(const char* name, const int64_t* shape, const void* input,
                         int dim) override;
   
   virtual void GetOutput(int index, void* out) override;

--- a/include/dlr_tvm.h
+++ b/include/dlr_tvm.h
@@ -42,7 +42,7 @@ class DLR_DLL TVMModel : public DLRModel {
   virtual const char* GetInputName(int index) const override;
   virtual const char* GetInputType(int index) const override;
   virtual void GetInput(const char* name, void* input) override;
-  virtual void SetInput(const char* name, const int64_t* shape, void* input,
+  virtual void SetInput(const char* name, const int64_t* shape, const void* input,
                         int dim) override;
 
   virtual void GetOutput(int index, void* out) override;

--- a/src/dlr.cc
+++ b/src/dlr.cc
@@ -80,7 +80,7 @@ extern "C" int GetDLRWeightName(DLRModelHandle* handle, int index,
 }
 
 extern "C" int SetDLRInput(DLRModelHandle* handle, const char* name,
-                           const int64_t* shape, void* input, int dim) {
+                           const int64_t* shape, const void* input, int dim) {
   API_BEGIN();
   DLRModel* model = static_cast<DLRModel*>(*handle);
   CHECK(model != nullptr) << "model is nullptr, create it first";

--- a/src/dlr_data_transform.cc
+++ b/src/dlr_data_transform.cc
@@ -17,7 +17,7 @@ bool DataTransform::HasOutputTransform(const nlohmann::json& metadata, int index
 }
 
 tvm::runtime::NDArray DataTransform::TransformInput(const nlohmann::json& metadata, int index,
-                                                    const int64_t* shape, void* input, int dim,
+                                                    const int64_t* shape, const void* input, int dim,
                                                     DLDataType dtype, DLContext ctx) const {
   auto& mapping = metadata["DataTransform"]["Input"][std::to_string(index)]["CategoricalString"];
   nlohmann::json input_json = GetAsJson(shape, input, dim);
@@ -26,10 +26,10 @@ tvm::runtime::NDArray DataTransform::TransformInput(const nlohmann::json& metada
   return input_array;
 }
 
-nlohmann::json DataTransform::GetAsJson(const int64_t* shape, void* input, int dim) const {
+nlohmann::json DataTransform::GetAsJson(const int64_t* shape, const void* input, int dim) const {
   CHECK_EQ(dim, 1) << "String input must be 1-D vector.";
   // Interpret input as json
-  const char* input_str = static_cast<char*>(input);
+  const char* input_str = static_cast<const char*>(input);
   nlohmann::json input_json;
   try {
     input_json = nlohmann::json::parse(input_str, input_str + shape[0]);

--- a/src/dlr_hexagon/dlr_hexagon.cc
+++ b/src/dlr_hexagon/dlr_hexagon.cc
@@ -245,7 +245,7 @@ const char* HexagonModel::GetWeightName(int index) const {
 }
 
 void HexagonModel::SetInput(const char* name, const int64_t* shape,
-                            void* input, int dim) {
+                            const void* input, int dim) {
   int index = GetInputId(name);
 
   // Check Size and Dim

--- a/src/dlr_pipeline.cc
+++ b/src/dlr_pipeline.cc
@@ -97,7 +97,7 @@ const char* PipelineModel::GetWeightName(int index) const {
   return dlr_models_[0]->GetWeightName(index);
 }
 
-void PipelineModel::SetInput(const char* name, const int64_t* shape, void* input, int dim) {
+void PipelineModel::SetInput(const char* name, const int64_t* shape, const void* input, int dim) {
   dlr_models_[0]->SetInput(name, shape, input, dim);
 }
 
@@ -141,7 +141,7 @@ void PipelineModel::Run() {
       std::vector<int64_t> prev_output_shape(prev_output_dim, -1);
       prev_model->GetOutputShape(j, prev_output_shape.data());
       const void* prev_model_output = prev_model->GetOutputPtr(j);
-      curr_model->SetInput(input_name, prev_output_shape.data(), (void*)prev_model_output, prev_output_dim);
+      curr_model->SetInput(input_name, prev_output_shape.data(), prev_model_output, prev_output_dim);
     }
     curr_model->Run();
   }

--- a/src/dlr_relayvm.cc
+++ b/src/dlr_relayvm.cc
@@ -185,7 +185,7 @@ DLDataType RelayVMModel::GetInputDLDataType(int index) {
   return dtype;
 }
 
-void RelayVMModel::SetInput(const char* name, const int64_t* shape, void* input, int dim) {
+void RelayVMModel::SetInput(const char* name, const int64_t* shape, const void* input, int dim) {
   int index = GetInputIndex(name);
   DLDataType dtype = GetInputDLDataType(index);
   // Handle string input.
@@ -195,7 +195,7 @@ void RelayVMModel::SetInput(const char* name, const int64_t* shape, void* input,
     return;
   }
   DLTensor input_tensor;
-  input_tensor.data = input;
+  input_tensor.data = const_cast<void*>(input);
   input_tensor.ctx = ctx_;
   input_tensor.ndim = dim;
   input_tensor.shape = const_cast<int64_t*>(shape);

--- a/src/dlr_treelite.cc
+++ b/src/dlr_treelite.cc
@@ -138,7 +138,7 @@ const char* TreeliteModel::GetWeightName(int index) const {
 }
 
 void TreeliteModel::SetInput(const char* name, const int64_t* shape,
-                             void* input, int dim) {
+                             const void* input, int dim) {
   // NOTE: Assume that missing values are represented by NAN
   CHECK_SHAPE("Mismatch found in input dimension", dim, kInputDim);
   // NOTE: If number of columns is less than num_feature, missing columns

--- a/src/dlr_tvm.cc
+++ b/src/dlr_tvm.cc
@@ -145,14 +145,14 @@ const char* TVMModel::GetWeightName(int index) const {
   return weight_names_[index].c_str();
 }
 
-void TVMModel::SetInput(const char* name, const int64_t* shape, void* input,
-                        int dim) {
+void TVMModel::SetInput(const char* name, const int64_t* shape,
+                        const void* input, int dim) {
   std::string str(name);
   int index = tvm_graph_runtime_->GetInputIndex(str);
   tvm::runtime::NDArray arr = tvm_graph_runtime_->GetInput(index);
   DLTensor input_tensor = *(arr.operator->());
   input_tensor.ctx = DLContext{kDLCPU, 0};
-  input_tensor.data = input;
+  input_tensor.data = const_cast<void*>(input);
   int64_t read_size =
       std::accumulate(shape, shape + dim, 1, std::multiplies<int64_t>());
   int64_t expected_size = std::accumulate(

--- a/tests/cpp/dlr_pipeline_skl_xgb_test.cc
+++ b/tests/cpp/dlr_pipeline_skl_xgb_test.cc
@@ -54,7 +54,7 @@ TEST(PipelineTest, TestSetDLRInput) {
   int64_t shape[1] = { static_cast<int64_t>(in_data.length()) };
   int ndim = 1;
   const char* input_name = "input";
-  EXPECT_EQ(SetDLRInput(&model, input_name, shape, const_cast<char*>(in_data.c_str()), ndim), 0);
+  EXPECT_EQ(SetDLRInput(&model, input_name, shape, in_data.c_str(), ndim), 0);
   std::vector<float> exp_data = {0.5, 0.6, 0.55, 0.66, 0.73, 0.83};
   std::vector<float> in_data2(6);
   EXPECT_EQ(GetDLRInput(&model, input_name, in_data2.data()), 0);
@@ -129,7 +129,7 @@ TEST(PipelineTest, TestRunDLRModel_GetDLROutput) {
   int64_t shape[1] = { static_cast<int64_t>(in_data.length()) };
   int ndim = 1;
   const char* input_name = "input";
-  EXPECT_EQ(SetDLRInput(&model, input_name, shape, const_cast<char*>(in_data.c_str()), ndim), 0);
+  EXPECT_EQ(SetDLRInput(&model, input_name, shape, in_data.c_str(), ndim), 0);
   EXPECT_EQ(RunDLRModel(&model), 0);
   // check output metadata
   int64_t output_size;

--- a/tests/cpp/dlr_relayvm_test.cc
+++ b/tests/cpp/dlr_relayvm_test.cc
@@ -13,11 +13,11 @@ int main(int argc, char **argv) {
 
 class RelayVMTest : public ::testing::Test {
  protected:
-  int8_t *img;
   const int batch_size = 1;
   size_t img_size = 512 * 512 * 3;
   const int64_t input_shape[4] = {1, 512, 512, 3};
   const int input_dim = 4;
+  std::vector<int8_t> img{std::vector<int8_t>(img_size)};
 
   dlr::RelayVMModel *model;
 
@@ -27,13 +27,10 @@ class RelayVMTest : public ::testing::Test {
     DLContext ctx = {static_cast<DLDeviceType>(device_type), device_id};
     std::vector<std::string> paths = {"./ssd_mobilenet_v1"};
     model = new dlr::RelayVMModel(paths, ctx);
-
-    img = new int8_t[img_size];
   }
 
   ~RelayVMTest() {
     delete model;
-    delete img;
   }
 };
 
@@ -61,7 +58,7 @@ TEST_F(RelayVMTest, TestGetInputDim) { EXPECT_EQ(model->GetInputDim(0), 4); }
 
 
 TEST_F(RelayVMTest, TestSetInput) {
-  EXPECT_NO_THROW(model->SetInput("image_tensor", input_shape, img, input_dim));
+  EXPECT_NO_THROW(model->SetInput("image_tensor", input_shape, img.data(), input_dim));
 }
 
 TEST_F(RelayVMTest, TestGetNumOutputs) { EXPECT_EQ(model->GetNumOutputs(), 4); }
@@ -82,7 +79,7 @@ TEST_F(RelayVMTest, TestGetOutputType) {
 }
 
 TEST_F(RelayVMTest, TestRun) {
-  EXPECT_NO_THROW(model->SetInput("image_tensor", input_shape, img, input_dim));
+  EXPECT_NO_THROW(model->SetInput("image_tensor", input_shape, img.data(), input_dim));
   model->Run();
 }
 
@@ -90,7 +87,7 @@ TEST_F(RelayVMTest, TestGetOutputShape) {
   int64_t output_shape[2];
   EXPECT_NO_THROW(model->GetOutputShape(0, output_shape));
   
-  EXPECT_NO_THROW(model->SetInput("image_tensor", input_shape, img, input_dim));
+  EXPECT_NO_THROW(model->SetInput("image_tensor", input_shape, img.data(), input_dim));
   EXPECT_NO_THROW(model->Run());
   
   int64_t output_0_shape[2];
@@ -118,7 +115,7 @@ TEST_F(RelayVMTest, TestGetOutputSizeDim) {
   EXPECT_NO_THROW(model->GetOutputSizeDim(0, &size, &dim));
   EXPECT_EQ(size, 100);
 
-  EXPECT_NO_THROW(model->SetInput("image_tensor", input_shape, img, input_dim));
+  EXPECT_NO_THROW(model->SetInput("image_tensor", input_shape, img.data(), input_dim));
   EXPECT_NO_THROW(model->Run());
   
   EXPECT_NO_THROW(model->GetOutputSizeDim(0, &size, &dim));
@@ -136,7 +133,7 @@ TEST_F(RelayVMTest, TestGetOutputSizeDim) {
 }
 
 TEST_F(RelayVMTest, TestGetOutput) {
-  EXPECT_NO_THROW(model->SetInput("image_tensor", input_shape, img, input_dim));
+  EXPECT_NO_THROW(model->SetInput("image_tensor", input_shape, img.data(), input_dim));
   EXPECT_NO_THROW(model->Run());
 
   float output3[100];

--- a/tests/cpp/dlr_test.cc
+++ b/tests/cpp/dlr_test.cc
@@ -64,17 +64,13 @@ TEST(DLR, TestGetDLRWeightName) {
 TEST(DLR, TestSetDLRInput) {
   auto model = GetDLRModel();
   size_t img_size = 224*224*3;
-  float* img = LoadImageAndPreprocess("cat224-3.txt", img_size, 1);
+  std::vector<float> img = LoadImageAndPreprocess("cat224-3.txt", img_size, 1);
   int64_t shape[4] = {1, 224, 224, 3};
   const char* input_name = "input_tensor";
-  float* in_img = (float*) malloc(sizeof(float)*224*224*3);
-  EXPECT_EQ(SetDLRInput(&model, input_name, shape, img, 4), 0);
-  EXPECT_EQ(GetDLRInput(&model, input_name, in_img), 0);
-  EXPECT_EQ(*img, *in_img);
-  EXPECT_EQ(*(img + 224*224), *(in_img + 224*224));
-  EXPECT_EQ(*(img + 224*224*3 - 1), *(in_img + 224*224*3 - 1));
-  free(in_img);
-  delete [] img;
+  std::vector<float> img2(img_size);
+  EXPECT_EQ(SetDLRInput(&model, input_name, shape, img.data(), 4), 0);
+  EXPECT_EQ(GetDLRInput(&model, input_name, img2.data()), 0);
+  EXPECT_EQ(img, img2);
   DeleteDLRModel(&model);
 }
 
@@ -184,10 +180,10 @@ TEST(DLR, TestGetDLRBackend) {
 TEST(DLR, TestRunDLRModel_GetDLROutput) {
   auto model = GetDLRModel();
   size_t img_size = 224*224*3;
-  float* img = LoadImageAndPreprocess("cat224-3.txt", img_size, 1);
+  std::vector<float> img = LoadImageAndPreprocess("cat224-3.txt", img_size, 1);
   int64_t shape[4] = {1, 224, 224, 3};
   const char* input_name = "input_tensor";
-  EXPECT_EQ(SetDLRInput(&model, input_name, shape, img, 4), 0);
+  EXPECT_EQ(SetDLRInput(&model, input_name, shape, img.data(), 4), 0);
   EXPECT_EQ(RunDLRModel(&model), 0);
   // output 0
   int output0[1];
@@ -210,7 +206,6 @@ TEST(DLR, TestRunDLRModel_GetDLROutput) {
   for (int i = 0; i < 1001; i++) {
     EXPECT_EQ(output1_p[i], output1[i]);
   }
-  delete [] img;
   DeleteDLRModel(&model);
 }
 

--- a/tests/cpp/test_utils.hpp
+++ b/tests/cpp/test_utils.hpp
@@ -7,11 +7,11 @@
 #include <sstream>
 #include <cstring>
 
-float* LoadImageAndPreprocess(const std::string& img_path, size_t size,
-                              int batch_size) {
+std::vector<float> LoadImageAndPreprocess(const std::string& img_path, size_t size,
+                                          int batch_size) {
   std::string line;
   std::ifstream fp(img_path);
-  float* img = new float[size * batch_size];
+  std::vector<float> img(size * batch_size);
   size_t i = 0;
   if (fp.is_open()) {
     while (getline(fp, line) && i < size) {
@@ -26,7 +26,7 @@ float* LoadImageAndPreprocess(const std::string& img_path, size_t size,
   LOG(INFO) << "Image read - OK, float[" << i << "]";
 
   for (int j = 1; j < batch_size; j++) {
-    std::memcpy(img + j * size, img, size * sizeof(float));
+    std::copy_n(img.cbegin(), size, img.begin() + j * size);
   }
   return img;
 }


### PR DESCRIPTION
- Mark input data pointer as const in C API `SetDLRInput` and C++ API `SetInput`. It is totally compatible with existing DLR API. No changes needed in existing users programs after DLR update.
- Change `LoadImageAndPreprocess` internal test utils method to return vector.
- Use vector to create input/output buffers in tests. (remove memalloc, new[], free and delete[])