### PR TITLE
[RelayVM] Only allocate new input buffer for VM when needed

### DIFF
--- a/include/dlr_data_transform.h
+++ b/include/dlr_data_transform.h
@@ -12,14 +12,17 @@ namespace dlr {
 
 /*! \brief Base case for input transformers. */
 class DLR_DLL Transformer {
+ protected:
+  const tvm::runtime::NDArray empty_;
+
  public:
   virtual void MapToNDArray(const nlohmann::json& input_json, const nlohmann::json& transform,
                             tvm::runtime::NDArray& input_array) const = 0;
 
   /*! \brief Helper function for TransformInput. Allocates NDArray to store mapped input data. */
-  virtual tvm::runtime::NDArray InitNDArray(const nlohmann::json& input_json,
-                                            const nlohmann::json& transform, DLDataType dtype,
-                                            DLContext ctx) const;
+  virtual void InitNDArray(const nlohmann::json& input_json, const nlohmann::json& transform,
+                           DLDataType dtype, DLContext ctx,
+                           tvm::runtime::NDArray& input_array) const;
 };
 
 class DLR_DLL FloatTransformer : public Transformer {
@@ -72,9 +75,8 @@ class DLR_DLL DateTimeTransformer : public Transformer {
   void MapToNDArray(const nlohmann::json& input_json, const nlohmann::json& transform,
                     tvm::runtime::NDArray& input_array) const;
 
-  tvm::runtime::NDArray InitNDArray(const nlohmann::json& input_json,
-                                    const nlohmann::json& transform, DLDataType dtype,
-                                    DLContext ctx) const;
+  void InitNDArray(const nlohmann::json& input_json, const nlohmann::json& transform,
+                   DLDataType dtype, DLContext ctx, tvm::runtime::NDArray& input_array) const;
 };
 
 /*! \brief Handles transformations of input and output data. */

--- a/include/dlr_relayvm.h
+++ b/include/dlr_relayvm.h
@@ -46,6 +46,7 @@ class DLR_DLL RelayVMModel : public DLRModel {
   tvm::runtime::ObjectRef output_ref_;
   std::vector<tvm::runtime::NDArray> outputs_;
   std::vector<std::vector<int64_t>> output_shapes_;
+  const tvm::runtime::NDArray empty_;
 
 #ifdef ENABLE_DATATRANSFORM
   DataTransform data_transform_;

--- a/src/dlr_relayvm.cc
+++ b/src/dlr_relayvm.cc
@@ -332,10 +332,10 @@ void RelayVMModel::SetInputTensor(const char* name, DLTensor* tensor) {
 }
 
 void RelayVMModel::UpdateInputs() {
-  const int kNumArgs = num_inputs_ + 1;
-  TVMValue* values = (TVMValue*)malloc(sizeof(TVMValue) * kNumArgs);
-  int* type_codes = (int*)malloc(sizeof(int) * kNumArgs);
-  auto arg_setter = tvm::runtime::TVMArgsSetter(values, type_codes);
+  const size_t num_args = num_inputs_ + 1;
+  std::vector<TVMValue> values(num_args);
+  std::vector<int> type_codes(num_args);
+  tvm::runtime::TVMArgsSetter arg_setter(values.data(), type_codes.data());
   arg_setter(0, ENTRY_FUNCTION);
   for (int i = 0; i < inputs_.size(); i++) {
     arg_setter(i + 1, inputs_[i]);
@@ -343,10 +343,7 @@ void RelayVMModel::UpdateInputs() {
 
   tvm::runtime::PackedFunc set_input = vm_module_->GetFunction("set_input");
   tvm::runtime::TVMRetValue rv;
-  set_input.CallPacked(tvm::runtime::TVMArgs(values, type_codes, kNumArgs), &rv);
-
-  free(values);
-  free(type_codes);
+  set_input.CallPacked(tvm::runtime::TVMArgs(values.data(), type_codes.data(), num_args), &rv);
 }
 
 void RelayVMModel::Run() {

--- a/tests/cpp/dlr_data_transform_test.cc
+++ b/tests/cpp/dlr_data_transform_test.cc
@@ -48,6 +48,11 @@ TEST(DLR, DataTransformCategoricalString) {
   std::vector<tvm::runtime::NDArray> transformed_data(1);
   EXPECT_NO_THROW(transform.TransformInput(metadata, shape.data(), const_cast<char*>(data),
                                            shape.size(), dtypes, ctx, &transformed_data));
+  // Test that same buffer is reused.
+  const void* buffer = transformed_data[0]->data;
+  EXPECT_NO_THROW(transform.TransformInput(metadata, shape.data(), const_cast<char*>(data),
+                                           shape.size(), dtypes, ctx, &transformed_data));
+  EXPECT_EQ(buffer, transformed_data[0]->data);
 
   std::vector<float> expected_output = {0, 1, 2, -1, -1, -1};
   EXPECT_EQ(transformed_data[0]->ndim, 2);

--- a/tests/cpp/dlr_relayvm_test.cc
+++ b/tests/cpp/dlr_relayvm_test.cc
@@ -51,6 +51,8 @@ TEST_F(RelayVMTest, TestGetInputDim) { EXPECT_EQ(model->GetInputDim(0), 4); }
 
 TEST_F(RelayVMTest, TestSetInput) {
   EXPECT_NO_THROW(model->SetInput("image_tensor", input_shape, img.data(), input_dim));
+  // Second time should reuse same buffer.
+  EXPECT_NO_THROW(model->SetInput("image_tensor", input_shape, img.data(), input_dim));
 }
 
 TEST_F(RelayVMTest, TestGetNumOutputs) { EXPECT_EQ(model->GetNumOutputs(), 4); }


### PR DESCRIPTION
Current code allocates new buffer for VM models on each call to SetInput. With this change, the same buffer is reused unless the shape or dtype changes.