### PR TITLE
Use -Wl,--exclude-libs,ALL flag for DLR linking only

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,14 +74,7 @@ option(TEST_COVERAGE "C++ test coverage" OFF)
 # Compiler flags
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-# --exclude-libs is not available on Windows and macOS. As such, Windows and 
-# Mac do not support the creation of multiple DLRModel instances (in Python) in 
-# case model folders have their own libdlr.so.
-if (WIN32 OR APPLE)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-else()
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wl,--exclude-libs,ALL")
-endif()
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -funroll-loops")
 set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS}")
@@ -130,7 +123,7 @@ if(USE_OPENCL)
       if(NOT OpenCL_FOUND)
         message(FATAL_ERROR "OpenCL not found, please specify OpenCL location with -DUSE_OPENCL=/path/to/OpenCL")
       endif(NOT OpenCL_FOUND)
-    else(USE_OPENCL STREQUAL "ON")
+    else()
       set(OpenCL_TOOLKIT_ROOT_DIR ${USE_OPENCL})
       message(STATUS "Custom OPENCL_PATH=" ${OpenCL_TOOLKIT_ROOT_DIR})
       set(OpenCL_INCLUDE_DIRS ${OpenCL_TOOLKIT_ROOT_DIR}/include)
@@ -258,6 +251,14 @@ add_library(dlr SHARED $<TARGET_OBJECTS:objdlr>)
 set_output_directory(dlr ${CMAKE_BINARY_DIR}/lib)
 set_target_properties(dlr PROPERTIES LINKER_LANGUAGE CXX)
 message(STATUS "DLR_LINKER_LIBS: " ${DLR_LINKER_LIBS})
+# --exclude-libs is not available on Windows and macOS. As such, Windows and
+# Mac do not support the creation of multiple DLRModel instances (in Python) in
+# case model folders have their own libdlr.so.
+if(WIN32 OR APPLE)
+  message(STATUS "Loading of multiple different DLR shared libraries in Python session is not supported on Windows and Mac")
+else()
+  target_link_libraries(dlr PRIVATE "-Wl,--exclude-libs,ALL")
+endif()
 target_link_libraries(dlr PRIVATE treelite_runtime_static tvm_runtime_static)
 target_link_libraries(dlr PUBLIC ${DLR_LINKER_LIBS})
 if(DLR_STATIC_LIBSTDCPP)


### PR DESCRIPTION
We should use `-Wl,--exclude-libs,ALL` flag only in dlr shared library linking command.
The fix removes the following warnings when building CXX object with clang++ for Android
```
[ 73%] Building CXX object 3rdparty/tvm/CMakeFiles/tvm_runtime_static.dir/src/runtime/rpc/rpc_event_impl.cc.o
clang++: warning: -Wl,--exclude-libs,ALL: 'linker' input unused [-Wunused-command-line-argument]
```
### Validation
```
# Get exported func count before
# Linux gcc
readelf -Ws lib/libdlr.so | grep "FUNC    GLOBAL DEFAULT" | wc -l
808

# Get exported func count after
# Linux gcc
readelf -Ws lib/libdlr.so | grep "FUNC    GLOBAL DEFAULT" | wc -l
808
```

libdlr.so linking command after the fix -  (`-Wl,--exclude-libs,ALL` flag is inserted after .o and before .a files)
```
[100%] Linking CXX shared library lib/libdlr.so
/usr/bin/cmake -E cmake_link_script CMakeFiles/dlr.dir/link.txt --verbose=1
/usr/bin/c++ -fPIC  -funroll-loops -O3 -DNDEBUG  -shared -Wl,-soname,libdlr.so -o lib/libdlr.so  \
CMakeFiles/objdlr.dir/src/dlr.cc.o CMakeFiles/objdlr.dir/src/dlr_allocator.cc.o CMakeFiles/objdlr.dir/src/dlr_common.cc.o \
CMakeFiles/objdlr.dir/src/dlr_pipeline.cc.o CMakeFiles/objdlr.dir/src/dlr_relayvm.cc.o CMakeFiles/objdlr.dir/src/dlr_treelite.cc.o  \
CMakeFiles/objdlr.dir/src/dlr_tvm.cc.o CMakeFiles/objdlr.dir/3rdparty/tvm/src/runtime/dso_library.cc.o  \
CMakeFiles/objdlr.dir/3rdparty/tvm/src/runtime/cpu_device_api.cc.o  \
CMakeFiles/objdlr.dir/3rdparty/tvm/src/runtime/metadata_module.cc.o  \
CMakeFiles/objdlr.dir/3rdparty/tvm/src/runtime/contrib/sort/sort.cc.o \
-Wl,--exclude-libs,ALL lib/libtreelite_runtime_static.a  \
3rdparty/tvm/libtvm_runtime_static.a -lpthread -ldl 3rdparty/treelite/dmlc-core/libdmlc.a -lrt
```