### PR TITLE
avoid targeting android with -lpthread flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -258,7 +258,7 @@ set_target_properties(dlr PROPERTIES LINKER_LANGUAGE CXX)
 message(STATUS "DLR_LINKER_LIBS: " ${DLR_LINKER_LIBS})
 if(ANDROID_BUILD)
   target_link_libraries(dlr treelite_runtime_static tvm_runtime_static ${DLR_LINKER_LIBS})
-else(ANDROID_BUILD)
+else()
   target_link_libraries(dlr treelite_runtime_static tvm_runtime_static ${DLR_LINKER_LIBS} -lpthread)
 endif()
 


### PR DESCRIPTION
On some old version of CMake, it consider the expression `ANDROID_BUILD` in `else(ANDROID_BUILD)` as a condition, therefore, the statement is misleading. Removing expression in `else()` statement would provide a clear logic to CMake.