### PR TITLE
Allows user to configure RelayVM allocator via env var or metadata file

### DIFF
--- a/include/dlr_relayvm.h
+++ b/include/dlr_relayvm.h
@@ -47,6 +47,7 @@ class DLR_DLL RelayVMModel : public DLRModel {
   std::vector<tvm::runtime::NDArray> outputs_;
   std::vector<std::vector<int64_t>> output_shapes_;
   const tvm::runtime::NDArray empty_;
+  tvm::runtime::vm::AllocatorType allocator_type_;
 
 #ifdef ENABLE_DATATRANSFORM
   DataTransform data_transform_;
@@ -62,13 +63,15 @@ class DLR_DLL RelayVMModel : public DLRModel {
 
  public:
   explicit RelayVMModel(const std::vector<std::string>& files, const DLContext& ctx)
-      : DLRModel(ctx, DLRBackend::kRELAYVM) {
+      : DLRModel(ctx, DLRBackend::kRELAYVM),
+        allocator_type_(tvm::runtime::vm::AllocatorType::kPooled) {
     SetupVMModule(files);
     FetchInputNodesData();
     FetchOutputNodesData();
   }
   explicit RelayVMModel(std::vector<DLRModelElem> model_elems, const DLContext& ctx)
-      : DLRModel(ctx, DLRBackend::kRELAYVM) {
+      : DLRModel(ctx, DLRBackend::kRELAYVM),
+        allocator_type_(tvm::runtime::vm::AllocatorType::kPooled) {
     SetupVMModule(model_elems);
     FetchInputNodesData();
     FetchOutputNodesData();

--- a/include/dlr_relayvm.h
+++ b/include/dlr_relayvm.h
@@ -100,6 +100,7 @@ class DLR_DLL RelayVMModel : public DLRModel {
   void GetOutputTensor(int index, DLTensor* out);
   virtual void SetNumThreads(int threads) override;
   virtual void UseCPUAffinity(bool use) override;
+  tvm::runtime::vm::AllocatorType GetAllocatorType();
 
   /*
     Following methods use metadata file to lookup input and output names.

--- a/src/dlr_relayvm.cc
+++ b/src/dlr_relayvm.cc
@@ -75,10 +75,10 @@ void RelayVMModel::SetupVMModule(const std::vector<DLRModelElem>& model_elems) {
 
   LoadJsonFromString(metadata_data, this->metadata_);
   ValidateDeviceTypeIfExists();
-  // Override allocator.
-  const char* val = std::getenv("DLR_VM_ALLOCATOR");
-  if ((metadata_.count("Model") && metadata_["Model"].count("VMAllocator") &&
-       metadata_["Model"]["VMAllocator"].get<std::string>() == "naive") ||
+  // Override allocator - default is kPooled.
+  const char* val = std::getenv("DLR_RELAYVM_ALLOCATOR");
+  if ((metadata_.count("Model") && metadata_["Model"].count("RelayVMAllocator") &&
+       metadata_["Model"]["RelayVMAllocator"].get<std::string>() == "naive") ||
       (val != nullptr && std::string(val) == "naive")) {
     allocator_type_ = tvm::runtime::vm::AllocatorType::kNaive;
   }
@@ -532,3 +532,5 @@ int RelayVMModel::GetNumInputs() const {
 
   return num_inputs_;
 }
+
+tvm::runtime::vm::AllocatorType RelayVMModel::GetAllocatorType() { return allocator_type_; }

--- a/tests/cpp/dlr_relayvm_test.cc
+++ b/tests/cpp/dlr_relayvm_test.cc
@@ -1,6 +1,7 @@
 #include "dlr_relayvm.h"
 
 #include <gtest/gtest.h>
+#include <nlohmann/json.hpp>
 
 #include "test_utils.hpp"
 
@@ -136,4 +137,46 @@ TEST_F(RelayVMTest, TestGetOutput) {
   for (int i = 0; i < 100; i++) {
     EXPECT_EQ(output3_p[i], output3[i]);
   }
+}
+
+TEST(DLR, TestRelayVMAllocatorDefault) {
+  DLContext ctx = {static_cast<DLDeviceType>(kDLCPU), 0};
+  std::vector<std::string> paths = {"./ssd_mobilenet_v1"};
+  std::vector<std::string> files = dlr::FindFiles(paths);
+  dlr::RelayVMModel* model = new dlr::RelayVMModel(files, ctx);
+
+  EXPECT_EQ(model->GetAllocatorType(), tvm::runtime::vm::AllocatorType::kPooled);
+
+  delete model;
+}
+
+TEST(DLR, TestRelayVMAllocatorEnvVar) {
+  EXPECT_EQ(SetEnv("DLR_RELAYVM_ALLOCATOR", "naive"), 0);
+  DLContext ctx = {static_cast<DLDeviceType>(kDLCPU), 0};
+  std::vector<std::string> paths = {"./ssd_mobilenet_v1"};
+  std::vector<std::string> files = dlr::FindFiles(paths);
+  dlr::RelayVMModel* model = new dlr::RelayVMModel(files, ctx);
+
+  EXPECT_EQ(model->GetAllocatorType(), tvm::runtime::vm::AllocatorType::kNaive);
+
+  delete model;
+  EXPECT_EQ(SetEnv("DLR_RELAYVM_ALLOCATOR", ""), 0);
+}
+
+TEST(DLR, TestRelayVMAllocatorFromMetadata) {
+  DLContext ctx = {static_cast<DLDeviceType>(kDLCPU), 0};
+  std::string ro_file = "./ssd_mobilenet_v1/code.ro";
+  std::string so_file = "./ssd_mobilenet_v1/compiled.so";
+  std::string meta_file = "./ssd_mobilenet_v1/compiled.meta";
+  std::ifstream ifs(meta_file);
+  nlohmann::json metadata = nlohmann::json::parse(ifs);
+  metadata["Model"]["RelayVMAllocator"] = "naive";
+  std::string meta_str = metadata.dump();
+  std::vector<DLRModelElem> model_elems = {
+      {DLRModelElemType::RELAY_EXEC, ro_file.c_str(), nullptr, 0},
+      {DLRModelElemType::TVM_LIB, so_file.c_str(), nullptr, 0},
+      {DLRModelElemType::NEO_METADATA, nullptr, meta_str.c_str(), meta_str.size()}};
+  dlr::RelayVMModel* model = new dlr::RelayVMModel(model_elems, ctx);
+  EXPECT_EQ(model->GetAllocatorType(), tvm::runtime::vm::AllocatorType::kNaive);
+  delete model;
 }

--- a/tests/cpp/dlr_relayvm_test.cc
+++ b/tests/cpp/dlr_relayvm_test.cc
@@ -1,6 +1,7 @@
 #include "dlr_relayvm.h"
 
 #include <gtest/gtest.h>
+
 #include <nlohmann/json.hpp>
 
 #include "test_utils.hpp"

--- a/tests/cpp/test_utils.hpp
+++ b/tests/cpp/test_utils.hpp
@@ -4,6 +4,7 @@
 #include <dlpack/dlpack.h>
 #include <dmlc/logging.h>
 
+#include <stdlib.h>
 #include <cstring>
 #include <fstream>
 #include <iostream>
@@ -102,6 +103,14 @@ DLTensor GetEmptyDLTensor(int ndim, int64_t* shape, uint8_t dtype, uint8_t bits)
 void DeleteDLTensor(DLTensor& dltensor) {
   free(dltensor.shape);
   free(dltensor.data);
+}
+
+int SetEnv(const char* key, const char* value) {
+#ifdef _WIN32
+  return static_cast<int>(_putenv_s(key, value));
+#else
+  return setenv(key, value, 1);
+#endif  // _WIN32
 }
 
 #endif


### PR DESCRIPTION
Fixes #296

Default allocator is still Pooled.
Can be changed with env var `DLR_VM_ALLOCATOR=naive` or from metadata file:
```
{
  "Model": {
    "VMAllocator": "naive",
    ...
  }
}
```