### PR TITLE
Allow option to build python-only wheel

### DIFF
--- a/tests/ci_build/create_wheel.sh
+++ b/tests/ci_build/create_wheel.sh
@@ -10,7 +10,7 @@ fi
 
 cd python
 rm -f dist/*
-"${PYTHON_COMMAND}" setup.py bdist_wheel --universal
+"${PYTHON_COMMAND}" setup.py bdist_wheel
 for file in dist/*.whl
 do
   mv ${file} ${file%-any.whl}-${suffix}.whl


### PR DESCRIPTION
Since Neo now will include the libdlr.so with the compiled model itself, most users won't actually need to build their own libdlr.so. This PR adds option to build a python-only DLR wheel which doesn't have libdlr.so, so the user is not required to build anything from source.

Thanks @apivovarov for the idea
https://github.com/neo-ai/neo-ai-dlr/issues/306