### PR TITLE
Fixing excessive memory usage in texttransformer by cleaning the look…

### DIFF
--- a/src/dlr_data_transform.cc
+++ b/src/dlr_data_transform.cc
@@ -301,6 +301,8 @@ void TextTransformer::MapToNDArray(const nlohmann::json& input_json,
       }
     }
   }
+  vocab_to_cols_->clear();
+  col_to_id_->clear();
 }
 
 template <typename T>


### PR DESCRIPTION
[Sklearn DataTransform]
+ Temp variable cleaning preventing excessive memory growing in RedShift container