### PR TITLE
Fix: update vm artifacts to pass unit test.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -472,10 +472,10 @@ if(DLR_BUILD_TESTS AND NOT(AAR_BUILD))
   if(NOT IS_DIRECTORY ${RELAYVM_MODEL_DIR})
     file(MAKE_DIRECTORY ${RELAYVM_MODEL_DIR})
     download_file(
-      https://neo-ai-dlr-test-artifacts.s3-us-west-2.amazonaws.com/compiled-models/release-1.5.0/${RELAYVM_MODEL}
+      https://neo-ai-dlr-test-artifacts.s3-us-west-2.amazonaws.com/compiled-models/release-1.10.0/${RELAYVM_MODEL}
       /tmp/${RELAYVM_MODEL}
       SHA1
-      49ddd9e815c6cc14ef0e9a594c8c2d0d129e5e91
+      38111e6432d643122ebf6ed5493e415871dc3fa5
     )
     # this is OS-agnostic
     execute_process(COMMAND ${CMAKE_COMMAND} -E tar -xf /tmp/${RELAYVM_MODEL}


### PR DESCRIPTION
Thanks for contributing to DLR! By submitting this pull request, you confirm that your contribution is made under the terms of the [Apache 2.0 license](https://github.com/neo-ai/neo-ai-dlr/blob/main/LICENSE).

Please refer to our [guideline](https://github.com/neo-ai/neo-ai-dlr/blob/main/CONTRIBUTING.md) for useful information and tips.

Before
```
cmake -DENABLE_DATATRANSFORM=ON .. && make -j16 && make test
Running tests...
Test project /home/ubuntu/neo-ai/neo-ai-dlr/build
      Start  1: dlr_allocator_test
 1/14 Test  #1: dlr_allocator_test ...............   Passed    0.57 sec
      Start  2: dlr_common_test
 2/14 Test  #2: dlr_common_test ..................   Passed    0.00 sec
      Start  3: dlr_data_transform_test
 3/14 Test  #3: dlr_data_transform_test ..........***Failed    0.00 sec
      Start  4: dlr_elem_test
 4/14 Test  #4: dlr_elem_test ....................   Passed    4.62 sec
      Start  5: dlr_pipeline_skl_xgb_test
 5/14 Test  #5: dlr_pipeline_skl_xgb_test ........***Failed    0.01 sec
      Start  6: dlr_pipeline_test
 6/14 Test  #6: dlr_pipeline_test ................   Passed    0.01 sec
      Start  7: dlr_relayvm_elem_test
 7/14 Test  #7: dlr_relayvm_elem_test ............***Exception: SegFault  1.80 sec
      Start  8: dlr_relayvm_test
 8/14 Test  #8: dlr_relayvm_test .................***Exception: SegFault  1.24 sec
      Start  9: dlr_test
 9/14 Test  #9: dlr_test .........................***Exception: SegFault  4.53 sec
      Start 10: dlr_treelite_test
10/14 Test #10: dlr_treelite_test ................***Exception: SegFault  0.10 sec
      Start 11: dlr_tvm_elem_test
11/14 Test #11: dlr_tvm_elem_test ................   Passed    2.42 sec
      Start 12: dlr_tvm_test
12/14 Test #12: dlr_tvm_test .....................   Passed    2.71 sec
      Start 13: dlr_dlsym_test
13/14 Test #13: dlr_dlsym_test ...................   Passed    4.22 sec
      Start 14: dlr_multiple_lib_test
14/14 Test #14: dlr_multiple_lib_test ............   Passed    0.89 sec

57% tests passed, 6 tests failed out of 14

Total Test time (real) =  23.14 sec

The following tests FAILED:
          3 - dlr_data_transform_test (Failed)
          5 - dlr_pipeline_skl_xgb_test (Failed)
          7 - dlr_relayvm_elem_test (SEGFAULT)
          8 - dlr_relayvm_test (SEGFAULT)
          9 - dlr_test (SEGFAULT)
         10 - dlr_treelite_test (SEGFAULT)
```
After
```
cmake -DENABLE_DATATRANSFORM=ON .. && make -j16 && make test
Running tests...
Test project /home/ubuntu/neo-ai/neo-ai-dlr/build
      Start  1: dlr_allocator_test
 1/14 Test  #1: dlr_allocator_test ...............   Passed    0.57 sec
      Start  2: dlr_common_test
 2/14 Test  #2: dlr_common_test ..................   Passed    0.00 sec
      Start  3: dlr_data_transform_test
 3/14 Test  #3: dlr_data_transform_test ..........***Failed    0.00 sec
      Start  4: dlr_elem_test
 4/14 Test  #4: dlr_elem_test ....................   Passed    4.62 sec
      Start  5: dlr_pipeline_skl_xgb_test
 5/14 Test  #5: dlr_pipeline_skl_xgb_test ........***Failed    0.01 sec
      Start  6: dlr_pipeline_test
 6/14 Test  #6: dlr_pipeline_test ................   Passed    0.01 sec
      Start  7: dlr_relayvm_elem_test
 7/14 Test  #7: dlr_relayvm_elem_test ............   Passed    2.33 sec
      Start  8: dlr_relayvm_test
 8/14 Test  #8: dlr_relayvm_test .................   Passed    1.54 sec
      Start  9: dlr_test
 9/14 Test  #9: dlr_test .........................   Passed    4.94 sec
      Start 10: dlr_treelite_test
10/14 Test #10: dlr_treelite_test ................***Exception: SegFault  0.10 sec
      Start 11: dlr_tvm_elem_test
11/14 Test #11: dlr_tvm_elem_test ................   Passed    2.41 sec
      Start 12: dlr_tvm_test
12/14 Test #12: dlr_tvm_test .....................   Passed    2.73 sec
      Start 13: dlr_dlsym_test
13/14 Test #13: dlr_dlsym_test ...................   Passed    4.27 sec
      Start 14: dlr_multiple_lib_test
14/14 Test #14: dlr_multiple_lib_test ............   Passed    0.90 sec

79% tests passed, 3 tests failed out of 14

Total Test time (real) =  24.44 sec

The following tests FAILED:
          3 - dlr_data_transform_test (Failed)
          5 - dlr_pipeline_skl_xgb_test (Failed)
         10 - dlr_treelite_test (SEGFAULT)
```
