### PR TITLE
Fix dlr tests for ASAN

### DIFF
--- a/demo/cpp/model_peeker.cc
+++ b/demo/cpp/model_peeker.cc
@@ -147,5 +147,7 @@ int main(int argc, char** argv) {
 
   peek_model(model);
 
+  // cleanup
+  DeleteDLRModel(&model);
   return 0;
 }

--- a/demo/cpp/run_resnet.cc
+++ b/demo/cpp/run_resnet.cc
@@ -137,5 +137,8 @@ int main(int argc, char** argv) {
     max_pred = max_pred_uint8;
   }
   std::cout << "Max probability is " << max_pred << " at index " << max_id << std::endl;
+
+  // cleanup
+  DeleteDLRModel(&model);
   return 0;
 }

--- a/include/dlr_treelite.h
+++ b/include/dlr_treelite.h
@@ -22,7 +22,8 @@ struct TreeliteInput {
   std::vector<size_t, DLRAllocator<size_t>> row_ptr;
   size_t num_row;
   size_t num_col;
-  CSRBatchHandle handle;
+  CSRBatchHandle handle = nullptr;
+  ~TreeliteInput();
 };
 
 /*! \brief Get the paths of the Treelite model files.

--- a/src/dlr_treelite.cc
+++ b/src/dlr_treelite.cc
@@ -40,6 +40,11 @@ ModelPath dlr::SetTreelitePaths(const std::vector<std::string>& files) {
   return paths;
 }
 
+TreeliteInput::~TreeliteInput() {
+  if (handle) TreeliteDeleteSparseBatch(handle);
+  handle = nullptr;
+}
+
 void TreeliteModel::SetupTreeliteModule(const std::vector<std::string>& model_path) {
   ModelPath paths = SetTreelitePaths(model_path);
   // If OMP_NUM_THREADS is set, use it to determine number of threads;

--- a/tests/cpp/dlr_elem_test.cc
+++ b/tests/cpp/dlr_elem_test.cc
@@ -162,6 +162,7 @@ TEST(DLR, TestGetDLRNumOutputs) {
   int num_outputs;
   EXPECT_EQ(GetDLRNumOutputs(&model, &num_outputs), 0);
   EXPECT_EQ(num_outputs, 2);
+  DeleteDLRModel(&model);
 }
 
 TEST(DLR, TestGetDLROutputType) {

--- a/tests/cpp/dlr_pipeline_skl_xgb_test.cc
+++ b/tests/cpp/dlr_pipeline_skl_xgb_test.cc
@@ -91,6 +91,7 @@ TEST(PipelineTest, TestGetDLRNumOutputs) {
   int num_outputs;
   EXPECT_EQ(GetDLRNumOutputs(&model, &num_outputs), 0);
   EXPECT_EQ(num_outputs, 1);
+  DeleteDLRModel(&model);
 }
 
 TEST(PipelineTest, TestGetDLROutputType) {

--- a/tests/cpp/dlr_pipeline_test.cc
+++ b/tests/cpp/dlr_pipeline_test.cc
@@ -134,6 +134,7 @@ TEST(PipelineTest, TestGetDLRNumOutputs) {
   int num_outputs;
   EXPECT_EQ(GetDLRNumOutputs(&model, &num_outputs), 0);
   EXPECT_EQ(num_outputs, 2);
+  DeleteDLRModel(&model);
 }
 
 TEST(PipelineTest, TestGetDLROutputType) {

--- a/tests/cpp/dlr_test.cc
+++ b/tests/cpp/dlr_test.cc
@@ -121,6 +121,7 @@ TEST(DLR, TestGetDLRNumOutputs) {
   int num_outputs;
   EXPECT_EQ(GetDLRNumOutputs(&model, &num_outputs), 0);
   EXPECT_EQ(num_outputs, 2);
+  DeleteDLRModel(&model);
 }
 
 TEST(DLR, TestGetDLROutputType) {
@@ -253,6 +254,7 @@ TEST(DLR, TestCreateFromPaths_TVM) {
     EXPECT_EQ(((float*)(output1_p->dl_tensor.data))[i], ((float*)(output1.data))[i]);
   }
 
+  output1_p->deleter(output1_p);
   DeleteDLTensor(output0);
   DeleteDLTensor(output1);
   DeleteDLTensor(input);
@@ -297,6 +299,7 @@ TEST(DLR, TestCreateFromPaths_RelayVM) {
     EXPECT_EQ(((float*)(output3_p->dl_tensor.data))[i], ((float*)(output3.data))[i]);
   }
 
+  output3_p->deleter(output3_p);
   DeleteDLTensor(output3);
   DeleteDLTensor(input);
   DeleteDLRModel(&model);
@@ -378,6 +381,7 @@ TEST(DLR, TestSetInputTensorZeroCopy_TVM) {
     EXPECT_EQ(((float*)(output1_p->dl_tensor.data))[i], ((float*)(output1.data))[i]);
   }
 
+  output1_p->deleter(output1_p);
   DeleteDLTensor(output0);
   DeleteDLTensor(output1);
   DeleteDLTensor(input);

--- a/tests/cpp/dlsym/dlr_dlsym_test.cc
+++ b/tests/cpp/dlsym/dlr_dlsym_test.cc
@@ -187,6 +187,7 @@ TEST(DLR, TestGetDLRNumOutputs) {
   int num_outputs;
   EXPECT_EQ(GetDLRNumOutputs(&model, &num_outputs), 0);
   EXPECT_EQ(num_outputs, 2);
+  DeleteDLRModel(&model);
 }
 
 TEST(DLR, TestGetDLROutputType) {


### PR DESCRIPTION
This PR fixes AddressSanitizer errors in dlr tests. For Example:
```
Direct leak of 200 byte(s) in 1 object(s) allocated from
...
Indirect leak of 2208 byte(s) in 3 object(s) allocated from:
...
```

To build libdlr.so and DLR tests binaries with Debug info and AddressSanitizer enabled use the following flags:
```
cmake .. \
-DCMAKE_CXX_FLAGS="-fsanitize=address -g3" \
-DCMAKE_SHARED_LINKER_FLAGS="-fsanitize=address -g3" \
-DCMAKE_BUILD_TYPE=Debug

make -j16

./dlr_allocator_test
./dlr_common_test
./dlr_data_transform_test
./dlr_dlsym_test
./dlr_elem_test
./dlr_multiple_lib_test
./dlr_pipeline_skl_xgb_test
./dlr_pipeline_test
./dlr_relayvm_elem_test
./dlr_relayvm_test
./dlr_test
./dlr_treelite_test
./dlr_tvm_elem_test
./dlr_tvm_test

```

to install AddressSanitizer on Ubuntu
```
apt install libasanN

# Select libasan N version depending on your gcc:
# libasan2: gcc-5
# libasan3: gcc-6
# libasan4: gcc-7
# libasan5: gcc-8
```
