### PR TITLE
[DataTransform] Ignore unused string input

### DIFF
--- a/src/dlr_data_transform.cc
+++ b/src/dlr_data_transform.cc
@@ -26,7 +26,8 @@ void DataTransform::TransformInput(const nlohmann::json& metadata, const int64_t
                                    std::vector<tvm::runtime::NDArray>* tvm_inputs) const {
   nlohmann::json input_json = GetAsJson(shape, input, dim);
   const auto& transforms = metadata["DataTransform"]["Input"]["ColumnTransform"];
-  for (int i = 0; i < transforms.size(); i++) {
+  CHECK_LE(tvm_inputs->size(), transforms.size());
+  for (int i = 0; i < tvm_inputs->size(); i++) {
     tvm_inputs->at(i) = InitNDArray(input_json, dtypes[i], ctx);
 
     const std::string& transformer_type = transforms[i]["Type"].get_ref<const std::string&>();


### PR DESCRIPTION
For handling ambigious columns we made it so the model always has two inputs, one for input interpreted as float and other for input encoded as categorical string. So if the "ColumnTransform" metadata is present, DLR is expecting the model to have two inputs. But in this case, only the float input was used by the model and TVM deleted the second input during compilation. This PR makes DLR robust to this case and will ignore the unused string input