### PR TITLE
Enable TVM Runtime's `TVM_C_API_MEM_MGMT` flag to fix mem leak

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,9 @@ set(DMLC_CORE_SRC "${TVM_SRC}/3rdparty/dmlc-core")
 set(DLPACK_SRC "${TVM_SRC}/3rdparty/dlpack")
 set(FMT_SRC "${TREELITE_SRC}/3rdparty/fmt")
 
+# DLR only uses C-APIs from TVM RunTime
+set(TVM_C_API_MEM_MGMT ON)
+
 include_directories("${TVM_SRC}/include")
 include_directories("${TVM_SRC}/src/runtime")
 include_directories("${DLPACK_SRC}/include")


### PR DESCRIPTION
https://github.com/neo-ai/tvm/pull/187 fixes an important
memory leak that can be avoided in C/C++ clients.
DLR is one such client.

Thanks for contributing to DLR! By submitting this pull request, you confirm that your contribution is made under the terms of the [Apache 2.0 license](https://github.com/neo-ai/neo-ai-dlr/blob/main/LICENSE).

Please refer to our [guideline](https://github.com/neo-ai/neo-ai-dlr/blob/main/CONTRIBUTING.md) for useful information and tips.
