### PR TITLE
Remove hardcoded BUILD_SHARED_LIBS=ON

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,9 +69,6 @@ set(CMAKE_MACOSX_RPATH TRUE)
 
 set(python-build "bp3-python setup.py build")
 
-# Set BUILD_SHARED_LIBS as option. By default, build shared libraries;
-# User can set this to OFF to build static libraries instead.
-option(BUILD_SHARED_LIBS "Build shared library" ON)
 option(TEST_COVERAGE "C++ test coverage" OFF)
 
 # Compiler flags
@@ -280,12 +277,11 @@ FILE(GLOB MAIN_SRC src/*.cc)
 
 set(USE_LIBBACKTRACE OFF)
 add_subdirectory(${TVM_SRC} EXCLUDE_FROM_ALL)
-set(BUILD_SHARED_LIBS_SAVED "${BUILD_SHARED_LIBS}") # Save BUILD_SHARED_LIBS
+# Ask Treelite to add_library treelite_runtime_static
+set(BUILD_STATIC_LIBS_SAVED "${BUILD_STATIC_LIBS}") # Save BUILD_STATIC_LIBS
 set(BUILD_STATIC_LIBS ON)
-set(BUILD_SHARED_LIBS OFF)
 add_subdirectory(${TREELITE_SRC} EXCLUDE_FROM_ALL)
-set(BUILD_SHARED_LIBS "${BUILD_SHARED_LIBS_SAVED}")  # Restore BUILD_SHARED_LIBS
-set(BUILD_STATIC_LIBS OFF)
+set(BUILD_STATIC_LIBS "${BUILD_STATIC_LIBS_SAVED}")  # Restore BUILD_STATIC_LIBS
 add_library(objdlr OBJECT ${DLR_SRC})
 
 target_compile_definitions(objdlr PUBLIC DMLC_USE_LOGGING_LIBRARY=<tvm/runtime/logging.h>)


### PR DESCRIPTION
There is no need to set `BUILD_SHARED_LIBS=ON` because we explicitly say to build static and shared DLR libraries

Disadvantage of setting `BUILD_SHARED_LIBS=ON` is that it confuses 3rd party projects builds and we need to add unnecessary workarounds. E.g. for  static `libdmlc.a` build.

### Tesing
DLR build produces both static and shared DLR libs

libdmlc.a was built as static lib 

libdlr.so depends only on system libs
```
# ls -la lib/
-rwxr-xr-x  1 root root 2783528 Feb  3 06:22 libdlr.so
-rw-r--r--  1 root root 2104608 Feb  3 06:22 libdlr_static.a

# ls _deps/dmlccore-build/
CMakeFiles  Makefile  cmake_install.cmake  include  libdmlc.a

# ldd lib/libdlr.so 
	linux-vdso.so.1 (0x00007fffaf984000)
	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f2d1e583000)
	libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007f2d1e37f000)
	libstdc++.so.6 => /usr/lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007f2d1dff6000)
	libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007f2d1ddde000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f2d1d9ed000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f2d1ebe5000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f2d1d64f000)
```