### PR TITLE
Fix duplicate wheel files issue during Multi-stage Docker build

### DIFF
--- a/container/Dockerfile.cpu
+++ b/container/Dockerfile.cpu
@@ -45,7 +45,7 @@ COPY python/ /workspace/python/
 COPY cmake/ /workspace/cmake/
 COPY 3rdparty/ /workspace/3rdparty/
 
-RUN \
+RUN rm -rf /workspace/python/dist && \
     mkdir /workspace/build && cd /workspace/build && \
     cmake .. && make -j15 && cd ../python && \
     python3 setup.py bdist_wheel

--- a/container/Dockerfile.gpu
+++ b/container/Dockerfile.gpu
@@ -53,7 +53,7 @@ COPY python/ /workspace/python/
 COPY cmake/ /workspace/cmake/
 COPY 3rdparty/ /workspace/3rdparty/
 
-RUN \
+RUN rm -rf /workspace/python/dist && \
     mkdir /workspace/build && cd /workspace/build && \
     cmake .. -DUSE_CUDA=ON -DUSE_CUDNN=ON -DUSE_TENSORRT=/packages/TensorRT-7.1.3.4 && \
     make -j15 && cd ../python && \


### PR DESCRIPTION
Multi-stage Docker build copies whole python folder into itself. At that time python/dist might have previously built wheel file.
After the build in the Container is done python/dist might have two files. e.g. 
- `dlr-1.9.1-py3-none-any.whl` 
- `dlr-1.9.1-py3-none-manylinux1_x86_64.whl`

One is build before docker build and another is built during docker built.


To prevent the issue we need to clean pyhton/dist folder before wheel file build in the container

Example of the problematic build https://neo-ai-ci.amazon-ml.com/blue/organizations/jenkins/neo-ai-dlr/detail/PR-380/2/pipeline/

