### PR TITLE
Use plat-name in create_wheel.sh

### DIFF
--- a/tests/ci_build/create_wheel.sh
+++ b/tests/ci_build/create_wheel.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 set -e
 
-suffix="$1"
+if [ -z "$1" ]; then
+  echo "Error: <plat-name> should be provided, e.g. manylinux1_x86_64"
+  exit 1
+fi
 
 if [[ -z "${PYTHON_COMMAND}" ]]
 then
@@ -10,8 +13,4 @@ fi
 
 cd python
 rm -f dist/*
-"${PYTHON_COMMAND}" setup.py bdist_wheel
-for file in dist/*.whl
-do
-  mv ${file} ${file%-any.whl}-${suffix}.whl
-done
+"${PYTHON_COMMAND}" setup.py bdist_wheel --plat-name=$1


### PR DESCRIPTION
Use setup.py `--plat-name` option to create wheel file with required suffix.
e.g.
```
# command
tests/ci_build/create_wheel.sh manylinux1_x86_64
# creates
python/dist/dlr-1.6.0-py3-none-manylinux1_x86_64.whl
```