### PR TITLE
Maintain order of input names to fix wrong dtype issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -471,6 +471,22 @@ if(NOT(AAR_BUILD))
     file(REMOVE /tmp/${INVERSELABEL_MODEL})
   endif()
 
+  set(INPUTORDER_MODEL input_order-ml_m4.tar.gz)
+  set(INPUTORDER_MODEL_DIR ${CMAKE_CURRENT_BINARY_DIR}/input_order)
+  if(NOT IS_DIRECTORY ${INPUTORDER_MODEL_DIR})
+    file(MAKE_DIRECTORY ${INPUTORDER_MODEL_DIR})
+    download_file(
+      https://neo-ai-dlr-test-artifacts.s3-us-west-2.amazonaws.com/compiled-models/release-1.9.0/${INPUTORDER_MODEL}
+      /tmp/${INPUTORDER_MODEL}
+      SHA1
+      e677130d4e47f0a5298f0280aa36a28ae9bb5ef1
+    )
+    # this is OS-agnostic
+    execute_process(COMMAND ${CMAKE_COMMAND} -E tar -xf /tmp/${INPUTORDER_MODEL}
+                    WORKING_DIRECTORY ${INPUTORDER_MODEL_DIR})
+    file(REMOVE /tmp/${INPUTORDER_MODEL})
+  endif()
+
   if(WITH_HEXAGON)
       # Download Test Hexagon model for Android 64 aarch64
       file(MAKE_DIRECTORY dlr_hexagon_model)

