### PR TITLE
Use ColumnTransform for string inputs to support ambiguous column types.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -439,20 +439,20 @@ if(NOT(AAR_BUILD))
     file(REMOVE /tmp/${RELAYVM_MODEL})
   endif()
 
-  set(ONEHOTENCODER_MODEL onehotencoder-ml_m4.tar.gz)
-  set(ONEHOTENCODER_MODEL_DIR ${CMAKE_CURRENT_BINARY_DIR}/onehotencoder)
-  if(NOT IS_DIRECTORY ${ONEHOTENCODER_MODEL_DIR})
-    file(MAKE_DIRECTORY ${ONEHOTENCODER_MODEL_DIR})
+  set(AUTOML_MODEL automl-ml_m4.tar.gz)
+  set(AUTOML_MODEL_DIR ${CMAKE_CURRENT_BINARY_DIR}/automl)
+  if(NOT IS_DIRECTORY ${AUTOML_MODEL_DIR})
+    file(MAKE_DIRECTORY ${AUTOML_MODEL_DIR})
     download_file(
-      https://neo-ai-dlr-test-artifacts.s3-us-west-2.amazonaws.com/compiled-models/release-1.4.0/${ONEHOTENCODER_MODEL}
-      /tmp/${ONEHOTENCODER_MODEL}
+      https://neo-ai-dlr-test-artifacts.s3-us-west-2.amazonaws.com/compiled-models/release-1.4.0/${AUTOML_MODEL}
+      /tmp/${AUTOML_MODEL}
       SHA1
-      d9490ca854fd89280c84646ab3a8e6f558c0ff6a
+      6d0fdda6b3d5040507ac321adb69cd644ed39f66
     )
     # this is OS-agnostic
-    execute_process(COMMAND ${CMAKE_COMMAND} -E tar -xf /tmp/${ONEHOTENCODER_MODEL}
-                    WORKING_DIRECTORY ${ONEHOTENCODER_MODEL_DIR})
-    file(REMOVE /tmp/${ONEHOTENCODER_MODEL})
+    execute_process(COMMAND ${CMAKE_COMMAND} -E tar -xf /tmp/${AUTOML_MODEL}
+                    WORKING_DIRECTORY ${AUTOML_MODEL_DIR})
+    file(REMOVE /tmp/${AUTOML_MODEL})
   endif()
 
   set(PIPELINE_MODEL1 ${CMAKE_CURRENT_BINARY_DIR}/pipeline_model1)

