### PR TITLE
Add CreateDLRModelFromModelElem

### DIFF
--- a/include/dlr.h
+++ b/include/dlr.h
@@ -47,6 +47,17 @@ typedef void (*DLRFreeFunctionPtr)(void*);
 typedef void* (*DLRMemalignFunctionPtr)(size_t, size_t);
 #endif
 
+#ifndef DLR_MODEL_ELEM
+#define DLR_MODEL_ELEM
+enum DLRModelElemType { HEXAGON_LIB, NEO_METADATA, TVM_GRAPH, TVM_LIB, TVM_PARAMS, RELAY_EXEC };
+typedef struct ModelElem {
+  const DLRModelElemType type;
+  const char* path;
+  const void* data;
+  const size_t data_size;
+} DLRModelElem;
+#endif
+
 /*!
  \brief Creates a DLR model.
  \param handle The pointer to save the model handle.
@@ -58,6 +69,18 @@ typedef void* (*DLRMemalignFunctionPtr)(size_t, size_t);
  */
 DLR_DLL
 int CreateDLRModel(DLRModelHandle* handle, const char* model_path, int dev_type, int dev_id);
+
+/*!
+ \brief Creates a DLR model from model elements.
+ \param handle The pointer to save the model handle.
+ \param model_elems DLR Model elements. Element can be file path or data pointer in memory.
+ \param dev_type Device type. Valid values are in the DLDeviceType enum in dlpack.h.
+ \param dev_id Device ID.
+ \return 0 for success, -1 for error. Call DLRGetLastError() to get the error message.
+ */
+DLR_DLL
+int CreateDLRModelFromModelElem(DLRModelHandle* handle, const DLRModelElem* model_elems,
+                                size_t model_elems_size, int dev_type, int dev_id);
 
 #ifdef DLR_HEXAGON
 /*!

--- a/include/dlr_common.h
+++ b/include/dlr_common.h
@@ -75,6 +75,8 @@ std::string GetParentFolder(const std::string& path);
 
 void LoadJsonFromFile(const std::string& path, nlohmann::json& jsonObject);
 
+void LoadJsonFromString(const std::string& jsonData, nlohmann::json& jsonObject);
+
 inline bool StartsWith(const std::string& mainStr, const std::string& toMatch) {
   return mainStr.size() >= toMatch.size() && mainStr.compare(0, toMatch.size(), toMatch) == 0;
 }

--- a/include/dlr_common.h
+++ b/include/dlr_common.h
@@ -77,6 +77,9 @@ void LoadJsonFromFile(const std::string& path, nlohmann::json& jsonObject);
 
 void LoadJsonFromString(const std::string& jsonData, nlohmann::json& jsonObject);
 
+std::string LoadFileToString(const std::string& path,
+                             std::ios_base::openmode mode = std::ios_base::in);
+
 inline bool StartsWith(const std::string& mainStr, const std::string& toMatch) {
   return mainStr.size() >= toMatch.size() && mainStr.compare(0, toMatch.size(), toMatch) == 0;
 }

--- a/include/dlr_common.h
+++ b/include/dlr_common.h
@@ -39,6 +39,17 @@
 #define DLR_DLL
 #endif  // defined(_MSC_VER) || defined(_WIN32)
 
+#ifndef DLR_MODEL_ELEM
+#define DLR_MODEL_ELEM
+enum DLRModelElemType { HEXAGON_LIB, NEO_METADATA, TVM_GRAPH, TVM_LIB, TVM_PARAMS, RELAY_EXEC };
+typedef struct ModelElem {
+  const DLRModelElemType type;
+  const char* path;
+  const void* data;
+  const size_t data_size;
+} DLRModelElem;
+#endif
+
 namespace dlr {
 
 /* The following file names are reserved by SageMaker and should not be used
@@ -76,11 +87,13 @@ inline bool EndsWith(const std::string& mainStr, const std::string& toMatch) {
     return false;
 }
 
-enum class DLRBackend { kTVM, kTREELITE, kHEXAGON, kRELAYVM, kPIPELINE };
+enum class DLRBackend { kTVM, kTREELITE, kHEXAGON, kRELAYVM, kPIPELINE, kUNKNOWN };
 
 /*! \brief Get the backend based on the contents of the model folder.
  */
-DLRBackend GetBackend(std::vector<std::string> dirname);
+DLRBackend GetBackend(const std::vector<std::string>& dirname);
+
+DLRBackend GetBackend(const std::vector<DLRModelElem>& model_elems);
 
 std::string GetMetadataFile(const std::string& dirname);
 

