### PR TITLE
Enable TVM Runtime's `C_REGISTRY` flag to fix mem leak [WIP]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,9 @@ set(DMLC_CORE_SRC "${TVM_SRC}/3rdparty/dmlc-core")
 set(DLPACK_SRC "${TVM_SRC}/3rdparty/dlpack")
 set(FMT_SRC "${TREELITE_SRC}/3rdparty/fmt")
 
+# DLR only uses C-APIs from TVM RunTime
+set(C_REGISTRY ON)
+
 include_directories("${TVM_SRC}/include")
 include_directories("${TVM_SRC}/src/runtime")
 include_directories("${DLPACK_SRC}/include")


### PR DESCRIPTION
https://github.com/neo-ai/tvm/pull/187 fixes an important
memory leak that can be avoided in C/C++ clients. DLR is one such client.

Pushing this commit out for review until PR-187 is merged in Neo TVM.
Once that's done we update the TVM commit to the latest in DLR project

Thanks for contributing to DLR! By submitting this pull request, you confirm that your contribution is made under the terms of the [Apache 2.0 license](https://github.com/neo-ai/neo-ai-dlr/blob/master/LICENSE).

Please refer to our [guideline](https://github.com/neo-ai/neo-ai-dlr/blob/master/CONTRIBUTING.md) for useful information and tips.