--- a/include/dlr_data_transform.h
+++ b/include/dlr_data_transform.h
@@ -9,10 +9,11 @@
 
 namespace dlr {
 
+/*! \brief Base case for input transformers. */
 class DLR_DLL Transformer {
  public:
-  virtual void MapToNDArray(const nlohmann::json& input_json, tvm::runtime::NDArray& input_array,
-                            const nlohmann::json& mapping) const = 0;
+  virtual void MapToNDArray(const nlohmann::json& input_json, const nlohmann::json& transform,
+                            tvm::runtime::NDArray& input_array) const = 0;
 };
 
 class DLR_DLL FloatTransformer : public Transformer {
@@ -21,10 +22,8 @@ class DLR_DLL FloatTransformer : public Transformer {
   const float kBadValue = std::numeric_limits<float>::quiet_NaN();
 
  public:
-  void MapToNDArray(const nlohmann::json& input_json, tvm::runtime::NDArray& input_array,
-                    const nlohmann::json& mapping) const;
-
-  // bool HasTransform(const nlohmann::json& metadata) const;
+  void MapToNDArray(const nlohmann::json& input_json, const nlohmann::json& transform,
+                    tvm::runtime::NDArray& input_array) const;
 };
 
 class DLR_DLL CategoricalStringTransformer : public Transformer {
@@ -33,10 +32,8 @@ class DLR_DLL CategoricalStringTransformer : public Transformer {
   const float kMissingValue = -1.0f;
 
  public:
-  void MapToNDArray(const nlohmann::json& input_json, tvm::runtime::NDArray& input_array,
-                    const nlohmann::json& mapping) const;
-
-  // bool HasTransform(const nlohmann::json& metadata) const;
+  void MapToNDArray(const nlohmann::json& input_json, const nlohmann::json& transform,
+                    tvm::runtime::NDArray& input_array) const;
 };
 
 /*! \brief Handles transformations of input and output data. */
@@ -65,15 +62,9 @@ class DLR_DLL DataTransform {
    * mapping to convert strings to numbers, and produce a numeric NDArray which can be given to TVM
    * for the model input.
    */
-<<<<<<< HEAD
-  tvm::runtime::NDArray TransformInput(const nlohmann::json& metadata, int index,
-                                       const int64_t* shape, const void* input, int dim, DLDataType dtype,
-                                       DLContext ctx) const;
-=======
-  void TransformInput(const nlohmann::json& metadata, const int64_t* shape, void* input, int dim,
-                      DLDataType dtype, DLContext ctx,
+  void TransformInput(const nlohmann::json& metadata, const int64_t* shape, const void* input, int dim,
+                      const std::vector<DLDataType>& dtypes, DLContext ctx,
                       std::vector<tvm::runtime::NDArray>* tvm_inputs) const;
->>>>>>> Use ColumnTransform
 };
 
 }  // namespace dlr

--- a/include/dlr_relayvm.h
+++ b/include/dlr_relayvm.h
@@ -73,6 +73,7 @@ class DLR_DLL RelayVMModel : public DLRModel {
   virtual void GetInput(const char* name, void* input) override;
   virtual void SetInput(const char* name, const int64_t* shape, const void* input,
                         int dim) override;
+  virtual int GetNumInputs() const override;
   virtual void Run() override;
   tvm::runtime::NDArray GetOutput(int index);
   virtual void GetOutput(int index, void* out) override;

--- a/src/dlr_data_transform.cc
+++ b/src/dlr_data_transform.cc
@@ -2,11 +2,15 @@
 
 using namespace dlr;
 
-bool DataTransform::HasInputTransform(const nlohmann::json& metadata, int index) const {
-  auto index_str = std::to_string(index);
-  return metadata.count("DataTransform") && metadata["DataTransform"].count("Input") &&
-         metadata["DataTransform"]["Input"].count(index_str) &&
-         metadata["DataTransform"]["Input"][index_str].count("CategoricalString");
+bool DataTransform::HasInputTransform(const nlohmann::json& metadata) const {
+  try {
+    if (metadata.at("DataTransform").at("Input").count("ColumnTransform")) {
+      return true;
+    }
+  } catch (nlohmann::json::out_of_range& e) {
+    // ignore
+  }
+  return false;
 }
 
 bool DataTransform::HasOutputTransform(const nlohmann::json& metadata, int index) const {
@@ -16,14 +20,23 @@ bool DataTransform::HasOutputTransform(const nlohmann::json& metadata, int index
          metadata["DataTransform"]["Output"][index_str].count("CategoricalString");
 }
 
-tvm::runtime::NDArray DataTransform::TransformInput(const nlohmann::json& metadata, int index,
-                                                    const int64_t* shape, const void* input, int dim,
-                                                    DLDataType dtype, DLContext ctx) const {
-  auto& mapping = metadata["DataTransform"]["Input"][std::to_string(index)]["CategoricalString"];
+void DataTransform::TransformInput(const nlohmann::json& metadata, const int64_t* shape,
+                                   const void* input, int dim, DLDataType dtype, DLContext ctx,
+                                   std::vector<tvm::runtime::NDArray>* tvm_inputs) const {
   nlohmann::json input_json = GetAsJson(shape, input, dim);
-  tvm::runtime::NDArray input_array = InitNDArray(index, input_json, mapping, dtype, ctx);
-  MapToNDArray(input_json, input_array, mapping);
-  return input_array;
+  const auto& columns = metadata["DataTransform"]["Input"]["ColumnTransform"];
+  for (int i = 0; i < columns.size(); i++) {
+    // TODO: dtype is index dependent
+    tvm_inputs->at(i) = InitNDArray(input_json, dtype, ctx);
+
+    const std::string& transformer_type = columns[i]["Type"].get_ref<const std::string&>();
+    auto it = GetTransformerMap()->find(transformer_type);
+    CHECK(it != GetTransformerMap()->end())
+        << transformer_type << " is not a valid DataTransform type.";
+    const auto transformer = it->second;
+
+    transformer->MapToNDArray(input_json, tvm_inputs->at(i), columns[i]["Map"]);
+  }
 }
 
 nlohmann::json DataTransform::GetAsJson(const int64_t* shape, const void* input, int dim) const {
@@ -41,8 +54,7 @@ nlohmann::json DataTransform::GetAsJson(const int64_t* shape, const void* input,
   return input_json;
 }
 
-tvm::runtime::NDArray DataTransform::InitNDArray(int index, const nlohmann::json& input_json,
-                                                 const nlohmann::json& mapping, DLDataType dtype,
+tvm::runtime::NDArray DataTransform::InitNDArray(const nlohmann::json& input_json, DLDataType dtype,
                                                  DLContext ctx) const {
   // Create NDArray for transformed input which will be passed to TVM.
   std::vector<int64_t> arr_shape = {static_cast<int64_t>(input_json.size()),
@@ -52,44 +64,63 @@ tvm::runtime::NDArray DataTransform::InitNDArray(int index, const nlohmann::json
   return tvm::runtime::NDArray::Empty(arr_shape, dtype, ctx);
 }
 
-void DataTransform::MapToNDArray(const nlohmann::json& input_json,
-                                 tvm::runtime::NDArray& input_array,
-                                 const nlohmann::json& mapping) const {
+void FloatTransformer::MapToNDArray(const nlohmann::json& input_json,
+                                    tvm::runtime::NDArray& input_array,
+                                    const nlohmann::json& mapping) const {
+  DLTensor* input_tensor = const_cast<DLTensor*>(input_array.operator->());
+  CHECK_EQ(input_tensor->ctx.device_type, DLDeviceType::kDLCPU)
+      << "DataTransform is only supported for CPU.";
+  float* data = static_cast<float*>(input_tensor->data);
+  for (size_t r = 0; r < input_json.size(); ++r) {
+    CHECK_EQ(input_json[r].size(), input_json[0].size()) << "Inconsistent number of columns";
+    for (size_t c = 0; c < input_json[r].size(); ++c) {
+      const int out_index = r * input_json[r].size() + c;
+      // Data is numeric, pass through. Attempt to convert string to float.
+      try {
+        data[out_index] = input_json[r][c].is_number()
+                              ? input_json[r][c].get<float>()
+                              : std::stof(input_json[r][c].get_ref<const std::string&>());
+      } catch (const std::exception& ex) {
+        // Any error will fallback safely to kBadValue.
+        data[out_index] = kBadValue;
+      }
+    }
+  }
+}
+
+void CategoricalStringTransformer::MapToNDArray(const nlohmann::json& input_json,
+                                                tvm::runtime::NDArray& input_array,
+                                                const nlohmann::json& mapping) const {
   DLTensor* input_tensor = const_cast<DLTensor*>(input_array.operator->());
   // Writing directly to the DLTensor will only work for CPU context. For other contexts, we would
   // need to create an intermediate buffer on CPU and copy that to the context.
   CHECK_EQ(input_tensor->ctx.device_type, DLDeviceType::kDLCPU)
       << "DataTransform CategoricalString is only supported for CPU.";
   float* data = static_cast<float*>(input_tensor->data);
-  CHECK_EQ(input_json[0].size(), mapping.size())
-      << "Number of columns should match, got " << input_json[0].size() << " but expected "
-      << mapping.size();
   // Copy data into data, mapping strings to float along the way.
   for (size_t r = 0; r < input_json.size(); ++r) {
-    CHECK_EQ(input_json[r].size(), mapping.size()) << "Inconsistent number of columns";
+    CHECK_EQ(input_json[r].size(), input_json[0].size()) << "Inconsistent number of columns";
     for (size_t c = 0; c < input_json[r].size(); ++c) {
       const int out_index = r * input_json[r].size() + c;
-      if (!mapping[c].empty()) {
-        // Look up in map. If not found, use kMissingValue.
-        try {
-          const std::string& data_str = input_json[r][c].get_ref<const std::string&>();
-          auto it = mapping[c].find(data_str);
-          data[out_index] = it != mapping[c].end() ? it->operator float() : kMissingValue;
-        } catch (const std::exception& ex) {
-          // Any error will fallback safely to kMissingValue.
-          data[out_index] = kMissingValue;
-        }
-      } else {
-        // Data is numeric, pass through. Attempt to convert string to float.
-        try {
-          data[out_index] = input_json[r][c].is_number()
-                                ? input_json[r][c].get<float>()
-                                : std::stof(input_json[r][c].get_ref<const std::string&>());
-        } catch (const std::exception& ex) {
-          // Any error will fallback safely to kBadValue.
-          data[out_index] = kBadValue;
-        }
+      // Look up in map. If not found, use kMissingValue.
+      try {
+        const std::string& data_str = input_json[r][c].get_ref<const std::string&>();
+        auto it = mapping.find(data_str);
+        data[out_index] = it != mapping.end() ? it->operator float() : kMissingValue;
+      } catch (const std::exception& ex) {
+        // Any error will fallback safely to kMissingValue.
+        data[out_index] = kMissingValue;
       }
     }
   }
+}
+
+const std::shared_ptr<std::unordered_map<std::string, std::shared_ptr<Transformer>>>
+DataTransform::GetTransformerMap() const {
+  static auto map =
+      std::make_shared<std::unordered_map<std::string, std::shared_ptr<Transformer>>>();
+  if (!map->empty()) return map;
+  map->emplace("float", std::make_shared<FloatTransformer>());
+  map->emplace("CategoricalString", std::make_shared<CategoricalStringTransformer>());
+  return map;
 }

--- a/src/dlr_relayvm.cc
+++ b/src/dlr_relayvm.cc
@@ -186,14 +186,14 @@ DLDataType RelayVMModel::GetInputDLDataType(int index) {
 }
 
 void RelayVMModel::SetInput(const char* name, const int64_t* shape, const void* input, int dim) {
-  int index = GetInputIndex(name);
-  DLDataType dtype = GetInputDLDataType(index);
   // Handle string input.
-  if (HasMetadata() && data_transform_.HasInputTransform(metadata_, index)) {
-    inputs_[index] =
-        data_transform_.TransformInput(metadata_, index, shape, input, dim, dtype, ctx_);
+  if (HasMetadata() && data_transform_.HasInputTransform(metadata_)) {
+    std::vector<DLDataType> dtypes;
+    data_transform_.TransformInput(metadata_, shape, input, dim, dtypes, ctx_, &inputs_);
     return;
   }
+  int index = GetInputIndex(name);
+  DLDataType dtype = GetInputDLDataType(index);
   DLTensor input_tensor;
   input_tensor.data = const_cast<void*>(input);
   input_tensor.ctx = ctx_;


### PR DESCRIPTION
The previous approach for supporting string input in DLR assumed that columns in the input data could only be strings OR floats. However, we found that many columns are interpreted as both string and float inside the compiled model. This would cause errors if the string was mapped to an integer with the old approach.

This PR supports the new approach where the compiled model will have 2 inputs, one for the input data interpreted as float and the other for input data mapped from strings to integers. See unit tests for an example.