### PR TITLE
fix image vulnerabilities

### DIFF
--- a/container/Dockerfile.cpu
+++ b/container/Dockerfile.cpu
@@ -13,6 +13,7 @@ RUN apt-get update && \
     wget \
     curl \
     ca-certificates \
+    libnettle6 \
     && rm -rf /var/lib/apt/lists/* \
     && curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python3 get-pip.py && rm get-pip.py \
     && rm -rf /root/.cache/pip

--- a/container/Dockerfile.gpu
+++ b/container/Dockerfile.gpu
@@ -20,8 +20,8 @@ RUN apt-get update && \
     curl \
     ca-certificates \
     openssl \
-    libssl1.1 \
     libnettle6 \
+    libssl1.1 \
     libzstd1 \
     && rm -rf /var/lib/apt/lists/* \
     && curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python3 get-pip.py && rm get-pip.py \

--- a/container/Dockerfile.gpu
+++ b/container/Dockerfile.gpu
@@ -19,6 +19,10 @@ RUN apt-get update && \
     wget \
     curl \
     ca-certificates \
+    openssl \
+    libssl1.1 \
+    libnettle6 \
+    libzstd1 \
     && rm -rf /var/lib/apt/lists/* \
     && curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python3 get-pip.py && rm get-pip.py \
     && rm -rf /root/.cache/pip


### PR DESCRIPTION
Thanks for contributing to DLR! By submitting this pull request, you confirm that your contribution is made under the terms of the [Apache 2.0 license](https://github.com/neo-ai/neo-ai-dlr/blob/main/LICENSE).

Please refer to our [guideline](https://github.com/neo-ai/neo-ai-dlr/blob/main/CONTRIBUTING.md) for useful information and tips.

[Issue] Inference images for XGBoost, Darknet CPU and GPU have image vulnerabilities, and inference team got sev2 for that. 
At first, we tried to rebuilt the image, the ECR scan result for vulnerabilities after rebuild:
xgboost: 1 High + 18 Medium -> 13 Medium
darknet cpu: 1 High + 18 Medium -> 13 Medium
darknet gpu: 3 High + 48 Medium -> 1 High + 14 Medium

DarkNet GPU base image itself has 1 high vulnerability, so I force to update the affect package to resolve the issue. 