### PR TITLE
[Treelite] Add TreeliteModel destructor

### DIFF
--- a/include/dlr_treelite.h
+++ b/include/dlr_treelite.h
@@ -62,6 +62,7 @@ class DLR_DLL TreeliteModel : public DLRModel {
       : DLRModel(dev, DLRBackend::kTREELITE) {
     SetupTreeliteModule(files);
   }
+  ~TreeliteModel();
 
   virtual const int GetInputDim(int index) const override;
   virtual const int64_t GetInputSize(int index) const override;

--- a/src/dlr_treelite.cc
+++ b/src/dlr_treelite.cc
@@ -41,7 +41,7 @@ ModelPath dlr::SetTreelitePaths(const std::vector<std::string>& files) {
 }
 
 TreeliteInput::~TreeliteInput() {
-  if (handle) TreeliteDMatrixFree(handle);
+  if (handle != nullptr) TreeliteDMatrixFree(handle);
   handle = nullptr;
 }
 
@@ -240,4 +240,11 @@ void TreeliteModel::SetNumThreads(int threads) {
 
 void TreeliteModel::UseCPUAffinity(bool use) {
   throw dmlc::Error("UseCPUAffinity is not supported by Treelite backend.");
+}
+
+// Destructor
+TreeliteModel::~TreeliteModel() {
+  // Delete predictor from memory
+  if (treelite_model_ != nullptr) TreelitePredictorFree(treelite_model_);
+  treelite_model_ = nullptr;
 }


### PR DESCRIPTION
Add TreeliteModel destructor

`TreeliteModel` class has `PredictorHandle treelite_model_` member.
`typedef void* PredictorHandle;`

Looks like we have a memory leak issue because we do not delete `treelite::Predictor` to which `treelite_model_` points.
`treelite_model_` is not wrapped with `unique_pointer`. wrapping `void*` with `unique_pointer` does not work anyway - it needs actual object type such as `predictor::Predict`.

it is easier to just add explicit cleanup method to `TreeliteModel` to fix memory leak issue.