--- a/include/dlr_relayvm.h
+++ b/include/dlr_relayvm.h
@@ -47,7 +47,6 @@ class DLR_DLL RelayVMModel : public DLRModel {
   void SetupVMModule(const std::vector<std::string>& paths);
   void SetupVMModule(const std::vector<DLRModelElem>& model_elems);
   void FetchInputNodesData();
-  void LoadMetadata(const std::string& metadata_path);
   void FetchOutputNodesData();
   void UpdateOutputs();
   void UpdateInputs();

--- a/include/dlr_relayvm.h
+++ b/include/dlr_relayvm.h
@@ -36,7 +36,6 @@ class DLR_DLL RelayVMModel : public DLRModel {
   static const std::string ENTRY_FUNCTION;
   std::vector<std::string> output_names_;
   std::vector<std::string> output_types_;
-  std::unique_ptr<ModelPath> path_;
   std::shared_ptr<tvm::runtime::Module> vm_module_;
   std::shared_ptr<tvm::runtime::Module> vm_executable_;
   std::vector<tvm::runtime::NDArray> inputs_;
@@ -44,10 +43,11 @@ class DLR_DLL RelayVMModel : public DLRModel {
   std::vector<tvm::runtime::NDArray> outputs_;
   std::vector<std::vector<int64_t>> output_shapes_;
   DataTransform data_transform_;
-  void InitModelPath(std::vector<std::string> paths);
-  void SetupVMModule();
+  ModelPath GetModelPath(const std::vector<std::string>& paths);
+  void SetupVMModule(const std::vector<std::string>& paths);
+  void SetupVMModule(const std::vector<DLRModelElem>& model_elems);
   void FetchInputNodesData();
-  void LoadMetadata();
+  void LoadMetadata(const std::string& metadata_path);
   void FetchOutputNodesData();
   void UpdateOutputs();
   void UpdateInputs();
@@ -56,9 +56,13 @@ class DLR_DLL RelayVMModel : public DLRModel {
  public:
   explicit RelayVMModel(std::vector<std::string> paths, const DLContext& ctx)
       : DLRModel(ctx, DLRBackend::kRELAYVM) {
-    InitModelPath(paths);
-    LoadMetadata();
-    SetupVMModule();
+    SetupVMModule(paths);
+    FetchInputNodesData();
+    FetchOutputNodesData();
+  }
+  explicit RelayVMModel(std::vector<DLRModelElem> model_elems, const DLContext& ctx)
+      : DLRModel(ctx, DLRBackend::kRELAYVM) {
+    SetupVMModule(model_elems);
     FetchInputNodesData();
     FetchOutputNodesData();
   }

--- a/include/dlr_tvm.h
+++ b/include/dlr_tvm.h
@@ -15,7 +15,7 @@ namespace dlr {
 
 /*! \brief Get the paths of the TVM model files.
  */
-ModelPath GetTvmPaths(std::vector<std::string> tar_path);
+ModelPath GetTvmPaths(const std::vector<std::string>& tar_path);
 
 /*! \brief class TVMModel
  */
@@ -26,7 +26,8 @@ class DLR_DLL TVMModel : public DLRModel {
   std::vector<const DLTensor*> outputs_;
   std::vector<std::string> output_types_;
   std::vector<std::string> weight_names_;
-  void SetupTVMModule(std::vector<std::string> model_path);
+  void SetupTVMModule(const std::vector<std::string>& model_path);
+  void SetupTVMModule(const std::vector<DLRModelElem>& model_elems);
   void UpdateInputShapes();
 
  public:
@@ -35,6 +36,10 @@ class DLR_DLL TVMModel : public DLRModel {
   explicit TVMModel(std::vector<std::string> model_path, const DLContext& ctx)
       : DLRModel(ctx, DLRBackend::kTVM) {
     SetupTVMModule(model_path);
+  }
+  explicit TVMModel(std::vector<DLRModelElem> model_elems, const DLContext& ctx)
+      : DLRModel(ctx, DLRBackend::kTVM) {
+    SetupTVMModule(model_elems);
   }
 
   virtual const int GetInputDim(int index) const override;

--- a/src/dlr.cc
+++ b/src/dlr.cc
@@ -271,6 +271,35 @@ extern "C" int CreateDLRModel(DLRModelHandle* handle, const char* model_path, in
   API_END();
 }
 
+extern "C" int CreateDLRModelFromModelElem(DLRModelHandle* handle, const DLRModelElem* model_elems,
+                                           size_t model_elems_size, int dev_type, int dev_id) {
+  API_BEGIN();
+  DLContext ctx;
+  ctx.device_type = static_cast<DLDeviceType>(dev_type);
+  ctx.device_id = dev_id;
+
+  std::vector<DLRModelElem> model_elem_vec(model_elems, model_elems + model_elems_size);
+
+  DLRBackend backend = dlr::GetBackend(model_elem_vec);
+  DLRModel* model;
+  try {
+    if (backend == DLRBackend::kTVM) {
+      model = new TVMModel(model_elem_vec, ctx);
+    } else if (backend == DLRBackend::kRELAYVM) {
+      model = new RelayVMModel(model_elem_vec, ctx);
+    } else {
+      LOG(FATAL) << "Unsupported backend!";
+      return -1;  // unreachable
+    }
+  } catch (dmlc::Error& e) {
+    LOG(ERROR) << e.what();
+    return -1;
+  }
+
+  *handle = model;
+  API_END();
+}
+
 /*! \brief Translate c args from ctypes to std types for DLRModel ctor.
  */
 extern "C" int CreateDLRPipeline(DLRModelHandle* handle, int num_models, const char** model_paths,

--- a/src/dlr_common.cc
+++ b/src/dlr_common.cc
@@ -77,6 +77,13 @@ void dlr::LoadJsonFromString(const std::string& jsonData, nlohmann::json& jsonOb
   }
 }
 
+std::string dlr::LoadFileToString(const std::string& path, std::ios_base::openmode mode) {
+  std::ifstream fstream(path, mode);
+  std::stringstream blob;
+  blob << fstream.rdbuf();
+  return blob.str();
+}
+
 DLRBackend dlr::GetBackend(const std::vector<std::string>& dir_paths) {
   // Support the case where user provides full path to hexagon file.
   if (EndsWith(dir_paths[0], "_hexagon_model.so")) {

--- a/src/dlr_common.cc
+++ b/src/dlr_common.cc
@@ -68,6 +68,15 @@ void dlr::LoadJsonFromFile(const std::string& path, nlohmann::json& jsonObject) 
   }
 }
 
+void dlr::LoadJsonFromString(const std::string& jsonData, nlohmann::json& jsonObject) {
+  std::stringstream jsonStrStream(jsonData);
+  try {
+    jsonStrStream >> jsonObject;
+  } catch (nlohmann::json::exception&) {
+    jsonObject = nullptr;
+  }
+}
+
 DLRBackend dlr::GetBackend(const std::vector<std::string>& dir_paths) {
   // Support the case where user provides full path to hexagon file.
   if (EndsWith(dir_paths[0], "_hexagon_model.so")) {

--- a/src/dlr_relayvm.cc
+++ b/src/dlr_relayvm.cc
@@ -75,7 +75,7 @@ void RelayVMModel::SetupVMModule(const std::vector<DLRModelElem>& model_elems) {
       if (el.path != nullptr) {
         model_lib_path = el.path;
       } else {
-        throw dmlc::Error("Invalid RelayVM model element TVM_LIB");
+        throw dmlc::Error("Invalid RelayVM model element TVM_LIB. TVM_LIB must be a file.");
       }
     } else if (el.type == DLRModelElemType::NEO_METADATA) {
       if (el.path != nullptr) {

--- a/src/dlr_relayvm.cc
+++ b/src/dlr_relayvm.cc
@@ -10,8 +10,8 @@ using namespace dlr;
 
 const std::string RelayVMModel::ENTRY_FUNCTION = "main";
 
-void RelayVMModel::InitModelPath(std::vector<std::string> paths) {
-  path_ = std::make_unique<ModelPath>();
+ModelPath RelayVMModel::GetModelPath(const std::vector<std::string>& paths) {
+  ModelPath model_path;
   std::vector<std::string> paths_vec;
   for (auto path : paths) {
     ListDir(path, paths_vec);
@@ -19,20 +19,31 @@ void RelayVMModel::InitModelPath(std::vector<std::string> paths) {
 
   for (auto path : paths_vec) {
     if (!EndsWith(path, LIBDLR) && EndsWith(path, ".so")) {
-      path_->model_lib = path;
+      model_path.model_lib = path;
     } else if (EndsWith(path, ".ro")) {
-      path_->relay_executable = path;
+      model_path.relay_executable = path;
     } else if (EndsWith(path, ".meta")) {
-      path_->metadata = path;
+      model_path.metadata = path;
     }
   }
 
-  if (path_->model_lib.empty() || path_->relay_executable.empty() || path_->metadata.empty()) {
+  if (model_path.model_lib.empty() || model_path.relay_executable.empty() ||
+      model_path.metadata.empty()) {
     throw dmlc::Error("Invalid RelayVM model artifact. Must have .so, .ro, and .meta files.");
   }
+  return model_path;
 }
 
-void RelayVMModel::SetupVMModule() {
+void RelayVMModel::SetupVMModule(const std::vector<std::string>& paths) {
+  ModelPath path = GetModelPath(paths);
+  const std::vector<DLRModelElem> model_elems = {
+      {DLRModelElemType::RELAY_EXEC, path.relay_executable.c_str(), nullptr, 0},
+      {DLRModelElemType::TVM_LIB, path.model_lib.c_str(), nullptr, 0},
+      {DLRModelElemType::NEO_METADATA, path.metadata.c_str(), nullptr, 0}};
+  SetupVMModule(model_elems);
+}
+
+void RelayVMModel::SetupVMModule(const std::vector<DLRModelElem>& model_elems) {
   // Set custom allocators in TVM.
   if (dlr::DLRAllocatorFunctions::GetMemalignFunction() &&
       dlr::DLRAllocatorFunctions::GetFreeFunction()) {
@@ -48,10 +59,42 @@ void RelayVMModel::SetupVMModule() {
                     "to override TVM allocations. Using default allocators.";
   }
 
-  tvm::runtime::Module lib = tvm::runtime::Module::LoadFromFile(path_->model_lib);
-  std::ifstream relay_ob(path_->relay_executable, std::ios::binary);
-  std::string code_data((std::istreambuf_iterator<char>(relay_ob)),
-                        std::istreambuf_iterator<char>());
+  std::string code_data;
+  std::string model_lib_path;
+  std::string metadata_path;
+  for (DLRModelElem el : model_elems) {
+    if (el.type == DLRModelElemType::RELAY_EXEC) {
+      if (el.path != nullptr) {
+        std::ifstream relay_ob(el.path, std::ios::binary);
+        code_data.assign((std::istreambuf_iterator<char>(relay_ob)),
+                         std::istreambuf_iterator<char>());
+      } else if (el.data != nullptr && el.data_size > 0) {
+        code_data.assign(static_cast<const char*>(el.data), el.data_size);
+      } else {
+        throw dmlc::Error("Invalid RelayVM model element RELAY_EXEC");
+      }
+    } else if (el.type == DLRModelElemType::TVM_LIB) {
+      if (el.path != nullptr) {
+        model_lib_path = el.path;
+      } else {
+        throw dmlc::Error("Invalid RelayVM model element TVM_LIB");
+      }
+    } else if (el.type == DLRModelElemType::NEO_METADATA) {
+      if (el.path != nullptr) {
+        metadata_path = el.path;
+      } else {
+        throw dmlc::Error("Invalid model element NEO_METADATA");
+      }
+    }
+  }
+  if (code_data.empty() || model_lib_path.empty() || metadata_path.empty()) {
+    throw dmlc::Error(
+        "Invalid RelayVM model. Must have RELAY_EXEC, TVM_LIB and NEO_METADATA elements");
+  }
+
+  LoadMetadata(metadata_path);
+
+  tvm::runtime::Module lib = tvm::runtime::Module::LoadFromFile(model_lib_path);
 
   vm_executable_ =
       std::make_shared<tvm::runtime::Module>(tvm::runtime::vm::Executable::Load(code_data, lib));
@@ -65,8 +108,8 @@ void RelayVMModel::SetupVMModule() {
        static_cast<int>(tvm::runtime::vm::AllocatorType::kPooled));
 }
 
-void RelayVMModel::LoadMetadata() {
-  LoadJsonFromFile(path_->metadata, metadata_);
+void RelayVMModel::LoadMetadata(const std::string& metadata_path) {
+  LoadJsonFromFile(metadata_path, metadata_);
   ValidateDeviceTypeIfExists();
 }
 

--- a/src/dlr_tvm.cc
+++ b/src/dlr_tvm.cc
@@ -9,7 +9,7 @@
 
 using namespace dlr;
 
-ModelPath dlr::GetTvmPaths(std::vector<std::string> dirname) {
+ModelPath dlr::GetTvmPaths(const std::vector<std::string>& dirname) {
   ModelPath paths;
   std::vector<std::string> paths_vec;
   for (auto dir : dirname) {
@@ -41,7 +41,19 @@ ModelPath dlr::GetTvmPaths(std::vector<std::string> dirname) {
   return paths;
 }
 
-void TVMModel::SetupTVMModule(std::vector<std::string> model_path) {
+void TVMModel::SetupTVMModule(const std::vector<std::string>& model_path) {
+  ModelPath paths = GetTvmPaths(model_path);
+  std::vector<DLRModelElem> model_elems = {
+      {DLRModelElemType::TVM_GRAPH, paths.model_json.c_str(), nullptr, 0},
+      {DLRModelElemType::TVM_PARAMS, paths.params.c_str(), nullptr, 0},
+      {DLRModelElemType::TVM_LIB, paths.model_lib.c_str(), nullptr, 0}};
+  if (!paths.metadata.empty()) {
+    model_elems.push_back({DLRModelElemType::NEO_METADATA, paths.metadata.c_str(), nullptr, 0});
+  }
+  SetupTVMModule(model_elems);
+}
+
+void TVMModel::SetupTVMModule(const std::vector<DLRModelElem>& model_elems) {
   // Set custom allocators in TVM.
   if (dlr::DLRAllocatorFunctions::GetMemalignFunction() &&
       dlr::DLRAllocatorFunctions::GetFreeFunction()) {
@@ -57,27 +69,68 @@ void TVMModel::SetupTVMModule(std::vector<std::string> model_path) {
                     "to override TVM allocations. Using default allocators.";
   }
 
-  ModelPath paths = GetTvmPaths(model_path);
-  std::ifstream jstream(paths.model_json);
-  std::stringstream json_blob;
-  json_blob << jstream.rdbuf();
-  std::ifstream pstream(paths.params, std::ios::in | std::ios::binary);
-  DLRStringStream param_blob;
-  param_blob << pstream.rdbuf();
-  auto param_data = param_blob.str();
-
-  tvm::runtime::Module module;
-  if (!IsFileEmpty(paths.model_lib)) {
-    module = tvm::runtime::Module::LoadFromFile(paths.model_lib);
+  std::string graph_str;
+  std::basic_string<char, std::char_traits<char>, dlr::DLRAllocator<char>> params_str;
+  const char* params_data = nullptr;
+  size_t params_size = 0;
+  std::string model_lib_path;
+  std::string metadata_path;
+  for (DLRModelElem el : model_elems) {
+    if (el.type == DLRModelElemType::TVM_GRAPH) {
+      if (el.path != nullptr) {
+        std::ifstream graph_stream(el.path);
+        std::stringstream graph_blob;
+        graph_blob << graph_stream.rdbuf();
+        graph_str = graph_blob.str();
+      } else if (el.data != nullptr) {
+        const char* graph_cstr = static_cast<const char*>(el.data);
+        graph_str = graph_cstr;
+      } else {
+        throw dmlc::Error("Invalid TVM model element TVM_GRAPH");
+      }
+    } else if (el.type == DLRModelElemType::TVM_PARAMS) {
+      if (el.path != nullptr) {
+        std::ifstream pstream(el.path, std::ios::in | std::ios::binary);
+        DLRStringStream params_blob;
+        params_blob << pstream.rdbuf();
+        params_str = params_blob.str();
+        params_data = params_str.data();
+        params_size = params_str.size();
+      } else if (el.data != nullptr && el.data_size > 0) {
+        params_data = static_cast<const char*>(el.data);
+        params_size = el.data_size;
+      } else {
+        throw dmlc::Error("Invalid TVM model element TVM_PARAMS");
+      }
+    } else if (el.type == DLRModelElemType::TVM_LIB) {
+      if (el.path != nullptr) {
+        model_lib_path = el.path;
+      } else {
+        throw dmlc::Error("Invalid TVM model element TVM_LIB");
+      }
+    } else if (el.type == DLRModelElemType::NEO_METADATA) {
+      if (el.path != nullptr) {
+        metadata_path = el.path;
+      } else {
+        throw dmlc::Error("Invalid model element NEO_METADATA");
+      }
+    }
   }
-  if (!paths.metadata.empty() && !IsFileEmpty(paths.metadata)) {
-    LoadJsonFromFile(paths.metadata, this->metadata_);
+  if (graph_str.empty() || params_data == nullptr || params_size <= 0 || model_lib_path.empty()) {
+    throw dmlc::Error("Invalid TVM model. Must have TVM_GRAPH, TVM_PARAMS and TVM_LIB elements");
+  }
+  tvm::runtime::Module module;
+  if (!IsFileEmpty(model_lib_path)) {
+    module = tvm::runtime::Module::LoadFromFile(model_lib_path);
+  }
+  if (!metadata_path.empty() && !IsFileEmpty(metadata_path)) {
+    LoadJsonFromFile(metadata_path, this->metadata_);
     ValidateDeviceTypeIfExists();
   }
 
   tvm_graph_runtime_ = tvm::runtime::make_object<tvm::runtime::GraphRuntime>();
-  tvm_graph_runtime_->Init(json_blob.str(), module, {ctx_});
-  dmlc::MemoryFixedSizeStream strm(const_cast<char*>(param_data.data()), param_data.size());
+  tvm_graph_runtime_->Init(graph_str, module, {ctx_});
+  dmlc::MemoryFixedSizeStream strm(const_cast<char*>(params_data), params_size);
   tvm_graph_runtime_->LoadParams(&strm);
 
   tvm_module_ = std::make_shared<tvm::runtime::Module>(tvm::runtime::Module(tvm_graph_runtime_));

--- a/src/dlr_tvm.cc
+++ b/src/dlr_tvm.cc
@@ -102,7 +102,7 @@ void TVMModel::SetupTVMModule(const std::vector<DLRModelElem>& model_elems) {
       if (el.path != nullptr) {
         model_lib_path = el.path;
       } else {
-        throw dmlc::Error("Invalid TVM model element TVM_LIB");
+        throw dmlc::Error("Invalid TVM model element TVM_LIB. TVM_LIB must be a file.");
       }
     } else if (el.type == DLRModelElemType::NEO_METADATA) {
       if (el.path != nullptr) {

--- a/src/dlr_tvm.cc
+++ b/src/dlr_tvm.cc
@@ -74,15 +74,11 @@ void TVMModel::SetupTVMModule(const std::vector<DLRModelElem>& model_elems) {
   const char* params_data = nullptr;
   size_t params_size = 0;
   std::string model_lib_path;
-  std::string metadata_path;
   std::string metadata_data;
   for (DLRModelElem el : model_elems) {
     if (el.type == DLRModelElemType::TVM_GRAPH) {
       if (el.path != nullptr) {
-        std::ifstream graph_stream(el.path);
-        std::stringstream graph_blob;
-        graph_blob << graph_stream.rdbuf();
-        graph_str = graph_blob.str();
+        graph_str = dlr::LoadFileToString(el.path);
       } else if (el.data != nullptr) {
         graph_str = static_cast<const char*>(el.data);
       } else {
@@ -110,7 +106,7 @@ void TVMModel::SetupTVMModule(const std::vector<DLRModelElem>& model_elems) {
       }
     } else if (el.type == DLRModelElemType::NEO_METADATA) {
       if (el.path != nullptr) {
-        metadata_path = el.path;
+        metadata_data = dlr::LoadFileToString(el.path);
       } else if (el.data != nullptr) {
         metadata_data = static_cast<const char*>(el.data);
       } else {
@@ -125,11 +121,7 @@ void TVMModel::SetupTVMModule(const std::vector<DLRModelElem>& model_elems) {
   if (!IsFileEmpty(model_lib_path)) {
     module = tvm::runtime::Module::LoadFromFile(model_lib_path);
   }
-  // Load Metadata from file or String
-  if (!metadata_path.empty() && !IsFileEmpty(metadata_path)) {
-    LoadJsonFromFile(metadata_path, this->metadata_);
-    ValidateDeviceTypeIfExists();
-  } else if (!metadata_data.empty()) {
+  if (!metadata_data.empty()) {
     LoadJsonFromString(metadata_data, this->metadata_);
     ValidateDeviceTypeIfExists();
   }

--- a/tests/cpp/dlr_elem_test.cc
+++ b/tests/cpp/dlr_elem_test.cc
@@ -1,0 +1,240 @@
+#include <gtest/gtest.h>
+
+#include "dlr.h"
+#include "test_utils.hpp"
+
+DLRModelHandle GetDLRModel() {
+  DLRModelHandle model = nullptr;
+  const std::string graph_file = "./resnet_v1_5_50/compiled_model.json";
+  const std::string params_file = "./resnet_v1_5_50/compiled.params";
+  const std::string so_file = "./resnet_v1_5_50/compiled.so";
+  const std::string meta_file = "./resnet_v1_5_50/compiled.meta";
+
+  // load graph json file
+  std::ifstream graph_stream(graph_file);
+  std::stringstream graph_blob;
+  graph_blob << graph_stream.rdbuf();
+  std::string graph_str = graph_blob.str();
+
+  // load params file
+  std::ifstream pstream(params_file, std::ios::in | std::ios::binary);
+  std::stringstream params_blob;
+  params_blob << pstream.rdbuf();
+  std::string params_str = params_blob.str();
+
+  std::vector<DLRModelElem> model_elems = {
+      {DLRModelElemType::TVM_GRAPH, nullptr, graph_str.c_str(), 0},
+      {DLRModelElemType::TVM_PARAMS, nullptr, params_str.data(), params_str.size()},
+      {DLRModelElemType::TVM_LIB, so_file.c_str(), nullptr, 0},
+      {DLRModelElemType::NEO_METADATA, meta_file.c_str(), nullptr, 0}};
+
+  int device_type = 1;  // cpu;
+  if (CreateDLRModelFromModelElem(&model, model_elems.data(), model_elems.size(), device_type, 0) !=
+      0) {
+    LOG(INFO) << DLRGetLastError() << std::endl;
+    throw std::runtime_error("Could not load DLR Model");
+  }
+  return model;
+}
+
+TEST(DLR, TestGetDLRDeviceType) {
+  const char* model_path = "./resnet_v1_5_50";
+  EXPECT_EQ(GetDLRDeviceType(model_path), -1);
+}
+
+TEST(DLR, TestGetDLRNumInputs) {
+  auto model = GetDLRModel();
+  int num_inputs;
+  EXPECT_EQ(GetDLRNumInputs(&model, &num_inputs), 0);
+  EXPECT_EQ(num_inputs, 1);
+  DeleteDLRModel(&model);
+}
+
+TEST(DLR, TestGetDLRNumWeights) {
+  auto model = GetDLRModel();
+  int num_weights;
+  EXPECT_EQ(GetDLRNumWeights(&model, &num_weights), 0);
+  EXPECT_EQ(num_weights, 108);
+  DeleteDLRModel(&model);
+}
+
+TEST(DLR, TestGetDLRInputName) {
+  auto model = GetDLRModel();
+  const char* input_name;
+  EXPECT_EQ(GetDLRInputName(&model, 0, &input_name), 0);
+  EXPECT_STREQ(input_name, "input_tensor");
+  DeleteDLRModel(&model);
+}
+
+TEST(DLR, TestGetDLRInputType) {
+  auto model = GetDLRModel();
+  const char* input_type;
+  EXPECT_EQ(GetDLRInputType(&model, 0, &input_type), 0);
+  EXPECT_STREQ(input_type, "float32");
+  DeleteDLRModel(&model);
+}
+
+TEST(DLR, TestGetDLRWeightName) {
+  auto model = GetDLRModel();
+  const char* weight_name;
+  EXPECT_EQ(GetDLRWeightName(&model, 0, &weight_name), 0);
+  EXPECT_STREQ(weight_name, "p0");
+  EXPECT_EQ(GetDLRWeightName(&model, 107, &weight_name), 0);
+  EXPECT_STREQ(weight_name, "p99");
+  DeleteDLRModel(&model);
+}
+
+TEST(DLR, TestSetDLRInput) {
+  auto model = GetDLRModel();
+  size_t img_size = 224 * 224 * 3;
+  std::vector<float> img = LoadImageAndPreprocess("cat224-3.txt", img_size, 1);
+  int64_t shape[4] = {1, 224, 224, 3};
+  const char* input_name = "input_tensor";
+  std::vector<float> img2(img_size);
+  EXPECT_EQ(SetDLRInput(&model, input_name, shape, img.data(), 4), 0);
+  EXPECT_EQ(GetDLRInput(&model, input_name, img2.data()), 0);
+  EXPECT_EQ(img, img2);
+  DeleteDLRModel(&model);
+}
+
+TEST(DLR, TestGetDLRInputShape) {
+  auto model = GetDLRModel();
+  int64_t input_size;
+  int input_dim;
+  int index = 0;
+  EXPECT_EQ(GetDLRInputSizeDim(&model, 0, &input_size, &input_dim), 0);
+  EXPECT_EQ(input_dim, 4);
+  EXPECT_EQ(input_size, 1 * 224 * 224 * 3);
+  std::vector<int64_t> shape(input_dim);
+  EXPECT_EQ(GetDLRInputShape(&model, 0, shape.data()), 0);
+  EXPECT_EQ(shape[0], 1);
+  EXPECT_EQ(shape[1], 224);
+  EXPECT_EQ(shape[2], 224);
+  EXPECT_EQ(shape[3], 3);
+  DeleteDLRModel(&model);
+}
+
+TEST(DLR, TestGetDLROutputShape) {
+  auto model = GetDLRModel();
+  int64_t output_size;
+  int output_dim;
+  int index = 0;
+  // output 0
+  EXPECT_EQ(GetDLROutputSizeDim(&model, 0, &output_size, &output_dim), 0);
+  EXPECT_EQ(output_dim, 1);
+  EXPECT_EQ(output_size, 1);
+  std::vector<int64_t> shape0(output_dim);
+  EXPECT_EQ(GetDLROutputShape(&model, 0, shape0.data()), 0);
+  EXPECT_EQ(shape0[0], 1);
+  // output 1
+  EXPECT_EQ(GetDLROutputSizeDim(&model, 1, &output_size, &output_dim), 0);
+  EXPECT_EQ(output_dim, 2);
+  EXPECT_EQ(output_size, 1001);
+  std::vector<int64_t> shape1(output_dim);
+  EXPECT_EQ(GetDLROutputShape(&model, 1, shape1.data()), 0);
+  EXPECT_EQ(shape1[0], 1);
+  EXPECT_EQ(shape1[1], 1001);
+  DeleteDLRModel(&model);
+}
+
+TEST(DLR, TestGetDLRNumOutputs) {
+  auto model = GetDLRModel();
+  int num_outputs;
+  EXPECT_EQ(GetDLRNumOutputs(&model, &num_outputs), 0);
+  EXPECT_EQ(num_outputs, 2);
+}
+
+TEST(DLR, TestGetDLROutputType) {
+  auto model = GetDLRModel();
+  // output 0
+  const char* output_type0;
+  EXPECT_EQ(GetDLROutputType(&model, 0, &output_type0), 0);
+  EXPECT_STREQ(output_type0, "int32");
+  // output 1
+  const char* output_type1;
+  EXPECT_EQ(GetDLROutputType(&model, 1, &output_type1), 0);
+  EXPECT_STREQ(output_type1, "float32");
+  DeleteDLRModel(&model);
+}
+
+TEST(DLR, GetDLRHasMetadata) {
+  auto model = GetDLRModel();
+  bool has_metadata;
+  EXPECT_EQ(GetDLRHasMetadata(&model, &has_metadata), 0);
+  EXPECT_TRUE(has_metadata);
+  DeleteDLRModel(&model);
+}
+
+TEST(DLR, TestGetDLROutputName) {
+  auto model = GetDLRModel();
+  // output 0
+  const char* output_name0;
+  EXPECT_EQ(GetDLROutputName(&model, 0, &output_name0), 0);
+  EXPECT_STREQ(output_name0, "ArgMax:0");
+  // output 1
+  const char* output_name1;
+  EXPECT_EQ(GetDLROutputName(&model, 1, &output_name1), 0);
+  EXPECT_STREQ(output_name1, "softmax_tensor:0");
+  DeleteDLRModel(&model);
+}
+
+TEST(DLR, TestGetDLROutputIndex) {
+  auto model = GetDLRModel();
+  // output 0
+  int output_index0;
+  EXPECT_EQ(GetDLROutputIndex(&model, "ArgMax:0", &output_index0), 0);
+  EXPECT_EQ(output_index0, 0);
+  // output 1
+  int output_index1;
+  EXPECT_EQ(GetDLROutputIndex(&model, "softmax_tensor:0", &output_index1), 0);
+  EXPECT_EQ(output_index1, 1);
+  DeleteDLRModel(&model);
+}
+
+TEST(DLR, TestGetDLRBackend) {
+  auto model = GetDLRModel();
+  const char* backend;
+  EXPECT_EQ(GetDLRBackend(&model, &backend), 0);
+  EXPECT_STREQ(backend, "tvm");
+  DeleteDLRModel(&model);
+}
+
+TEST(DLR, TestRunDLRModel_GetDLROutput) {
+  auto model = GetDLRModel();
+  size_t img_size = 224 * 224 * 3;
+  std::vector<float> img = LoadImageAndPreprocess("cat224-3.txt", img_size, 1);
+  int64_t shape[4] = {1, 224, 224, 3};
+  const char* input_name = "input_tensor";
+  EXPECT_EQ(SetDLRInput(&model, input_name, shape, img.data(), 4), 0);
+  EXPECT_EQ(RunDLRModel(&model), 0);
+  // output 0
+  int output0[1];
+  EXPECT_EQ(GetDLROutput(&model, 0, output0), 0);
+  EXPECT_EQ(output0[0], 112);
+  EXPECT_EQ(GetDLROutputByName(&model, "ArgMax:0", output0), 0);
+  EXPECT_EQ(output0[0], 112);
+  const void* output0_p;
+  EXPECT_EQ(GetDLROutputPtr(&model, 0, &output0_p), 0);
+  EXPECT_EQ(((int*)output0_p)[0], 112);
+  // output 1
+  float output1[1001];
+  EXPECT_EQ(GetDLROutput(&model, 1, output1), 0);
+  EXPECT_GT(output1[112], 0.01);
+  EXPECT_EQ(GetDLROutputByName(&model, "softmax_tensor:0", output1), 0);
+  EXPECT_GT(output1[112], 0.01);
+  float* output1_p;
+  EXPECT_EQ(GetDLROutputPtr(&model, 1, (const void**)&output1_p), 0);
+  EXPECT_GT(output1_p[112], 0.01);
+  for (int i = 0; i < 1001; i++) {
+    EXPECT_EQ(output1_p[i], output1[i]);
+  }
+  DeleteDLRModel(&model);
+}
+
+int main(int argc, char** argv) {
+  testing::InitGoogleTest(&argc, argv);
+#ifndef _WIN32
+  testing::FLAGS_gtest_death_test_style = "threadsafe";
+#endif  // _WIN32
+  return RUN_ALL_TESTS();
+}

--- a/tests/cpp/dlr_elem_test.cc
+++ b/tests/cpp/dlr_elem_test.cc
@@ -22,11 +22,17 @@ DLRModelHandle GetDLRModel() {
   params_blob << pstream.rdbuf();
   std::string params_str = params_blob.str();
 
+  // load metadata json file
+  std::ifstream meta_stream(meta_file);
+  std::stringstream meta_blob;
+  meta_blob << meta_stream.rdbuf();
+  std::string meta_str = meta_blob.str();
+
   std::vector<DLRModelElem> model_elems = {
       {DLRModelElemType::TVM_GRAPH, nullptr, graph_str.c_str(), 0},
       {DLRModelElemType::TVM_PARAMS, nullptr, params_str.data(), params_str.size()},
       {DLRModelElemType::TVM_LIB, so_file.c_str(), nullptr, 0},
-      {DLRModelElemType::NEO_METADATA, meta_file.c_str(), nullptr, 0}};
+      {DLRModelElemType::NEO_METADATA, nullptr, meta_str.c_str(), 0}};
 
   int device_type = 1;  // cpu;
   if (CreateDLRModelFromModelElem(&model, model_elems.data(), model_elems.size(), device_type, 0) !=

--- a/tests/cpp/dlr_elem_test.cc
+++ b/tests/cpp/dlr_elem_test.cc
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include "dlr.h"
+#include "dlr_common.h"
 #include "test_utils.hpp"
 
 DLRModelHandle GetDLRModel() {
@@ -10,23 +11,9 @@ DLRModelHandle GetDLRModel() {
   const std::string so_file = "./resnet_v1_5_50/compiled.so";
   const std::string meta_file = "./resnet_v1_5_50/compiled.meta";
 
-  // load graph json file
-  std::ifstream graph_stream(graph_file);
-  std::stringstream graph_blob;
-  graph_blob << graph_stream.rdbuf();
-  std::string graph_str = graph_blob.str();
-
-  // load params file
-  std::ifstream pstream(params_file, std::ios::in | std::ios::binary);
-  std::stringstream params_blob;
-  params_blob << pstream.rdbuf();
-  std::string params_str = params_blob.str();
-
-  // load metadata json file
-  std::ifstream meta_stream(meta_file);
-  std::stringstream meta_blob;
-  meta_blob << meta_stream.rdbuf();
-  std::string meta_str = meta_blob.str();
+  std::string graph_str = dlr::LoadFileToString(graph_file);
+  std::string params_str = dlr::LoadFileToString(params_file, std::ios::in | std::ios::binary);
+  std::string meta_str = dlr::LoadFileToString(meta_file);
 
   std::vector<DLRModelElem> model_elems = {
       {DLRModelElemType::TVM_GRAPH, nullptr, graph_str.c_str(), 0},

--- a/tests/cpp/dlr_relayvm_elem_test.cc
+++ b/tests/cpp/dlr_relayvm_elem_test.cc
@@ -29,16 +29,8 @@ class RelayVMElemTest : public ::testing::Test {
     std::string so_file = "./ssd_mobilenet_v1/compiled.so";
     std::string meta_file = "./ssd_mobilenet_v1/compiled.meta";
 
-    // load ro file
-    std::ifstream relay_ob(ro_file, std::ios::binary);
-    std::string code_data((std::istreambuf_iterator<char>(relay_ob)),
-                          std::istreambuf_iterator<char>());
-
-    // load metadata json file
-    std::ifstream meta_stream(meta_file);
-    std::stringstream meta_blob;
-    meta_blob << meta_stream.rdbuf();
-    std::string meta_str = meta_blob.str();
+    std::string code_data = dlr::LoadFileToString(ro_file, std::ios::binary);
+    std::string meta_str = dlr::LoadFileToString(meta_file);
 
     std::vector<DLRModelElem> model_elems = {
         {DLRModelElemType::RELAY_EXEC, nullptr, code_data.data(), code_data.size()},

--- a/tests/cpp/dlr_relayvm_elem_test.cc
+++ b/tests/cpp/dlr_relayvm_elem_test.cc
@@ -28,15 +28,22 @@ class RelayVMElemTest : public ::testing::Test {
     std::string ro_file = "./ssd_mobilenet_v1/code.ro";
     std::string so_file = "./ssd_mobilenet_v1/compiled.so";
     std::string meta_file = "./ssd_mobilenet_v1/compiled.meta";
+
     // load ro file
     std::ifstream relay_ob(ro_file, std::ios::binary);
     std::string code_data((std::istreambuf_iterator<char>(relay_ob)),
                           std::istreambuf_iterator<char>());
 
+    // load metadata json file
+    std::ifstream meta_stream(meta_file);
+    std::stringstream meta_blob;
+    meta_blob << meta_stream.rdbuf();
+    std::string meta_str = meta_blob.str();
+
     std::vector<DLRModelElem> model_elems = {
         {DLRModelElemType::RELAY_EXEC, nullptr, code_data.data(), code_data.size()},
         {DLRModelElemType::TVM_LIB, so_file.c_str(), nullptr, 0},
-        {DLRModelElemType::NEO_METADATA, meta_file.c_str(), nullptr, 0}};
+        {DLRModelElemType::NEO_METADATA, nullptr, meta_str.c_str(), 0}};
     model = new dlr::RelayVMModel(model_elems, ctx);
   }
 

--- a/tests/cpp/dlr_relayvm_elem_test.cc
+++ b/tests/cpp/dlr_relayvm_elem_test.cc
@@ -1,0 +1,146 @@
+#include <gtest/gtest.h>
+
+#include "dlr_relayvm.h"
+#include "test_utils.hpp"
+
+int main(int argc, char** argv) {
+  testing::InitGoogleTest(&argc, argv);
+#ifndef _WIN32
+  testing::FLAGS_gtest_death_test_style = "threadsafe";
+#endif  // _WIN32
+  return RUN_ALL_TESTS();
+}
+
+class RelayVMElemTest : public ::testing::Test {
+ protected:
+  const int batch_size = 1;
+  size_t img_size = 512 * 512 * 3;
+  const int64_t input_shape[4] = {1, 512, 512, 3};
+  const int input_dim = 4;
+  std::vector<int8_t> img{std::vector<int8_t>(img_size)};
+
+  dlr::RelayVMModel* model;
+
+  RelayVMElemTest() {
+    const int device_type = kDLCPU;
+    const int device_id = 0;
+    DLContext ctx = {static_cast<DLDeviceType>(device_type), device_id};
+    std::string ro_file = "./ssd_mobilenet_v1/code.ro";
+    std::string so_file = "./ssd_mobilenet_v1/compiled.so";
+    std::string meta_file = "./ssd_mobilenet_v1/compiled.meta";
+    // load ro file
+    std::ifstream relay_ob(ro_file, std::ios::binary);
+    std::string code_data((std::istreambuf_iterator<char>(relay_ob)),
+                          std::istreambuf_iterator<char>());
+
+    std::vector<DLRModelElem> model_elems = {
+        {DLRModelElemType::RELAY_EXEC, nullptr, code_data.data(), code_data.size()},
+        {DLRModelElemType::TVM_LIB, so_file.c_str(), nullptr, 0},
+        {DLRModelElemType::NEO_METADATA, meta_file.c_str(), nullptr, 0}};
+    model = new dlr::RelayVMModel(model_elems, ctx);
+  }
+
+  ~RelayVMElemTest() { delete model; }
+};
+
+TEST_F(RelayVMElemTest, TestGetNumInputs) { EXPECT_EQ(model->GetNumInputs(), 1); }
+
+TEST_F(RelayVMElemTest, TestGetInputName) { EXPECT_STREQ(model->GetInputName(0), "image_tensor"); }
+
+TEST_F(RelayVMElemTest, TestGetInputType) { EXPECT_STREQ(model->GetInputType(0), "uint8"); }
+
+TEST_F(RelayVMElemTest, TestGetInputShape) {
+  std::vector<int64_t> in_shape(std::begin(input_shape), std::end(input_shape));
+  EXPECT_EQ(model->GetInputShape(0), in_shape);
+}
+
+TEST_F(RelayVMElemTest, TestGetInputSize) { EXPECT_EQ(model->GetInputSize(0), 1 * 512 * 512 * 3); }
+
+TEST_F(RelayVMElemTest, TestGetInputDim) { EXPECT_EQ(model->GetInputDim(0), 4); }
+
+TEST_F(RelayVMElemTest, TestSetInput) {
+  EXPECT_NO_THROW(model->SetInput("image_tensor", input_shape, img.data(), input_dim));
+}
+
+TEST_F(RelayVMElemTest, TestGetNumOutputs) { EXPECT_EQ(model->GetNumOutputs(), 4); }
+
+TEST_F(RelayVMElemTest, TestGetOutputName) {
+  EXPECT_STREQ(model->GetOutputName(0), "detection_classes:0");
+  EXPECT_STREQ(model->GetOutputName(1), "num_detections:0");
+  EXPECT_STREQ(model->GetOutputName(2), "detection_boxes:0");
+  EXPECT_STREQ(model->GetOutputName(3), "detection_scores:0");
+}
+
+TEST_F(RelayVMElemTest, TestGetOutputType) {
+  EXPECT_STREQ(model->GetOutputType(0), "float32");
+  EXPECT_STREQ(model->GetOutputType(1), "float32");
+  EXPECT_STREQ(model->GetOutputType(2), "float32");
+  EXPECT_STREQ(model->GetOutputType(3), "float32");
+}
+
+TEST_F(RelayVMElemTest, TestRun) {
+  EXPECT_NO_THROW(model->SetInput("image_tensor", input_shape, img.data(), input_dim));
+  model->Run();
+}
+
+TEST_F(RelayVMElemTest, TestGetOutputShape) {
+  int64_t output_shape[2];
+  EXPECT_NO_THROW(model->GetOutputShape(0, output_shape));
+
+  EXPECT_NO_THROW(model->SetInput("image_tensor", input_shape, img.data(), input_dim));
+  EXPECT_NO_THROW(model->Run());
+
+  int64_t output_0_shape[2];
+  EXPECT_NO_THROW(model->GetOutputShape(0, output_0_shape));
+  EXPECT_EQ(output_0_shape[0], 1);
+  EXPECT_EQ(output_0_shape[1], 100);
+  int64_t output_1_shape[1];
+  EXPECT_NO_THROW(model->GetOutputShape(1, output_1_shape));
+  EXPECT_EQ(output_1_shape[0], 1);
+  int64_t output_2_shape[3];
+  EXPECT_NO_THROW(model->GetOutputShape(2, output_2_shape));
+  EXPECT_EQ(output_2_shape[0], 1);
+  EXPECT_EQ(output_2_shape[1], 100);
+  EXPECT_EQ(output_2_shape[2], 4);
+  int64_t output_3_shape[2];
+  EXPECT_NO_THROW(model->GetOutputShape(3, output_3_shape));
+  EXPECT_EQ(output_3_shape[0], 1);
+  EXPECT_EQ(output_3_shape[1], 100);
+}
+
+TEST_F(RelayVMElemTest, TestGetOutputSizeDim) {
+  int64_t size;
+  int dim;
+
+  EXPECT_NO_THROW(model->GetOutputSizeDim(0, &size, &dim));
+  EXPECT_EQ(size, 100);
+
+  EXPECT_NO_THROW(model->SetInput("image_tensor", input_shape, img.data(), input_dim));
+  EXPECT_NO_THROW(model->Run());
+
+  EXPECT_NO_THROW(model->GetOutputSizeDim(0, &size, &dim));
+  EXPECT_EQ(size, 100);
+  EXPECT_EQ(dim, 2);
+  EXPECT_NO_THROW(model->GetOutputSizeDim(1, &size, &dim));
+  EXPECT_EQ(size, 1);
+  EXPECT_EQ(dim, 1);
+  EXPECT_NO_THROW(model->GetOutputSizeDim(2, &size, &dim));
+  EXPECT_EQ(size, 400);
+  EXPECT_EQ(dim, 3);
+  EXPECT_NO_THROW(model->GetOutputSizeDim(3, &size, &dim));
+  EXPECT_EQ(size, 100);
+  EXPECT_EQ(dim, 2);
+}
+
+TEST_F(RelayVMElemTest, TestGetOutput) {
+  EXPECT_NO_THROW(model->SetInput("image_tensor", input_shape, img.data(), input_dim));
+  EXPECT_NO_THROW(model->Run());
+
+  float output3[100];
+  EXPECT_NO_THROW(model->GetOutput(3, output3));
+  float* output3_p;
+  EXPECT_NO_THROW(output3_p = (float*)model->GetOutputPtr(3));
+  for (int i = 0; i < 100; i++) {
+    EXPECT_EQ(output3_p[i], output3[i]);
+  }
+}

--- a/tests/cpp/dlr_tvm_elem_test.cc
+++ b/tests/cpp/dlr_tvm_elem_test.cc
@@ -1,0 +1,77 @@
+#include <gtest/gtest.h>
+
+#include "dlr.h"
+#include "dlr_tvm.h"
+#include "test_utils.hpp"
+
+class TVMElemTest : public ::testing::Test {
+ protected:
+  std::vector<float> img;
+  const int batch_size = 1;
+  size_t img_size = 224 * 224 * 3;
+  const int64_t input_shape[4] = {1, 224, 224, 3};
+  const int input_dim = 4;
+  const std::string graph_file = "./resnet_v1_5_50/compiled_model.json";
+  const std::string params_file = "./resnet_v1_5_50/compiled.params";
+  const std::string so_file = "./resnet_v1_5_50/compiled.so";
+  const std::string meta_file = "./resnet_v1_5_50/compiled.meta";
+
+  dlr::TVMModel* model;
+
+  TVMElemTest() {
+    // load graph json file
+    std::ifstream graph_stream(graph_file);
+    std::stringstream graph_blob;
+    graph_blob << graph_stream.rdbuf();
+    std::string graph_str = graph_blob.str();
+
+    // load params file
+    std::ifstream pstream(params_file, std::ios::in | std::ios::binary);
+    std::stringstream params_blob;
+    params_blob << pstream.rdbuf();
+    std::string params_str = params_blob.str();
+
+    std::vector<DLRModelElem> model_elems = {
+        {DLRModelElemType::TVM_GRAPH, nullptr, graph_str.c_str(), 0},
+        {DLRModelElemType::TVM_PARAMS, nullptr, params_str.data(), params_str.size()},
+        {DLRModelElemType::TVM_LIB, so_file.c_str(), nullptr, 0},
+        {DLRModelElemType::NEO_METADATA, meta_file.c_str(), nullptr, 0}};
+
+    // Setup input data
+    img = LoadImageAndPreprocess("cat224-3.txt", img_size, batch_size);
+
+    // Instantiate model
+    int device_type = 1;
+    int device_id = 0;
+    DLContext ctx = {static_cast<DLDeviceType>(device_type), device_id};
+    model = new dlr::TVMModel(model_elems, ctx);
+  }
+
+  ~TVMElemTest() { delete model; }
+};
+
+TEST_F(TVMElemTest, TestGetNumInputs) { EXPECT_EQ(model->GetNumInputs(), 1); }
+
+TEST_F(TVMElemTest, TestGetInput) {
+  EXPECT_NO_THROW(model->SetInput("input_tensor", input_shape, img.data(), input_dim));
+  std::vector<float> observed_input_data(img_size);
+  EXPECT_NO_THROW(model->GetInput("input_tensor", observed_input_data.data()));
+  EXPECT_EQ(img, observed_input_data);
+}
+
+TEST_F(TVMElemTest, TestGetInputShape) {
+  std::vector<int64_t> in_shape(std::begin(input_shape), std::end(input_shape));
+  EXPECT_EQ(model->GetInputShape(0), in_shape);
+}
+
+TEST_F(TVMElemTest, TestGetInputSize) { EXPECT_EQ(model->GetInputSize(0), 1 * 224 * 224 * 3); }
+
+TEST_F(TVMElemTest, TestGetInputDim) { EXPECT_EQ(model->GetInputDim(0), 4); }
+
+int main(int argc, char** argv) {
+  testing::InitGoogleTest(&argc, argv);
+#ifndef _WIN32
+  testing::FLAGS_gtest_death_test_style = "threadsafe";
+#endif  // _WIN32
+  return RUN_ALL_TESTS();
+}

--- a/tests/cpp/dlr_tvm_elem_test.cc
+++ b/tests/cpp/dlr_tvm_elem_test.cc
@@ -31,11 +31,17 @@ class TVMElemTest : public ::testing::Test {
     params_blob << pstream.rdbuf();
     std::string params_str = params_blob.str();
 
+    // load metadata json file
+    std::ifstream meta_stream(meta_file);
+    std::stringstream meta_blob;
+    meta_blob << meta_stream.rdbuf();
+    std::string meta_str = meta_blob.str();
+
     std::vector<DLRModelElem> model_elems = {
         {DLRModelElemType::TVM_GRAPH, nullptr, graph_str.c_str(), 0},
         {DLRModelElemType::TVM_PARAMS, nullptr, params_str.data(), params_str.size()},
         {DLRModelElemType::TVM_LIB, so_file.c_str(), nullptr, 0},
-        {DLRModelElemType::NEO_METADATA, meta_file.c_str(), nullptr, 0}};
+        {DLRModelElemType::NEO_METADATA, nullptr, meta_str.c_str(), 0}};
 
     // Setup input data
     img = LoadImageAndPreprocess("cat224-3.txt", img_size, batch_size);

--- a/tests/cpp/dlr_tvm_elem_test.cc
+++ b/tests/cpp/dlr_tvm_elem_test.cc
@@ -19,23 +19,9 @@ class TVMElemTest : public ::testing::Test {
   dlr::TVMModel* model;
 
   TVMElemTest() {
-    // load graph json file
-    std::ifstream graph_stream(graph_file);
-    std::stringstream graph_blob;
-    graph_blob << graph_stream.rdbuf();
-    std::string graph_str = graph_blob.str();
-
-    // load params file
-    std::ifstream pstream(params_file, std::ios::in | std::ios::binary);
-    std::stringstream params_blob;
-    params_blob << pstream.rdbuf();
-    std::string params_str = params_blob.str();
-
-    // load metadata json file
-    std::ifstream meta_stream(meta_file);
-    std::stringstream meta_blob;
-    meta_blob << meta_stream.rdbuf();
-    std::string meta_str = meta_blob.str();
+    std::string graph_str = dlr::LoadFileToString(graph_file);
+    std::string params_str = dlr::LoadFileToString(params_file, std::ios::in | std::ios::binary);
+    std::string meta_str = dlr::LoadFileToString(meta_file);
 
     std::vector<DLRModelElem> model_elems = {
         {DLRModelElemType::TVM_GRAPH, nullptr, graph_str.c_str(), 0},


### PR DESCRIPTION
This PR adds `CreateDLRModelFromModelElem` function.
Model Element can be file path or pointer to data in memory

Example:
```
  std::vector<DLRModelElem> model_elems = {
    {DLRModelElemType::TVM_GRAPH, nullptr, graph_str.c_str(), 0},
    {DLRModelElemType::TVM_PARAMS, nullptr, params_str.data(), params_str.size()},
    {DLRModelElemType::TVM_LIB, so_file.c_str(), nullptr, 0},
    {DLRModelElemType::NEO_METADATA, meta_file.c_str(), nullptr, 0}
  };

CreateDLRModelFromModelElem(&model, model_elems.data(), model_elems.size(), device_type, 0)
```
