### PR TITLE
Datetime Input Handling 

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,3 @@
-Thanks for contributing to DLR! By submitting this pull request, you confirm that your contribution is made under the terms of the [Apache 2.0 license](https://github.com/neo-ai/neo-ai-dlr/blob/master/LICENSE).
+Thanks for contributing to DLR! By submitting this pull request, you confirm that your contribution is made under the terms of the [Apache 2.0 license](https://github.com/neo-ai/neo-ai-dlr/blob/main/LICENSE).
 
-Please refer to our [guideline](https://github.com/neo-ai/neo-ai-dlr/blob/master/CONTRIBUTING.md) for useful information and tips.
+Please refer to our [guideline](https://github.com/neo-ai/neo-ai-dlr/blob/main/CONTRIBUTING.md) for useful information and tips.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,7 +50,7 @@ pipeline {
         unstash name: 'srcs'
         sh """
         tests/ci_build/git-clang-format.sh HEAD~1
-        tests/ci_build/git-clang-format.sh origin/master
+        tests/ci_build/git-clang-format.sh origin/main
         """
       }
     }

--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@ If you wish to opt-out of this data collection feature, please follow the steps 
 ## Examples
 We prepared several examples demonstrating how to use DLR API on different platforms
 
-* [Neo AI DLR image classification Android example application](https://github.com/neo-ai/neo-ai-dlr/tree/master/examples/android/image_classification)
-* [DL Model compiler for Android](https://github.com/neo-ai/neo-ai-dlr/tree/master/examples/android/tvm_compiler)
-* [DL Model compiler for AWS EC2 instances](https://github.com/neo-ai/neo-ai-dlr/tree/master/container/ec2_compilation_container)
+* [Neo AI DLR image classification Android example application](https://github.com/neo-ai/neo-ai-dlr/tree/main/examples/android/image_classification)
+* [DL Model compiler for Android](https://github.com/neo-ai/neo-ai-dlr/tree/main/examples/android/tvm_compiler)
+* [DL Model compiler for AWS EC2 instances](https://github.com/neo-ai/neo-ai-dlr/tree/main/container/ec2_compilation_container)
 
 ## License
 

--- a/container/ec2_compilation_container/README.md
+++ b/container/ec2_compilation_container/README.md
@@ -41,7 +41,7 @@ Each folder will have three files:
 * model.params
 
 Compiled models can be run using `neo-ai-dlr` API/lib.
-See [DLR EC2 examples](https://github.com/neo-ai/neo-ai-dlr/tree/master/examples/ec2)
+See [DLR EC2 examples](https://github.com/neo-ai/neo-ai-dlr/tree/main/examples/ec2)
 
 ### GluonCV
 To compile GluonCV models use script `compile_gluoncv.py`.

--- a/examples/android/image_classification/README.md
+++ b/examples/android/image_classification/README.md
@@ -13,7 +13,7 @@ models from different frameworks
 
 These instructions walk you through building and
 running the demo on an Android device. For an explanation of the source, see
-[DLR Android image classification example](https://github.com/neo-ai/neo-ai-dlr/tree/master/examples/android/image_classification).
+[DLR Android image classification example](https://github.com/neo-ai/neo-ai-dlr/tree/main/examples/android/image_classification).
 
 <!-- TODO(b/124116863): Add app screenshot. -->
 

--- a/examples/android/tvm_compiler/README.md
+++ b/examples/android/tvm_compiler/README.md
@@ -40,7 +40,7 @@ Each folder will have three files:
 * model.params
 
 Compiled models can be run using `neo-ai-dlr` API/lib.
-See [DLR Android examples](https://github.com/neo-ai/neo-ai-dlr/tree/master/examples/android)
+See [DLR Android examples](https://github.com/neo-ai/neo-ai-dlr/tree/main/examples/android)
 
 ### GluonCV
 To compile GluonCV models use script `compile_gluoncv.py`.

--- a/include/dlr_data_transform.h
+++ b/include/dlr_data_transform.h
@@ -52,15 +52,6 @@ class DLR_DLL DateTimeTransformer : public Transformer {
       "%Y-%m-%d %I:%M:%S%p",     "%Y-%m-%d %H:%M:%S",    "%Y-%m-%d",
   };
 
-  const std::map<std::string, int> month_to_digit = {
-      {"Jan", 1}, {"Feb", 2}, {"Mar", 3}, {"Apr", 4},  {"May", 5},  {"Jun", 6},
-      {"Jul", 7}, {"Aug", 8}, {"Sep", 9}, {"Oct", 10}, {"Nov", 11}, {"Dec", 12}};
-
-  const std::map<uint8_t, uint8_t> num_days = {{1, 31}, {2, 28},  {3, 31},  {4, 30},
-                                               {5, 31}, {6, 30},  {7, 31},  {8, 31},
-                                               {9, 30}, {10, 31}, {11, 30}, {12, 31}};
-  ;
-
   /*! \brief Split Strings in regard of given delimiter strings */
   std::string GetNextSplittedStr(std::string& input_string, std::string delimiter) const;
 
@@ -69,8 +60,7 @@ class DLR_DLL DateTimeTransformer : public Transformer {
 
   /*! \brief Convert a given string to an array of digits representing [WEEKDAY,
    * YEAR, HOUR, MINUTE, SECOND, MONTH, WEEK_OF_YEAR*/
-  void DigitizeDateTime(std::string& input_string, std::vector<int64_t>& datetime_digits,
-                        int64_t output_offset) const;
+  void DigitizeDateTime(std::string& input_string, std::vector<int64_t>& datetime_digits) const;
 
   int64_t GetWeekDay(int64_t year, int64_t month, int64_t day) const;
 

--- a/include/dlr_data_transform.h
+++ b/include/dlr_data_transform.h
@@ -69,7 +69,8 @@ class DLR_DLL DateTimeTransformer : public Transformer {
 
   /*! \brief Convert a given string to an array of digits representing [WEEKDAY,
    * YEAR, HOUR, MINUTE, SECOND, MONTH, WEEK_OF_YEAR*/
-  void DigitizeDateTime(std::string& input_string, std::vector<int64_t>& datetime_digits) const;
+  void DigitizeDateTime(std::string& input_string, std::vector<int64_t>& datetime_digits,
+                        int64_t output_offset) const;
 
   int64_t GetWeekDay(int64_t year, int64_t month, int64_t day) const;
 

--- a/include/dlr_data_transform.h
+++ b/include/dlr_data_transform.h
@@ -3,6 +3,7 @@
 
 #include <tvm/runtime/ndarray.h>
 
+#include <ctime>
 #include <nlohmann/json.hpp>
 
 #include "dlr_common.h"
@@ -45,6 +46,11 @@ class DLR_DLL DateTimeTransformer : public Transformer {
   /*! \brief Number of columns defined by Autopilot Sagemaker-Scikit-Learn-Extension for
    * DateTimeVectorizer */
   const int kNumDateTimeCols = 7;
+
+  const std::vector<std::string> datetime_templates = {
+      "%h %dth, %Y, %I:%M:%S%p", "%h %dth, %Y, %I:%M%p", "%h %dth, %Y, %I%p",
+      "%Y-%m-%d %I:%M:%S%p",     "%Y-%m-%d %H:%M:%S",    "%Y-%m-%d",
+  };
 
   const std::map<std::string, int> month_to_digit = {
       {"Jan", 1}, {"Feb", 2}, {"Mar", 3}, {"Apr", 4},  {"May", 5},  {"Jun", 6},

--- a/include/dlr_data_transform.h
+++ b/include/dlr_data_transform.h
@@ -52,12 +52,6 @@ class DLR_DLL DateTimeTransformer : public Transformer {
       "%Y-%m-%d %I:%M:%S%p",     "%Y-%m-%d %H:%M:%S",    "%Y-%m-%d",
   };
 
-  /*! \brief Split Strings in regard of given delimiter strings */
-  std::string GetNextSplittedStr(std::string& input_string, std::string delimiter) const;
-
-  /*! \brief Calculate if a given year is a leap year */
-  bool IsLeapYear(int64_t year) const;
-
   /*! \brief Convert a given string to an array of digits representing [WEEKDAY,
    * YEAR, HOUR, MINUTE, SECOND, MONTH, WEEK_OF_YEAR*/
   void DigitizeDateTime(std::string& input_string, std::vector<int64_t>& datetime_digits) const;

--- a/src/dlr_data_transform.cc
+++ b/src/dlr_data_transform.cc
@@ -130,7 +130,7 @@ tvm::runtime::NDArray DateTimeTransformer::InitNDArray(const nlohmann::json& inp
   // Create NDArray for transformed input which will be passed to TVM. NUM_COL
   // fixed to original input size + 7
   std::vector<int64_t> arr_shape = {static_cast<int64_t>(input_json.size()),
-                                    static_cast<int64_t>(input_json[0].size() + kNumDateTimeCols)};
+                                    static_cast<int64_t>(kNumDateTimeCols)};
   CHECK(dtype.code == kDLFloat && dtype.bits == 32 && dtype.lanes == 1)
       << "DataTransform DateTimeTransformer is only supported for float32 "
          "inputs.";
@@ -173,8 +173,7 @@ bool DateTimeTransformer::IsLeapYear(int64_t year) const {
 }
 
 void DateTimeTransformer::DigitizeDateTime(std::string& input_string,
-                                           std::vector<int64_t>& datetime_digits,
-                                           int64_t output_offset) const {
+                                           std::vector<int64_t>& datetime_digits) const {
   struct tm tm = {};
 
   char* strptime_success;
@@ -190,13 +189,16 @@ void DateTimeTransformer::DigitizeDateTime(std::string& input_string,
   int64_t week_of_year = (tm.tm_yday) / 7;
   if (week_offset > 0) week_of_year += 1;
 
-  datetime_digits[output_offset + 0] = tm.tm_wday;
-  datetime_digits[output_offset + 1] = 1900 + tm.tm_year;
-  datetime_digits[output_offset + 2] = tm.tm_hour;
-  datetime_digits[output_offset + 3] = tm.tm_min;
-  datetime_digits[output_offset + 4] = tm.tm_sec;
-  datetime_digits[output_offset + 5] = 1 + tm.tm_mon;
-  datetime_digits[output_offset + 6] = week_of_year;
+  datetime_digits[0] = tm.tm_wday;
+  datetime_digits[1] = 1900 + tm.tm_year;
+  datetime_digits[2] = tm.tm_hour;
+  datetime_digits[3] = tm.tm_min;
+  datetime_digits[4] = tm.tm_sec;
+  datetime_digits[5] = 1 + tm.tm_mon;
+  datetime_digits[6] = week_of_year;
+
+  for (auto d : datetime_digits) std::cout << d << ",";
+  std::cout << std::endl << std::endl;
 }
 
 void DateTimeTransformer::MapToNDArray(const nlohmann::json& input_json,
@@ -207,15 +209,15 @@ void DateTimeTransformer::MapToNDArray(const nlohmann::json& input_json,
       << "DataTransform DateTimeVectorizer is only supported for CPU.";
   float* data = static_cast<float*>(input_tensor->data);
 
-  size_t num_col = input_json[0].size() + kNumDateTimeCols;
-  std::vector<int64_t> datetime_digits = std::vector<int64_t>(num_col, 0);
+  std::vector<int64_t> datetime_digits = std::vector<int64_t>(kNumDateTimeCols, 0);
   for (size_t r = 0; r < input_json.size(); ++r) {
     CHECK(input_json[r].size() > 0)
         << "Input must contains a string of format [Date Month, Year, Time].";
-    std::string entry = input_json[r][0].get_ref<const std::string&>();
-    DigitizeDateTime(entry, datetime_digits, input_json[0].size());
-    for (size_t c = 0; c < num_col; ++c) {
-      const int out_index = r * num_col + c;
+    auto date_col = transform["DateCol"].get_ref<const nlohmann::json::number_integer_t&>();
+    std::string entry = input_json[r][date_col].get_ref<const std::string&>();
+    DigitizeDateTime(entry, datetime_digits);
+    for (size_t c = 0; c < kNumDateTimeCols; ++c) {
+      const int out_index = r * kNumDateTimeCols + c;
       data[out_index] = static_cast<float>(datetime_digits[c]);
     }
   }

--- a/src/dlr_data_transform.cc
+++ b/src/dlr_data_transform.cc
@@ -129,7 +129,6 @@ tvm::runtime::NDArray DateTimeTransformer::InitNDArray(const nlohmann::json& inp
                                                        DLDataType dtype, DLContext ctx) const {
   // Create NDArray for transformed input which will be passed to TVM. NUM_COL
   // fixed to original input size + 7
-  std::cout << "input_json/[0/].size(): " << input_json[0].size() << std::endl;
   std::vector<int64_t> arr_shape = {static_cast<int64_t>(input_json.size()),
                                     static_cast<int64_t>(input_json[0].size() + kNumDateTimeCols)};
   CHECK(dtype.code == kDLFloat && dtype.bits == 32 && dtype.lanes == 1)
@@ -177,14 +176,11 @@ void DateTimeTransformer::DigitizeDateTime(std::string& input_string,
                                            std::vector<int64_t>& datetime_digits,
                                            int64_t output_offset) const {
   struct tm tm = {};
-  std::cout << "input: " << input_string << std::endl;
-  std::cout << "datetime_digits_size: " << datetime_digits.size() << std::endl;
 
   char* strptime_success;
   for (const auto datetime_template : datetime_templates) {
     strptime_success = strptime(input_string.c_str(), datetime_template.c_str(), &tm);
     if (strptime_success) {
-      std::cout << "template: " << datetime_template << std::endl;
       break;
     }
   }
@@ -201,9 +197,6 @@ void DateTimeTransformer::DigitizeDateTime(std::string& input_string,
   datetime_digits[output_offset + 4] = tm.tm_sec;
   datetime_digits[output_offset + 5] = 1 + tm.tm_mon;
   datetime_digits[output_offset + 6] = week_of_year;
-
-  for (auto d : datetime_digits) std::cout << d << ",";
-  std::cout << std::endl << std::endl;
 }
 
 void DateTimeTransformer::MapToNDArray(const nlohmann::json& input_json,

--- a/src/dlr_data_transform.cc
+++ b/src/dlr_data_transform.cc
@@ -148,30 +148,6 @@ int64_t DateTimeTransformer::GetWeekDay(int64_t year, int64_t month, int64_t day
   return weekday;
 }
 
-std::string DateTimeTransformer::GetNextSplittedStr(std::string& input_string,
-                                                    std::string delimiter) const {
-  size_t pos = input_string.find(delimiter);
-  std::string splitted_str = input_string.substr(0, pos);
-  if (pos != std::string::npos) {
-    input_string.erase(0, pos + delimiter.length());
-  } else {
-    input_string.erase(0, input_string.size());
-  }
-  return splitted_str;
-}
-
-bool DateTimeTransformer::IsLeapYear(int64_t year) const {
-  if (year % 4 != 0) {
-    return false;
-  } else if (year % 100 != 0) {
-    return true;
-  } else if (year % 400 != 0) {
-    return false;
-  } else {
-    return true;
-  }
-}
-
 void DateTimeTransformer::DigitizeDateTime(std::string& input_string,
                                            std::vector<int64_t>& datetime_digits) const {
   struct tm tm = {};
@@ -196,9 +172,6 @@ void DateTimeTransformer::DigitizeDateTime(std::string& input_string,
   datetime_digits[4] = tm.tm_sec;
   datetime_digits[5] = 1 + tm.tm_mon;
   datetime_digits[6] = week_of_year;
-
-  for (auto d : datetime_digits) std::cout << d << ",";
-  std::cout << std::endl << std::endl;
 }
 
 void DateTimeTransformer::MapToNDArray(const nlohmann::json& input_json,

--- a/src/dlr_data_transform.cc
+++ b/src/dlr_data_transform.cc
@@ -128,7 +128,7 @@ void CategoricalStringTransformer::MapToNDArray(const nlohmann::json& input_json
 tvm::runtime::NDArray DateTimeTransformer::InitNDArray(const nlohmann::json& input_json,
                                                        DLDataType dtype, DLContext ctx) const {
   // Create NDArray for transformed input which will be passed to TVM. NUM_COL
-  // fixed to original input size + 7
+  // fixed to 7
   std::vector<int64_t> arr_shape = {static_cast<int64_t>(input_json.size()),
                                     static_cast<int64_t>(kNumDateTimeCols)};
   CHECK(dtype.code == kDLFloat && dtype.bits == 32 && dtype.lanes == 1)

--- a/tests/cpp/dlr_data_transform_test.cc
+++ b/tests/cpp/dlr_data_transform_test.cc
@@ -175,11 +175,11 @@ TEST(DLR, DataTransformDateTime) {
 
   EXPECT_EQ(transformed_data[0]->ndim, 2);
   EXPECT_EQ(transformed_data[0]->shape[0], 5);
-  EXPECT_EQ(transformed_data[0]->shape[1], 8);
+  EXPECT_EQ(transformed_data[0]->shape[1], 7);
 
-  std::vector<float> expected_output = {0, 3, 2018, 1, 34, 0, 1, 1,  0, 6, 2012, 23, 34, 59, 2, 6,
-                                        0, 3, 2006, 0, 0,  0, 8, 34, 0, 1, 2017, 14, 21, 28, 5, 19,
-                                        0, 0, 1900, 0, 0,  0, 1, 1};
+  std::vector<float> expected_output = {3, 2018, 1, 34, 0, 1, 1, 6, 2012, 23, 34, 59, 2, 6,
+                                        3, 2006, 0, 0,  0, 8, 34, 1, 2017, 14, 21, 28, 5, 19,
+                                        0, 1900, 0, 0,  0, 1, 1};
 
   for (size_t i = 0; i < expected_output.size(); ++i) {
     ExpectFloatEq(static_cast<float*>(transformed_data[0]->data)[i], expected_output[i]);

--- a/tests/cpp/dlr_data_transform_test.cc
+++ b/tests/cpp/dlr_data_transform_test.cc
@@ -155,7 +155,7 @@ TEST(DLR, DataTransformDateTime) {
         "Input": {
           "ColumnTransform": [
             {
-              "Type": "DateTime"
+              "Type": "DateTime", "DateCol": 0
             }
           ]
         }
@@ -177,9 +177,9 @@ TEST(DLR, DataTransformDateTime) {
   EXPECT_EQ(transformed_data[0]->shape[0], 5);
   EXPECT_EQ(transformed_data[0]->shape[1], 7);
 
-  std::vector<float> expected_output = {3, 2018, 1, 34, 0, 1, 1, 6, 2012, 23, 34, 59, 2, 6,
-                                        3, 2006, 0, 0,  0, 8, 34, 1, 2017, 14, 21, 28, 5, 19,
-                                        0, 1900, 0, 0,  0, 1, 1};
+  std::vector<float> expected_output = {3,  2018, 1, 34,   0, 1,    1, 6, 2012, 23, 34,   59,
+                                        2,  6,    3, 2006, 0, 0,    0, 8, 34,   1,  2017, 14,
+                                        21, 28,   5, 19,   0, 1900, 0, 0, 0,    1,  1};
 
   for (size_t i = 0; i < expected_output.size(); ++i) {
     ExpectFloatEq(static_cast<float*>(transformed_data[0]->data)[i], expected_output[i]);

--- a/tests/cpp/dlr_data_transform_test.cc
+++ b/tests/cpp/dlr_data_transform_test.cc
@@ -163,7 +163,8 @@ TEST(DLR, DataTransformDateTime) {
     })"_json;
   EXPECT_TRUE(transform.HasInputTransform(metadata));
 
-  const char* data = R"([["Jan 3rd, 2018, 1:34am"], ["Feb 11th, 2012, 11:34:59pm"], [""]])";
+  const char* data =
+      R"([["Jan 3th, 2018, 1:34am"], ["Feb 11th, 2012, 11:34:59pm"], ["2006-08-23"], ["2017-05-08 14:21:28"], [""]])";
   std::vector<int64_t> shape = {static_cast<int64_t>(std::strlen(data))};
 
   std::vector<DLDataType> dtypes = {DLDataType{kDLFloat, 32, 1}};
@@ -173,11 +174,12 @@ TEST(DLR, DataTransformDateTime) {
                                            shape.size(), dtypes, ctx, &transformed_data));
 
   EXPECT_EQ(transformed_data[0]->ndim, 2);
-  EXPECT_EQ(transformed_data[0]->shape[0], 3);
+  EXPECT_EQ(transformed_data[0]->shape[0], 5);
   EXPECT_EQ(transformed_data[0]->shape[1], 7);
 
-  std::vector<float> expected_output = {3,  2018, 1, 34, 0, 1, 1, 6, 2012, 23, 34,
-                                        59, 2,    6, 0,  0, 0, 0, 0, 0,    0};
+  std::vector<float> expected_output = {3,  2018, 1, 34,   0, 1,    1, 6, 2012, 23, 34,   59,
+                                        2,  6,    3, 2006, 0, 0,    0, 8, 34,   1,  2017, 14,
+                                        21, 28,   5, 19,   0, 1900, 0, 0, 0,    1,  1};
 
   for (size_t i = 0; i < expected_output.size(); ++i) {
     ExpectFloatEq(static_cast<float*>(transformed_data[0]->data)[i], expected_output[i]);

--- a/tests/cpp/dlr_data_transform_test.cc
+++ b/tests/cpp/dlr_data_transform_test.cc
@@ -175,11 +175,11 @@ TEST(DLR, DataTransformDateTime) {
 
   EXPECT_EQ(transformed_data[0]->ndim, 2);
   EXPECT_EQ(transformed_data[0]->shape[0], 5);
-  EXPECT_EQ(transformed_data[0]->shape[1], 7);
+  EXPECT_EQ(transformed_data[0]->shape[1], 8);
 
-  std::vector<float> expected_output = {3,  2018, 1, 34,   0, 1,    1, 6, 2012, 23, 34,   59,
-                                        2,  6,    3, 2006, 0, 0,    0, 8, 34,   1,  2017, 14,
-                                        21, 28,   5, 19,   0, 1900, 0, 0, 0,    1,  1};
+  std::vector<float> expected_output = {0, 3, 2018, 1, 34, 0, 1, 1,  0, 6, 2012, 23, 34, 59, 2, 6,
+                                        0, 3, 2006, 0, 0,  0, 8, 34, 0, 1, 2017, 14, 21, 28, 5, 19,
+                                        0, 0, 1900, 0, 0,  0, 1, 1};
 
   for (size_t i = 0; i < expected_output.size(); ++i) {
     ExpectFloatEq(static_cast<float*>(transformed_data[0]->data)[i], expected_output[i]);


### PR DESCRIPTION
- Add Templates for various Time formats. i.e. ["Jan 3th, 2018, 1:34am"], ["Feb 11th, 2012, 11:34:59pm"], ["2006-08-23"], ["2017-05-08 14:21:28"] etc.
- Switch to <ctime> for DateTime data processing.
- Separates the "DateTime" Input from "Float" and "Categorical"