### PR TITLE
Set env var BASELINE_BRANCH for git-clang-format

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,6 +33,8 @@ pipeline {
       }
       steps {
         nodeInfo()
+        setEnvBaselineBranch()
+        sh 'echo "BASELINE_BRANCH: ${BASELINE_BRANCH}"'
         checkoutSrcs()
         stash name: 'srcs', excludes: '.git/'
         milestone label: 'Sources ready', ordinal: 1
@@ -52,7 +54,7 @@ pipeline {
         unstash name: 'srcs'
         sh """
         tests/ci_build/git-clang-format.sh HEAD~1
-        tests/ci_build/git-clang-format.sh origin/$CHANGE_TARGET
+        tests/ci_build/git-clang-format.sh origin/${BASELINE_BRANCH}
         """
       }
     }
@@ -177,6 +179,15 @@ pipeline {
 }
 
 /* Function definitions to follow */
+
+// Set environment variable BASELINE_BRANCH
+def setEnvBaselineBranch() {
+    if (env.CHANGE_TARGET != null) {
+        env.BASELINE_BRANCH = env.CHANGE_TARGET;
+    } else {
+        env.BASELINE_BRANCH = env.BRANCH_NAME;
+    }
+}
 
 // Add more info about job node
 def nodeInfo() {


### PR DESCRIPTION
Set env var BASELINE_BRANCH for git-clang-format

We found that PR Jenkins builds and branch Jenkins builds have different sets of env variables indicating baseline_branch, e.g.
```
# PR-398 build:
CHANGE_TARGET - release-1.9.1
BRANCH_NAME=PR-398
GIT_BRANCH=PR-398

# release-1.9.1 branch build:
CHANGE_TARGET - missing
BRANCH_NAME=release-1.9.1
GIT_BRANCH=release-1.9.1
```

This PR adds Jenkins function to set dedicated env var `BASELINE_BRANCH`. It is used as a parameter in `git-clang-format.sh`

### Tests
The fix was tested in PR build and branch build:
- PR build - https://neo-ai-ci.amazon-ml.com/blue/organizations/jenkins/neo-ai-dlr/detail/PR-404/1/pipeline/36/
- branch build - https://neo-ai-ci.amazon-ml.com/blue/organizations/jenkins/neo-ai-dlr/detail/release-1.9.1/17/pipeline/10/