### PR TITLE
Fix dlr_pipeline_test for ASAN

### DIFF
--- a/demo/cpp/model_peeker.cc
+++ b/demo/cpp/model_peeker.cc
@@ -145,5 +145,7 @@ int main(int argc, char** argv) {
 
   peek_model(model);
 
+  // cleanup
+  DeleteDLRModel(&model);
   return 0;
 }

--- a/demo/cpp/run_resnet.cc
+++ b/demo/cpp/run_resnet.cc
@@ -143,5 +143,8 @@ int main(int argc, char** argv) {
   }
   std::cout << "Max probability is " << max_pred << " at index " << max_id
             << std::endl;
+
+  // cleanup
+  DeleteDLRModel(&model);
   return 0;
 }

--- a/include/dlr_treelite.h
+++ b/include/dlr_treelite.h
@@ -22,7 +22,8 @@ struct TreeliteInput {
   std::vector<size_t, DLRAllocator<size_t>> row_ptr;
   size_t num_row;
   size_t num_col;
-  CSRBatchHandle handle;
+  CSRBatchHandle handle = nullptr;
+  ~TreeliteInput();
 };
 
 /*! \brief Get the paths of the Treelite model files.

--- a/src/dlr_treelite.cc
+++ b/src/dlr_treelite.cc
@@ -52,6 +52,11 @@ ModelPath dlr::GetTreelitePaths(std::vector<std::string> dirname) {
   return paths;
 }
 
+TreeliteInput::~TreeliteInput() {
+  if (handle) TreeliteDeleteSparseBatch(handle);
+  handle = nullptr;
+}
+
 void TreeliteModel::SetupTreeliteModule(std::vector<std::string> model_path) {
   ModelPath paths = GetTreelitePaths(model_path);
   // If OMP_NUM_THREADS is set, use it to determine number of threads;

--- a/tests/cpp/dlr_pipeline_skl_xgb_test.cc
+++ b/tests/cpp/dlr_pipeline_skl_xgb_test.cc
@@ -96,6 +96,7 @@ TEST(PipelineTest, TestGetDLRNumOutputs) {
   int num_outputs;
   EXPECT_EQ(GetDLRNumOutputs(&model, &num_outputs), 0);
   EXPECT_EQ(num_outputs, 1);
+  DeleteDLRModel(&model);
 }
 
 TEST(PipelineTest, TestGetDLROutputType) {

--- a/tests/cpp/dlr_pipeline_test.cc
+++ b/tests/cpp/dlr_pipeline_test.cc
@@ -136,6 +136,7 @@ TEST(PipelineTest, TestGetDLRNumOutputs) {
   int num_outputs;
   EXPECT_EQ(GetDLRNumOutputs(&model, &num_outputs), 0);
   EXPECT_EQ(num_outputs, 2);
+  DeleteDLRModel(&model);
 }
 
 TEST(PipelineTest, TestGetDLROutputType) {

--- a/tests/cpp/dlr_test.cc
+++ b/tests/cpp/dlr_test.cc
@@ -120,6 +120,7 @@ TEST(DLR, TestGetDLRNumOutputs) {
   int num_outputs;
   EXPECT_EQ(GetDLRNumOutputs(&model, &num_outputs), 0);
   EXPECT_EQ(num_outputs, 2);
+  DeleteDLRModel(&model);
 }
 
 TEST(DLR, TestGetDLROutputType) {

--- a/tests/cpp/dlsym/dlr_dlsym_test.cc
+++ b/tests/cpp/dlsym/dlr_dlsym_test.cc
@@ -193,6 +193,7 @@ TEST(DLR, TestGetDLRNumOutputs) {
   int num_outputs;
   EXPECT_EQ(GetDLRNumOutputs(&model, &num_outputs), 0);
   EXPECT_EQ(num_outputs, 2);
+  DeleteDLRModel(&model);
 }
 
 TEST(DLR, TestGetDLROutputType) {


### PR DESCRIPTION
One of the dlr_pipeline_test test cases does not delete DLR model at the end.
It causes AddressSanitizer errors
```
Direct leak of 200 byte(s) in 1 object(s) allocated from
...
Indirect leak of 2208 byte(s) in 3 object(s) allocated from:
...
```

To run `dlr_pipeline_test` with AddressSanitizer enabled use the following flags:
```
cmake .. \
-DCMAKE_CXX_FLAGS="-fsanitize=address -g3" \
-DCMAKE_SHARED_LINKER_FLAGS="-fsanitize=address -g3" \
-DCMAKE_BUILD_TYPE=Debug

make -j16

./dlr_pipeline_test
```

to install AddressSanitizer on Ubuntu
```
apt install libasanN

# Select libasan N version depending on your gcc:
# libasan2: gcc-5
# libasan3: gcc-6
# libasan4: gcc-7
# libasan5: gcc-8
```