### PR TITLE
release-1.10.0 ShapeTuple comparison fix

### DIFF
--- a/src/dlr_data_transform.cc
+++ b/src/dlr_data_transform.cc
@@ -64,7 +64,8 @@ void Transformer::InitNDArray(const nlohmann::json& input_json, const nlohmann::
       << "DataTransform CategoricalString is only supported for float32 inputs.";
   // Only allocate new buffer if not initialized or if shape or dtype has changed. Context will
   // always match.
-  if (input_array == empty_ || input_array.Shape() != tvm::runtime::ShapeTuple(arr_shape)) {
+  if (input_array == empty_ || !std::equal(input_array.Shape().begin(), input_array.Shape().end(),
+                                           arr_shape.begin(), arr_shape.end())) {
     input_array = tvm::runtime::NDArray::Empty(arr_shape, dtype, dev);
   }
 }
@@ -141,7 +142,8 @@ void DateTimeTransformer::InitNDArray(const nlohmann::json& input_json,
   CHECK(dtype.code == kDLFloat && dtype.bits == 32 && dtype.lanes == 1)
       << "DataTransform DateTimeTransformer is only supported for float32 "
          "inputs.";
-  if (input_array == empty_ || input_array.Shape() != tvm::runtime::ShapeTuple(arr_shape)) {
+  if (input_array == empty_ || !std::equal(input_array.Shape().begin(), input_array.Shape().end(),
+                                           arr_shape.begin(), arr_shape.end())) {
     input_array = tvm::runtime::NDArray::Empty(arr_shape, dtype, dev);
   }
 }

--- a/tests/cpp/dlr_elem_test.cc
+++ b/tests/cpp/dlr_elem_test.cc
@@ -98,9 +98,9 @@ TEST(DLR, TestGetDLRWeightName) {
   auto model = GetDLRModel();
   const char* weight_name;
   EXPECT_EQ(GetDLRWeightName(&model, 0, &weight_name), 0);
-  EXPECT_STREQ(weight_name, "p45");
+  EXPECT_STREQ(weight_name, "p105");
   EXPECT_EQ(GetDLRWeightName(&model, 107, &weight_name), 0);
-  EXPECT_STREQ(weight_name, "p72");
+  EXPECT_STREQ(weight_name, "p76");
   DeleteDLRModel(&model);
 }
 

--- a/tests/cpp/dlsym/dlr_dlsym_test.cc
+++ b/tests/cpp/dlsym/dlr_dlsym_test.cc
@@ -117,9 +117,9 @@ TEST(DLR, TestGetDLRWeightName) {
   auto model = GetDLRModel();
   const char* weight_name;
   EXPECT_EQ(GetDLRWeightName(&model, 0, &weight_name), 0);
-  EXPECT_STREQ(weight_name, "p45");
+  EXPECT_STREQ(weight_name, "p105");
   EXPECT_EQ(GetDLRWeightName(&model, 107, &weight_name), 0);
-  EXPECT_STREQ(weight_name, "p72");
+  EXPECT_STREQ(weight_name, "p76");
   DeleteDLRModel(&model);
 }
 


### PR DESCRIPTION
ShapeTuple implementation requires comparing the elements in the container instead of using == and != operators.
This PR also adds two fix for the unit tests