--- a/src/dlr_tvm.cc
+++ b/src/dlr_tvm.cc
@@ -147,7 +147,7 @@ void TVMModel::UpdateInputShapes() {
 }
 
 std::vector<std::string> TVMModel::GetWeightNames() const {
-  return tvm_graph_runtime_->GetWeightNames();
+  return weight_names_;
 }
 
 const char* TVMModel::GetInputName(int index) const {

--- a/src/dlr_tvm.cc
+++ b/src/dlr_tvm.cc
@@ -113,11 +113,11 @@ void TVMModel::SetupTVMModule(const std::vector<DLRModelElem>& model_elems) {
   weight_names_ = tvm_graph_runtime_->GetWeightNames();
   num_weights_ = weight_names_.size();
   // tvm_graph_runtime_->GetInputName(*) returns both inputs and weights
-  // Compute set difference to get names of inputs only
-  std::sort(input_names.begin(), input_names.end());
-  std::sort(weight_names_.begin(), weight_names_.end());
-  std::set_difference(input_names.begin(), input_names.end(), weight_names_.begin(),
-                      weight_names_.end(), std::inserter(input_names_, input_names_.begin()));
+  // Remove weights from input_names while maintaining order.
+  std::unordered_set<std::string> weight_names_set(weight_names_.begin(), weight_names_.end());
+  for (auto& name : input_names) {
+    if (weight_names_set.count(name) == 0) input_names_.push_back(name);
+  }
   // Save the number of inputs
   num_inputs_ = input_names_.size();
   input_types_.resize(num_inputs_);

--- a/src/dlr_tvm.cc
+++ b/src/dlr_tvm.cc
@@ -103,22 +103,18 @@ void TVMModel::SetupTVMModule(const std::vector<DLRModelElem>& model_elems) {
 
   tvm_module_ = std::make_shared<tvm::runtime::Module>(tvm::runtime::Module(tvm_graph_runtime_));
 
-  // This is the combined count of inputs and weights
-  const auto num_inputs_weights = tvm_graph_runtime_->NumInputs();
-  std::vector<std::string> input_names;
-  for (int i = 0; i < num_inputs_weights; i++) {
-    input_names.push_back(tvm_graph_runtime_->GetInputName(i));
-  }
-  // Get list of weights
+  // Get list of weights.
   weight_names_ = tvm_graph_runtime_->GetWeightNames();
-  // Weight names can be in a random order. Sort them for consistency.
-  std::sort(weight_names_.begin(), weight_names_.end());
   num_weights_ = weight_names_.size();
-  // tvm_graph_runtime_->GetInputName(*) returns both inputs and weights
-  // Remove weights from input_names while maintaining order.
   std::unordered_set<std::string> weight_names_set(weight_names_.begin(), weight_names_.end());
-  for (auto& name : input_names) {
-    if (weight_names_set.count(name) == 0) input_names_.push_back(name);
+  // TVM inputs contains both inputs and weights.
+  const auto num_inputs_weights = tvm_graph_runtime_->NumInputs();
+  // Filter out weights to get only inputs.
+  for (int i = 0; i < num_inputs_weights; i++) {
+    auto name = tvm_graph_runtime_->GetInputName(i);
+    if (weight_names_set.count(name) == 0) {
+      input_names_.push_back(name);
+    }
   }
   // Save the number of inputs
   num_inputs_ = input_names_.size();

--- a/src/dlr_tvm.cc
+++ b/src/dlr_tvm.cc
@@ -146,9 +146,7 @@ void TVMModel::UpdateInputShapes() {
   }
 }
 
-std::vector<std::string> TVMModel::GetWeightNames() const {
-  return weight_names_;
-}
+std::vector<std::string> TVMModel::GetWeightNames() const { return weight_names_; }
 
 const char* TVMModel::GetInputName(int index) const {
   CHECK_LT(index, num_inputs_) << "Input index is out of range.";

--- a/src/dlr_tvm.cc
+++ b/src/dlr_tvm.cc
@@ -111,6 +111,8 @@ void TVMModel::SetupTVMModule(const std::vector<DLRModelElem>& model_elems) {
   }
   // Get list of weights
   weight_names_ = tvm_graph_runtime_->GetWeightNames();
+  // Weight names can be in a random order. Sort them for consistency.
+  std::sort(weight_names_.begin(), weight_names_.end());
   num_weights_ = weight_names_.size();
   // tvm_graph_runtime_->GetInputName(*) returns both inputs and weights
   // Remove weights from input_names while maintaining order.

--- a/tests/cpp/dlr_elem_test.cc
+++ b/tests/cpp/dlr_elem_test.cc
@@ -98,9 +98,9 @@ TEST(DLR, TestGetDLRWeightName) {
   auto model = GetDLRModel();
   const char* weight_name;
   EXPECT_EQ(GetDLRWeightName(&model, 0, &weight_name), 0);
-  EXPECT_STREQ(weight_name, "p0");
+  EXPECT_STREQ(weight_name, "p45");
   EXPECT_EQ(GetDLRWeightName(&model, 107, &weight_name), 0);
-  EXPECT_STREQ(weight_name, "p99");
+  EXPECT_STREQ(weight_name, "p72");
   DeleteDLRModel(&model);
 }
 

--- a/tests/cpp/dlr_test.cc
+++ b/tests/cpp/dlr_test.cc
@@ -57,9 +57,9 @@ TEST(DLR, TestGetDLRWeightName) {
   auto model = GetDLRModel();
   const char* weight_name;
   EXPECT_EQ(GetDLRWeightName(&model, 0, &weight_name), 0);
-  EXPECT_STREQ(weight_name, "p0");
+  EXPECT_STREQ(weight_name, "p45");
   EXPECT_EQ(GetDLRWeightName(&model, 107, &weight_name), 0);
-  EXPECT_STREQ(weight_name, "p99");
+  EXPECT_STREQ(weight_name, "p72");
   DeleteDLRModel(&model);
 }
 

--- a/tests/cpp/dlr_test.cc
+++ b/tests/cpp/dlr_test.cc
@@ -384,6 +384,31 @@ TEST(DLR, TestSetInputTensorZeroCopy_TVM) {
   DeleteDLRModel(&model);
 }
 
+TEST(DLR, TestDLRInputOrder) {
+  DLRModelHandle model = nullptr;
+  const char* model_path = "./input_order";
+  int device_type = 1;  // cpu;
+  if (CreateDLRModel(&model, model_path, device_type, 0) != 0) {
+    LOG(INFO) << DLRGetLastError() << std::endl;
+    throw std::runtime_error("Could not load DLR Model");
+  }
+  const char* input_names[4];
+  const char* input_types[4];
+  for (int i = 0; i < 4; ++i) {
+    EXPECT_EQ(GetDLRInputName(&model, i, &input_names[i]), 0);
+    EXPECT_EQ(GetDLRInputType(&model, i, &input_types[i]), 0);
+  }
+  EXPECT_STREQ(input_names[0], "image");
+  EXPECT_STREQ(input_names[1], "transform");
+  EXPECT_STREQ(input_names[2], "bbox");
+  EXPECT_STREQ(input_names[3], "index");
+  EXPECT_STREQ(input_types[0], "float32");
+  EXPECT_STREQ(input_types[1], "float32");
+  EXPECT_STREQ(input_types[2], "float32");
+  EXPECT_STREQ(input_types[3], "int32");
+  DeleteDLRModel(&model);
+}
+
 int main(int argc, char** argv) {
   testing::InitGoogleTest(&argc, argv);
 #ifndef _WIN32

--- a/tests/cpp/dlsym/dlr_dlsym_test.cc
+++ b/tests/cpp/dlsym/dlr_dlsym_test.cc
@@ -117,9 +117,9 @@ TEST(DLR, TestGetDLRWeightName) {
   auto model = GetDLRModel();
   const char* weight_name;
   EXPECT_EQ(GetDLRWeightName(&model, 0, &weight_name), 0);
-  EXPECT_STREQ(weight_name, "p0");
+  EXPECT_STREQ(weight_name, "p45");
   EXPECT_EQ(GetDLRWeightName(&model, 107, &weight_name), 0);
-  EXPECT_STREQ(weight_name, "p99");
+  EXPECT_STREQ(weight_name, "p72");
   DeleteDLRModel(&model);
 }
 


### PR DESCRIPTION
The order of the input names was being lost because it was sorted alphabetically when removing weight names. This led to DLR matching the input to the wrong index and therefore wrong dtype.

This probably wasn't an issue before because most models only have one input or all float32 inputs.

### Before

name, index, dtype
```
image 1 float32                                             
transform 3 int32
ValueError: input data with name transform should have dtype int32 but float32 is provided
```

### After

name, index, dtype
```
image 0 float32
transform 1 float32
bbox 2 float32
index 3 int32
```