### PR TITLE
Fix: treelite unit test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -456,13 +456,13 @@ if(DLR_BUILD_TESTS AND NOT(AAR_BUILD))
   if(NOT IS_DIRECTORY ${XGBOOST_TEST_MODEL})
     file(MAKE_DIRECTORY ${XGBOOST_TEST_MODEL})
     download_file(
-      https://neo-ai-dlr-test-artifacts.s3-us-west-2.amazonaws.com/compiled-models/xgboost_test.tar.gz
-      /tmp/xgboost_test.tar.gz
+      https://neo-ai-dlr-test-artifacts.s3-us-west-2.amazonaws.com/compiled-models/release-1.10.0/xgboost-ml_m5.tar.gz
+      /tmp/xgboost-ml_m5.tar.gz
       SHA1
-      4c8ac5f20db6c7c6d674dd2ac9d9e14ce887281e
+      1e45bb9d6108d70ac4ff37855cf13061d61ef742
     )
     # this is OS-agnostic
-    execute_process(COMMAND ${CMAKE_COMMAND} -E tar -xf /tmp/xgboost_test.tar.gz
+    execute_process(COMMAND ${CMAKE_COMMAND} -E tar -xf /tmp/xgboost-ml_m5.tar.gz
                     WORKING_DIRECTORY ${XGBOOST_TEST_MODEL})
     file(REMOVE /tmp/xgboost_test.tar.gz)
   endif()


### PR DESCRIPTION
```
Test project /home/ubuntu/neo-ai/neo-ai-dlr/build
      Start  1: dlr_allocator_test
 1/14 Test  #1: dlr_allocator_test ...............   Passed    0.57 sec
      Start  2: dlr_common_test
 2/14 Test  #2: dlr_common_test ..................   Passed    0.00 sec
      Start  3: dlr_data_transform_test
 3/14 Test  #3: dlr_data_transform_test ..........***Failed    0.00 sec
      Start  4: dlr_elem_test
 4/14 Test  #4: dlr_elem_test ....................   Passed    4.60 sec
      Start  5: dlr_pipeline_skl_xgb_test
 5/14 Test  #5: dlr_pipeline_skl_xgb_test ........***Failed    0.01 sec
      Start  6: dlr_pipeline_test
 6/14 Test  #6: dlr_pipeline_test ................   Passed    0.01 sec
      Start  7: dlr_relayvm_elem_test
 7/14 Test  #7: dlr_relayvm_elem_test ............   Passed    2.29 sec
      Start  8: dlr_relayvm_test
 8/14 Test  #8: dlr_relayvm_test .................   Passed    1.54 sec
      Start  9: dlr_test
 9/14 Test  #9: dlr_test .........................   Passed    4.93 sec
      Start 10: dlr_treelite_test
10/14 Test #10: dlr_treelite_test ................   Passed    0.02 sec
      Start 11: dlr_tvm_elem_test
11/14 Test #11: dlr_tvm_elem_test ................   Passed    2.43 sec
      Start 12: dlr_tvm_test
12/14 Test #12: dlr_tvm_test .....................   Passed    2.75 sec
      Start 13: dlr_dlsym_test
13/14 Test #13: dlr_dlsym_test ...................   Passed    4.20 sec
      Start 14: dlr_multiple_lib_test
14/14 Test #14: dlr_multiple_lib_test ............   Passed    0.90 sec

86% tests passed, 2 tests failed out of 14

Total Test time (real) =  24.27 sec

The following tests FAILED:
          3 - dlr_data_transform_test (Failed)
          5 - dlr_pipeline_skl_xgb_test (Failed)
```