### PR TITLE
[DataTranform] Make output transform more robust

### DIFF
--- a/include/dlr_data_transform.h
+++ b/include/dlr_data_transform.h
@@ -40,7 +40,7 @@ class DLR_DLL CategoricalStringTransformer : public Transformer {
 class DLR_DLL DataTransform {
  private:
   /*! \brief When there is no mapping entry for TransformOutput, this value is used. */
-  const char* kUnknownLabel = "<unknown_label>";
+  const char* kUnknownLabel = "<unseen_label>";
 
   /*! \brief Buffers to store transformed outputs. Maps output index to transformed data. */
   std::unordered_map<int, std::string> transformed_outputs_;

--- a/src/dlr_data_transform.cc
+++ b/src/dlr_data_transform.cc
@@ -178,19 +178,29 @@ void DataTransform::TransformOutput(const nlohmann::json& metadata, int index,
 }
 
 void DataTransform::GetOutputShape(int index, int64_t* shape) const {
-  shape[0] = transformed_outputs_.at(index).size();
+  auto it = transformed_outputs_.find(index);
+  shape[0] = it == transformed_outputs_.end() ? -1 : it->second.size();
 }
 
 void DataTransform::GetOutputSizeDim(int index, int64_t* size, int* dim) const {
-  *size = transformed_outputs_.at(index).size();
+  auto it = transformed_outputs_.find(index);
+  if (it == transformed_outputs_.end()) {
+    *size = -1;
+    *dim = 1;
+    return;
+  }
+  *size = it->second.size();
   *dim = 1;
 }
 
 void DataTransform::GetOutput(int index, void* output) const {
-  const std::string& output_str = transformed_outputs_.at(index);
-  std::copy(output_str.begin(), output_str.end(), static_cast<char*>(output));
+  auto it = transformed_outputs_.find(index);
+  CHECK(it != transformed_outputs_.end()) << "Inference has not been run or output does not exist.";
+  std::copy(it->second.begin(), it->second.end(), static_cast<char*>(output));
 }
 
 const void* DataTransform::GetOutputPtr(int index) const {
-  return static_cast<const void*>(transformed_outputs_.at(index).data());
+  auto it = transformed_outputs_.find(index);
+  CHECK(it != transformed_outputs_.end()) << "Inference has not been run or output does not exist.";
+  return static_cast<const void*>(it->second.data());
 }

--- a/src/dlr_data_transform.cc
+++ b/src/dlr_data_transform.cc
@@ -108,7 +108,17 @@ void CategoricalStringTransformer::MapToNDArray(const nlohmann::json& input_json
       const int out_index = r * input_json[r].size() + c;
       // Look up in map. If not found, use kMissingValue.
       try {
-        const std::string& data_str = input_json[r][c].get_ref<const std::string&>();
+        // If there is no items in map, try to pass forward as float.
+        if (mapping[c].empty()) {
+          data[out_index] = input_json[r][c].is_number()
+                                ? input_json[r][c].get<float>()
+                                : std::stof(input_json[r][c].get_ref<const std::string&>());
+          continue;
+        }
+        // For numbers, read as integer and convert to string.
+        std::string data_str = input_json[r][c].is_number()
+                                   ? std::to_string(input_json[r][c].get<int>())
+                                   : input_json[r][c].get<std::string>();
         auto it = mapping[c].find(data_str);
         data[out_index] = it != mapping[c].end() ? it->operator float() : kMissingValue;
       } catch (const std::exception& ex) {

--- a/src/dlr_data_transform.cc
+++ b/src/dlr_data_transform.cc
@@ -140,14 +140,17 @@ DataTransform::GetTransformerMap() const {
 }
 
 template <typename T>
-nlohmann::json DataTransform::TransformOutputHelper1D(const nlohmann::json& mapping, const T* data,
+nlohmann::json DataTransform::TransformOutputHelper1D(const nlohmann::json& transform,
+                                                      const T* data,
                                                       const std::vector<int64_t>& shape) const {
+  const nlohmann::json& mapping = transform["CategoricalString"];
   CHECK_EQ(shape.size(), 1);
   nlohmann::json output_json = nlohmann::json::array();
   for (int64_t i = 0; i < shape[0]; ++i) {
     auto it = mapping.find(std::to_string(data[i]));
     if (it == mapping.end()) {
-      output_json.push_back(kUnknownLabel);
+      output_json.push_back(transform.count("UnseenLabel") ? transform["UnseenLabel"]
+                                                           : kUnknownLabel);
     } else {
       output_json.push_back(*it);
     }
@@ -156,19 +159,20 @@ nlohmann::json DataTransform::TransformOutputHelper1D(const nlohmann::json& mapp
 }
 
 template <typename T>
-nlohmann::json DataTransform::TransformOutputHelper2D(const nlohmann::json& mapping, const T* data,
+nlohmann::json DataTransform::TransformOutputHelper2D(const nlohmann::json& transform,
+                                                      const T* data,
                                                       const std::vector<int64_t>& shape) const {
   CHECK_EQ(shape.size(), 2);
   nlohmann::json output_json = nlohmann::json::array();
   for (int64_t i = 0; i < shape[0]; ++i) {
-    output_json.push_back(TransformOutputHelper1D<T>(mapping, data + i * shape[1], {shape[1]}));
+    output_json.push_back(TransformOutputHelper1D<T>(transform, data + i * shape[1], {shape[1]}));
   }
   return output_json;
 }
 
 void DataTransform::TransformOutput(const nlohmann::json& metadata, int index,
                                     const tvm::runtime::NDArray& output_array) {
-  auto& mapping = metadata["DataTransform"]["Output"][std::to_string(index)]["CategoricalString"];
+  auto& transform = metadata["DataTransform"]["Output"][std::to_string(index)];
   const DLTensor* tensor = output_array.operator->();
   CHECK_EQ(tensor->ctx.device_type, DLDeviceType::kDLCPU)
       << "DataTransform CategoricalString is only supported for CPU.";
@@ -178,9 +182,9 @@ void DataTransform::TransformOutput(const nlohmann::json& metadata, int index,
   std::vector<int64_t> shape(output_array->shape, output_array->shape + output_array->ndim);
   nlohmann::json output_json;
   if (shape.size() == 1) {
-    output_json = TransformOutputHelper1D<int>(mapping, static_cast<int*>(tensor->data), shape);
+    output_json = TransformOutputHelper1D<int>(transform, static_cast<int*>(tensor->data), shape);
   } else if (shape.size() == 2) {
-    output_json = TransformOutputHelper2D<int>(mapping, static_cast<int*>(tensor->data), shape);
+    output_json = TransformOutputHelper2D<int>(transform, static_cast<int*>(tensor->data), shape);
   } else {
     throw dmlc::Error("DataTransform CategoricalString is only supported for 1-D or 2-D inputs.");
   }

--- a/tests/cpp/dlr_data_transform_test.cc
+++ b/tests/cpp/dlr_data_transform_test.cc
@@ -191,6 +191,15 @@ TEST(DLR, RelayVMDataTransformOutput) {
   std::vector<std::string> files = dlr::FindFiles(paths);
   dlr::RelayVMModel* model = new dlr::RelayVMModel(files, ctx);
 
+  int64_t size;
+  int dim;
+  EXPECT_NO_THROW(model->GetOutputSizeDim(0, &size, &dim));
+  EXPECT_EQ(size, -1);
+  EXPECT_EQ(dim, 1);
+  int64_t output_shape[1];
+  EXPECT_NO_THROW(model->GetOutputShape(0, output_shape));
+  EXPECT_EQ(output_shape[0], -1);
+
   std::vector<int> input_data = {0, 1, 2, 3, -75};
   std::vector<int64_t> shape = {5};
   EXPECT_STREQ(model->GetInputType(0), "int32");
@@ -200,13 +209,10 @@ TEST(DLR, RelayVMDataTransformOutput) {
   std::string expected_output =
       "[\"Iris-setosa\",\"Iris-versicolor\",\"Iris-virginica\",\"<unknown_label>\",\"<unknown_"
       "label>\"]";
-  int64_t size;
-  int dim;
   EXPECT_STREQ(model->GetOutputType(0), "json");
   EXPECT_NO_THROW(model->GetOutputSizeDim(0, &size, &dim));
   EXPECT_EQ(size, expected_output.size());
   EXPECT_EQ(dim, 1);
-  int64_t output_shape[1];
   EXPECT_NO_THROW(model->GetOutputShape(0, output_shape));
   EXPECT_EQ(output_shape[0], expected_output.size());
 


### PR DESCRIPTION
Current code would crash if `GetOutputShape` or `GetOutputSizeDim` was called before inference was ran for a model with an output DataTransform. Now DLR will give shape of -1.