### PR TITLE
Add support and tests for score output using variable pred_margin

### DIFF
--- a/include/dlr_treelite.h
+++ b/include/dlr_treelite.h
@@ -84,7 +84,7 @@ class DLR_DLL TreeliteModel : public DLRModel {
   virtual void SetNumThreads(int threads) override;
   virtual void UseCPUAffinity(bool use) override;
 
-  inline void SetPredMargin() { pred_margin = 1; };
+  inline void SetPredMargin(bool pred_margin) { pred_margin = int(pred_margin); };
 };
 
 }  // namespace dlr

--- a/include/dlr_treelite.h
+++ b/include/dlr_treelite.h
@@ -52,6 +52,9 @@ class DLR_DLL TreeliteModel : public DLRModel {
   void SetupTreeliteModule(const std::vector<std::string>& files);
   void UpdateInputShapes();
 
+  // whether to produce raw margin scores instead of transformed probabilities
+  int pred_margin = 0;
+
  public:
   /*! \brief Load model files from given folder path.
    */
@@ -80,6 +83,8 @@ class DLR_DLL TreeliteModel : public DLRModel {
   virtual void Run() override;
   virtual void SetNumThreads(int threads) override;
   virtual void UseCPUAffinity(bool use) override;
+
+  inline void SetPredMargin() { pred_margin = 1; };
 };
 
 }  // namespace dlr

--- a/src/dlr_treelite.cc
+++ b/src/dlr_treelite.cc
@@ -214,7 +214,7 @@ void TreeliteModel::Run() {
   size_t out_result_size;
   CHECK(treelite_input_);
   treelite_output_.resize(treelite_input_->num_row * treelite_output_buffer_size_);
-  CHECK_EQ(TreelitePredictorPredictBatch(treelite_model_, treelite_input_->handle, 1, 0, 
+  CHECK_EQ(TreelitePredictorPredictBatch(treelite_model_, treelite_input_->handle, 1, 0,
                                          pred_margin, treelite_output_.data(), &out_result_size),
            0)
       << TreeliteGetLastError();

--- a/src/dlr_treelite.cc
+++ b/src/dlr_treelite.cc
@@ -214,8 +214,8 @@ void TreeliteModel::Run() {
   size_t out_result_size;
   CHECK(treelite_input_);
   treelite_output_.resize(treelite_input_->num_row * treelite_output_buffer_size_);
-  CHECK_EQ(TreelitePredictorPredictBatch(treelite_model_, treelite_input_->handle, 1, 0, 0,
-                                         treelite_output_.data(), &out_result_size),
+  CHECK_EQ(TreelitePredictorPredictBatch(treelite_model_, treelite_input_->handle, 1, 0, 
+                                         pred_margin, treelite_output_.data(), &out_result_size),
            0)
       << TreeliteGetLastError();
 }

--- a/tests/cpp/dlr_treelite_test.cc
+++ b/tests/cpp/dlr_treelite_test.cc
@@ -117,7 +117,7 @@ TEST_F(TreeliteTest, TestGetOutput) {
 
 TEST_F(TreeliteTest, TestScoreOutput) {
   EXPECT_NO_THROW(model->SetInput("data", in_shape, data.data(), in_dim));
-  EXPECT_NO_THROW(model->SetPredMargin());
+  EXPECT_NO_THROW(model->SetPredMargin(true));
   EXPECT_NO_THROW(model->Run());
   float output[1];
   EXPECT_NO_THROW(model->GetOutput(0, output));

--- a/tests/cpp/dlr_treelite_test.cc
+++ b/tests/cpp/dlr_treelite_test.cc
@@ -1,5 +1,6 @@
 #include "dlr_treelite.h"
 
+#include <iostream>
 #include <gtest/gtest.h>
 
 int main(int argc, char** argv) {
@@ -106,6 +107,17 @@ TEST_F(TreeliteTest, TestGetOutputSizeDim) {
 
 TEST_F(TreeliteTest, TestGetOutput) {
   EXPECT_NO_THROW(model->SetInput("data", in_shape, data.data(), in_dim));
+  EXPECT_NO_THROW(model->Run());
+  float output[1];
+  EXPECT_NO_THROW(model->GetOutput(0, output));
+  float* output_p;
+  EXPECT_NO_THROW(output_p = (float*)model->GetOutputPtr(0));
+  EXPECT_EQ(output_p[0], output[0]);
+}
+
+TEST_F(TreeliteTest, TestScoreOutput) {
+  EXPECT_NO_THROW(model->SetInput("data", in_shape, data.data(), in_dim));
+  EXPECT_NO_THROW(model->SetPredMargin());
   EXPECT_NO_THROW(model->Run());
   float output[1];
   EXPECT_NO_THROW(model->GetOutput(0, output));

--- a/tests/cpp/dlr_treelite_test.cc
+++ b/tests/cpp/dlr_treelite_test.cc
@@ -1,6 +1,5 @@
 #include "dlr_treelite.h"
 
-#include <iostream>
 #include <gtest/gtest.h>
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
User can enable the score output in replacement of probabilities by using the function SetPredMargin().