### PR TITLE
Install universal dlr if libdlr.so is not found

### DIFF
--- a/python/dlr/libpath.py
+++ b/python/dlr/libpath.py
@@ -10,24 +10,20 @@ class DLRLibraryNotFound(Exception):
     pass
 
 
-def find_lib_path(model_path=None, use_default_dlr=True, logger=None, setup=False):
+def find_lib_path(model_path=None, use_default_dlr=True, logger=None):
     """Find the path to DLR dynamic library files."""
 
     curr_path = os.path.dirname(os.path.abspath(os.path.expanduser(__file__)))
-    if setup:
-        # Only look in build directory when installing or building wheel.
-        dll_paths = [os.path.join(curr_path, '../../build/lib/')]
-    else:
-        # Prioritize library in system path over the current_path.
-        dll_paths = [os.path.join(sys.prefix, 'dlr'),
-                     os.path.join(sys.prefix, 'local', 'dlr'),
-                     os.path.join(sys.exec_prefix, 'local', 'dlr'),
-                     os.path.join(os.path.expanduser('~'), '.local', 'dlr'),
-                     os.path.join(curr_path, '../../lib/'),
-                     os.path.join(curr_path, '../../build/lib/'),
-                     os.path.join(curr_path, './lib/'),
-                     os.path.join(curr_path, './build/lib/'), 
-                     curr_path]
+    # Prioritize library in system path over the current_path.
+    dll_paths = [os.path.join(sys.prefix, 'dlr'),
+                 os.path.join(sys.prefix, 'local', 'dlr'),
+                 os.path.join(sys.exec_prefix, 'local', 'dlr'),
+                 os.path.join(os.path.expanduser('~'), '.local', 'dlr'),
+                 os.path.join(curr_path, '../../lib/'),
+                 os.path.join(curr_path, '../../build/lib/'),
+                 os.path.join(curr_path, './lib/'),
+                 os.path.join(curr_path, './build/lib/'),
+                 curr_path]
     
     if sys.platform == 'win32':
         if platform.architecture()[0] == '64bit':


### PR DESCRIPTION
This PR allows to install universal version of DLR.

If `libdlr.so` is not found in build/lib folder then
```
# the following command will install universal DLR package (without libdlr.so)
python3 setup.py install

# the following command will create universal DLR wheel (without libdlr.so)
python3 setup.py bdist_wheel
```

Example
```
python3 setup.py install 
libdlr.so is not found!
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
!!! Preparing universal py3 version of DLR !!!
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
running install
running bdist_egg
running egg_info
...
```
```
python3 setup.py bdist_wheel 
libdlr.so is not found!
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
!!! Preparing universal py3 version of DLR !!!
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
running bdist_wheel
running build
running build_py
```

DLR does not support Python2. We probably should disable `bdist_wheel --universal` option. `py2.py3` wheels should not be allowed. Pypi repo should only have py3 wheels.
