### PR TITLE
Add SparseInput flag to metadata for treelite models

### DIFF
--- a/include/dlr_treelite.h
+++ b/include/dlr_treelite.h
@@ -46,6 +46,8 @@ class DLR_DLL TreeliteModel : public DLRModel {
   size_t treelite_output_size_;
   std::unique_ptr<TreeliteInput> treelite_input_;
   std::vector<float, DLRAllocator<float>> treelite_output_;
+  /*! \brief Whether input is sparse (zero values should be skipped) */
+  bool has_sparse_input_;
   void SetupTreeliteModule(const std::vector<std::string>& files);
   void UpdateInputShapes();
 

--- a/src/dlr_treelite.cc
+++ b/src/dlr_treelite.cc
@@ -74,9 +74,13 @@ void TreeliteModel::SetupTreeliteModule(const std::vector<std::string>& model_pa
       << TreeliteGetLastError();
   CHECK_LE(treelite_output_size_, num_output_class) << "Precondition violated";
   UpdateInputShapes();
+  has_sparse_input_ = false;
   if (!paths.metadata.empty() && !IsFileEmpty(paths.metadata)) {
     LoadJsonFromFile(paths.metadata, this->metadata_);
     ValidateDeviceTypeIfExists();
+    if (metadata_.count("Model") && metadata_["Model"].count("SparseInput")) {
+      has_sparse_input_ = metadata_["Model"]["SparseInput"].get<std::string>() == "1";
+    }
   }
 }
 
@@ -139,10 +143,10 @@ void TreeliteModel::SetInput(const char* name, const int64_t* shape, const void*
   treelite_input_->row_ptr.reserve(batch_size);
   for (size_t i = 0; i < batch_size; ++i) {
     for (uint32_t j = 0; j < num_col; ++j) {
-      if (!std::isnan(input_f[i * num_col + j]) && input_f[i * num_col + j] != 0.0f) {
-        treelite_input_->data.push_back(input_f[i * num_col + j]);
-        treelite_input_->col_ind.push_back(j);
-      }
+      if (std::isnan(input_f[i * num_col + j])) continue;
+      if (has_sparse_input_ && input_f[i * num_col + j] == 0.0f) continue;
+      treelite_input_->data.push_back(input_f[i * num_col + j]);
+      treelite_input_->col_ind.push_back(j);
     }
     treelite_input_->row_ptr.push_back(treelite_input_->data.size());
   }


### PR DESCRIPTION
While https://github.com/neo-ai/neo-ai-dlr/pull/297 was correct for some Treelite models which expect sparse inputs, it produced incorrect results for Treelite models expecting dense inputs (where zero is different than missing).

With this PR, the change from #297 is only enabled if a "SparseInput" flag is set in the metadata.


"Sparse" elements are treated as "missing" by the tree booster and as zeros by the linear booster.
https://github.com/dmlc/xgboost/issues/1634
https://www.kaggle.com/c/porto-seguro-safe-driver-prediction/discussion/40835
