### PR TITLE
Add SetDLRInputZeroCopy

### DIFF
--- a/include/dlr.h
+++ b/include/dlr.h
@@ -207,6 +207,19 @@ DLR_DLL
 int SetDLRInputTensor(DLRModelHandle* handle, const char* name, void* tensor);
 
 /*!
+ * \brief Sets the input from existing DLTensor without copying data. Can only be
+ *        used with TVM models (GraphRuntime). Input tensor device must match the device of the
+ *        model, and data must be alligned to 128 bytes. GetDLRInput cannot be used for inputs set
+ *        via SetDLRInputZeroCopy.
+ * \param handle The model handle returned from CreateDLRModel().
+ * \param name The input node name.
+ * \param tensor The input DLTensor.
+ * \return 0 for success, -1 for error. Call DLRGetLastError() to get the error message.
+ */
+DLR_DLL
+int SetDLRInputTensorZeroCopy(DLRModelHandle* handle, const char* name, void* tensor);
+
+/*!
  \brief Gets the current value of the input according the node name.
  \param handle The model handle returned from CreateDLRModel().
  \param name The input node name.

--- a/include/dlr_tvm.h
+++ b/include/dlr_tvm.h
@@ -48,6 +48,7 @@ class DLR_DLL TVMModel : public DLRModel {
   virtual void SetInput(const char* name, const int64_t* shape, const void* input,
                         int dim) override;
   void SetInputTensor(const char* name, DLTensor* tensor);
+  void SetInputTensorZeroCopy(const char* name, DLTensor* tensor);
 
   virtual void GetOutput(int index, void* out) override;
   void GetOutputManagedTensorPtr(int index, const DLManagedTensor** out);

--- a/src/dlr.cc
+++ b/src/dlr.cc
@@ -104,6 +104,21 @@ extern "C" int SetDLRInputTensor(DLRModelHandle* handle, const char* name, void*
   API_END();
 }
 
+extern "C" int SetDLRInputTensorZeroCopy(DLRModelHandle* handle, const char* name, void* tensor) {
+  API_BEGIN();
+  DLRModel* dlr_model = static_cast<DLRModel*>(*handle);
+  DLRBackend backend = dlr_model->GetBackend();
+  CHECK(backend == DLRBackend::kTVM)
+      << "model is not a TVMModel. Found '" << kBackendToStr[static_cast<int>(backend)]
+      << "' but expected 'tvm'";
+
+  DLTensor* dltensor = static_cast<DLTensor*>(tensor);
+  TVMModel* tvm_model = static_cast<TVMModel*>(*handle);
+  CHECK(tvm_model != nullptr) << "model is nullptr, create it first";
+  tvm_model->SetInputTensorZeroCopy(name, dltensor);
+  API_END();
+}
+
 extern "C" int GetDLRInput(DLRModelHandle* handle, const char* name, void* input) {
   API_BEGIN();
   DLRModel* model = static_cast<DLRModel*>(*handle);

--- a/tests/cpp/test_utils.hpp
+++ b/tests/cpp/test_utils.hpp
@@ -9,6 +9,18 @@
 #include <iostream>
 #include <sstream>
 
+void* alligned_malloc(size_t size, size_t align) {
+  void* ptr;
+#ifdef _MSC_VER
+  ptr = _aligned_malloc(size, align);
+#else
+  if (posix_memalign(&ptr, align, size) != 0) {
+    return 0;
+  }
+#endif
+  return ptr;
+}
+
 std::vector<float> LoadImageAndPreprocess(const std::string& img_path, size_t size,
                                           int batch_size) {
   std::string line;
@@ -40,11 +52,11 @@ DLTensor GetInputDLTensor(int ndim, int64_t* shape, const char* filename) {
   DLTensor dltensor;
   dltensor.ctx = {kDLCPU, 0};
   dltensor.ndim = ndim;
-  dltensor.shape = (int64_t*)malloc(ndim * sizeof(int64_t));
+  dltensor.shape = (int64_t*)alligned_malloc(ndim * sizeof(int64_t), 128);
   dltensor.strides = 0;
   dltensor.byte_offset = 0;
   dltensor.dtype = {kDLFloat, 32, 1};
-  dltensor.data = malloc(img_size * sizeof(float));
+  dltensor.data = alligned_malloc(img_size * sizeof(float), 128);
 
   // copy shapes
   for (int i = 0; i < ndim; i++) dltensor.shape[i] = shape[i];


### PR DESCRIPTION
Enables zero copy set input for TVM graph runtime models only.

Fixes #300