### PR TITLE
Fix C compiler errors in dlr.h

### DIFF
--- a/include/dlr.h
+++ b/include/dlr.h
@@ -1,6 +1,7 @@
 #ifndef DLR_H_
 #define DLR_H_
 
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -51,7 +52,7 @@ typedef void* (*DLRMemalignFunctionPtr)(size_t, size_t);
 #define DLR_MODEL_ELEM
 enum DLRModelElemType { HEXAGON_LIB, NEO_METADATA, TVM_GRAPH, TVM_LIB, TVM_PARAMS, RELAY_EXEC };
 typedef struct ModelElem {
-  const DLRModelElemType type;
+  const enum DLRModelElemType type;
   const char* path;
   const void* data;
   const size_t data_size;


### PR DESCRIPTION
I noticed that clang or gcc (C compilers) show the following errors in `dlr.h`.
```
$ clang --std=c11 aa.c 
In file included from aa.c:1:
./dlr.h:350:55: error: unknown type name 'bool'
DLR_DLL int GetDLRHasMetadata(DLRModelHandle* handle, bool* has_metadata);
                                                      ^
1 error generated.
```
```
$ clang --std=c11 aa.c 
In file included from aa.c:1:
./dlr.h:55:10: error: must use 'enum' tag to refer to type 'DLRModelElemType'
  const DLRModelElemType type;
         ^
         enum 
1 error generated.
```
This PR fixes them