### PR TITLE
Add TF2ModelImpl.

### DIFF
--- a/python/dlr/api.py
+++ b/python/dlr/api.py
@@ -43,6 +43,15 @@ def _find_model_file(model_path, ext):
         return model_files[0]
     return None
 
+def _find_saved_model(model_path):
+    if not os.path.isdir(model_path):
+        return False
+    model_file = glob.glob(os.path.abspath(os.path.join(model_path, '*' + '.pb')))
+    variables = glob.glob(os.path.abspath(os.path.join(model_path, 'variables')))
+    if any(len(e) == 0 for e in (model_file, variables)):
+        return False
+    return True
+
 def _is_module_found(name):
     try:
         __import__(name)
@@ -52,7 +61,7 @@ def _is_module_found(name):
 
 # Wrapper class
 class DLRModel(IDLRModel):
-    
+
     @call_phone_home
     def __init__(self, model_path, dev_type=None, dev_id=None, error_log_file=None, use_default_dlr=False):
         """
@@ -76,13 +85,19 @@ class DLRModel(IDLRModel):
         self.neo_logger = create_logger(log_file=error_log_file)
         try:
             # Find correct runtime implementation for the model
-            self._model = model_path
-            from .dlr_model import DLRModelImpl
-            if dev_type is None:
-                dev_type = 'cpu'
-            if dev_id is None:
-                dev_id = 0
-            self._impl = DLRModelImpl(model_path, dev_type, dev_id, error_log_file, use_default_dlr)
+            # Tensorflow saved model
+            if _find_saved_model(model_path):
+                self.neo_logger.info("found TF2.x saved model, dlr will use TensorFlow runtime.")
+                from .tf_model import TFModelImpl
+                self._impl = TFModelImpl(model_path, dev_type, dev_id, error_log_file, use_default_dlr)
+            else:
+                # Default to TVM+Treelite
+                from .dlr_model import DLRModelImpl
+                if dev_type is None:
+                    dev_type = 'cpu'
+                if dev_id is None:
+                    dev_id = 0
+                self._impl = DLRModelImpl(model_path, dev_type, dev_id, error_log_file, use_default_dlr)
         except Exception as ex:
             self.neo_logger.exception("error in DLRModel instantiation {}".format(ex))
             raise ex
@@ -160,7 +175,7 @@ class DLRModel(IDLRModel):
             self.neo_logger.exception("error in getting output names {} {}".format(self._impl.__class__.__name__, ex))
             raise ex
 
-    
+
     def get_version(self):
         """
         Get version of loaded DLR library.

--- a/python/dlr/metadata.py
+++ b/python/dlr/metadata.py
@@ -1,3 +1,4 @@
 NAME = ['DLRModel']
 
 VERSION = "1.10.0"
+MIN_TENSORFLOW_VERSION = "2.3.0"

--- a/python/dlr/tf_model.py
+++ b/python/dlr/tf_model.py
@@ -1,0 +1,143 @@
+import tensorflow as tf
+from tensorflow.python.tools import saved_model_utils
+
+from .api import IDLRModel
+from .neologger import create_logger
+from .metadata import VERSION
+
+class TFModelImpl(IDLRModel):
+    """
+    TFModelImpl is a wrapper on top of tensorflow which implements DLRModel API
+    Parameters
+    ----------
+    model_path : str
+        Full path to the directory containing the saved model
+    dev_type : str
+        Device type ('cpu' or 'gpu')
+    dev_id : int
+        Device ID
+    """
+
+    def __init__(self, model_path, dev_type=None, dev_id=None, error_log_file=None, use_default_dlr=False):
+
+        self.model_path = model_path
+        self.logger = create_logger(log_file=error_log_file)
+        if dev_type is not None:
+            devices = ["cpu", "gpu"]
+            if dev_type not in devices:
+                raise ValueError(
+                    "Invalid device type {}. Valid devices: {}".format(dev_type, devices))
+        if dev_type == 'gpu':
+            physical_devices = tf.config.list_physical_devices('GPU')
+            tf.config.experimental.set_memory_growth(
+                physical_devices[dev_id], True)
+            self.logger.info("TF memory_growth: {}".format(
+                tf.config.experimental.get_memory_growth(physical_devices[dev_id])))
+
+        self.use_default_dlr = use_default_dlr
+        self._lib = None
+        self.version = VERSION
+
+        self.saved_model = tf.saved_model.load(model_path)
+        tag_set = 'serve'
+        assert len(self.saved_model.signatures) > 0
+        signature_def_key = 'serving_default'
+        if signature_def_key not in self.saved_model.signatures:
+            signature_def_key = list(self.saved_model.signatures.keys())[0]
+        self.func = self.saved_model.signatures[signature_def_key]
+        meta_graph_def = saved_model_utils.get_meta_graph_def(model_path, tag_set)
+        inputs_tensor_info = meta_graph_def.signature_def[signature_def_key].inputs
+        outputs_tensor_info = meta_graph_def.signature_def[signature_def_key].outputs
+        self.input_tensor_names = list(inputs_tensor_info.keys())
+        self.output_tensor_names = list(outputs_tensor_info.keys())
+
+    def get_input_names(self):
+        """
+        Get all input names
+        Returns
+        -------
+        out : list of :py:class:`str`
+        """
+        return self.input_tensor_names
+
+    def get_output_names(self):
+        """
+        Get all output names
+        Returns
+        -------
+        out : list of :py:class:`str`
+        """
+        return self.output_tensor_names
+
+    def get_input(self, name, shape=None):
+        """
+        Get the current value of an input
+        Parameters
+        ----------
+        name : str
+            The name of an input
+        shape : np.array (optional)
+            If given, use as the shape of the returned array. Otherwise, the shape of
+            the returned array will be inferred from the last call to set_input().
+        """
+        self._validate_input_name(name)
+        if name not in self.input_values:
+            return None
+        out = self.input_values[name]
+        if shape is not None:
+            out = out.reshape(shape)
+        return out
+
+    def _validate_input_name(self, name):
+        if name not in self.input_tensor_names:
+            raise ValueError(
+                "Invalid input tensor name '{}'. List of input tensor names: {}".format(name, self.input_tensor_names))
+
+    def _validate_input(self, input_values):
+        if isinstance(input_values, dict):
+            for k in input_values.keys():
+                if not isinstance(k, str):
+                    raise ValueError("input key must be string")
+                self._validate_input_name(k)
+            self.input_values = input_values
+        elif isinstance(input_values, (list, tuple)):
+            l_names, l_input_values = len(
+                self.input_tensor_names), len(input_values)
+            assert l_names == l_input_values, "Input tensor number does not match, expect {}, got {}".format(
+                l_names, l_input_values)
+            self.input_values = dict(
+                zip(self.input_tensor_names, input_values))
+        else:
+            self.input_values = {self.input_tensor_names[0]: input_values}
+
+    def get_version(self):
+        """
+        Get DLR version
+
+        Returns
+        -------
+        out : py:class:`int`
+        """
+        return self.version
+
+    def run(self, input_values):
+        """
+        Run inference with given input(s)
+        Parameters
+        ----------
+        input_values :
+            Input tensor, or dict/list/tuple of input tensors (of any type).
+
+        Returns
+        -------
+        out :
+            Prediction result.
+        """
+
+        self._validate_input(input_values)
+        if isinstance(self.input_values, dict):
+            out = self.func(**self.input_values)
+        else:
+            out = self.func(input_values)
+
+        return out

--- a/tests/python/unittest/test_tf2.py
+++ b/tests/python/unittest/test_tf2.py
@@ -1,0 +1,61 @@
+from dlr import DLRModel
+import numpy as np
+import tensorflow as tf
+from tensorflow.keras import Model
+
+SAVED_MODEL_PATH = "/tmp/saved_model"
+
+signature_list = [tf.TensorSpec(shape=[2,2], dtype=tf.float32, name="input1"),
+                  tf.TensorSpec(shape=[2,2], dtype=tf.float32, name="input2") ]
+
+class TestModel(Model):
+    @tf.function(input_signature = [signature_list])
+    def call(self, inputs):
+        a, b = inputs
+        ab = tf.matmul(a, b)
+        mm = tf.matmul(a, ab)
+        output1 = tf.square(mm)
+        mm_flat = tf.reshape(mm, shape=[-1])
+        output2 = tf.argmax(mm_flat)
+        return {"output1": output1, "output2" : output2}
+
+def test_tf_model(dev_type=None, dev_id=None):
+    model = TestModel()
+
+    tf.saved_model.save(model, SAVED_MODEL_PATH)
+    model = DLRModel(SAVED_MODEL_PATH, dev_type, dev_id)
+
+    inp1 = tf.constant([[4., 1.], [3., 2.]])
+    inp2 = tf.constant([[0., 1.], [1., 0.]])
+    # list input
+    inputs = [inp1, inp2]
+    res = model.run(inputs)
+    # dict input
+    inputs = {"input1" : inp1, "input2" : inp2}
+    res = model.run(inputs)
+
+    inp_names = model.get_input_names()
+    assert inp_names == ['input1', 'input2']
+
+    out_names = model.get_output_names()
+    assert out_names == ['output1', 'output2']
+
+    assert res is not None
+    assert len(res) == 2
+    assert np.alltrue(res['output1'] == [[36., 361.], [49.,  324.]])
+    assert res['output2'] == 1
+
+    m_inp1 = model.get_input('input1')
+    m_inp2 = model.get_input('input2')
+    assert np.alltrue(m_inp1 == inp1)
+    assert np.alltrue(m_inp2 == inp2)
+
+def test_tf_model_on_cpu_0():
+    test_tf_model("cpu", 0)
+
+def test_tf_model_on_gpu_0():
+    test_tf_model("gpu", 0)
+
+if __name__ == '__main__':
+    test_tf_model()
+    print('All tests passed!')

--- a/tests/python/unittest/test_tf2.py
+++ b/tests/python/unittest/test_tf2.py
@@ -8,7 +8,7 @@ SAVED_MODEL_PATH = "/tmp/saved_model"
 signature_list = [tf.TensorSpec(shape=[2,2], dtype=tf.float32, name="input1"),
                   tf.TensorSpec(shape=[2,2], dtype=tf.float32, name="input2") ]
 
-class TestModel(Model):
+class TestTF2Model(Model):
     @tf.function(input_signature = [signature_list])
     def call(self, inputs):
         a, b = inputs
@@ -19,8 +19,9 @@ class TestModel(Model):
         output2 = tf.argmax(mm_flat)
         return {"output1": output1, "output2" : output2}
 
-def test_tf_model(dev_type=None, dev_id=None):
-    model = TestModel()
+def test_tf2_model(dev_type=None, dev_id=None):
+
+    model = TestTF2Model()
 
     tf.saved_model.save(model, SAVED_MODEL_PATH)
     model = DLRModel(SAVED_MODEL_PATH, dev_type, dev_id)
@@ -50,12 +51,6 @@ def test_tf_model(dev_type=None, dev_id=None):
     assert np.alltrue(m_inp1 == inp1)
     assert np.alltrue(m_inp2 == inp2)
 
-def test_tf_model_on_cpu_0():
-    test_tf_model("cpu", 0)
-
-def test_tf_model_on_gpu_0():
-    test_tf_model("gpu", 0)
-
 if __name__ == '__main__':
-    test_tf_model()
+    test_tf2_model()
     print('All tests passed!')


### PR DESCRIPTION
TF2ModelImpl is a wrapper on top of tensorflow2.x which implements DLRModel API.
It allows to load tensorflow2.x saved model and run inference. I have verified with `ssd_mobilenet_v2_320x320_coco17_tpu-8` too.

```
root@ce5f72a26aac:/neo-ai-dlr# python test_tf2.py

 CALL HOME FEATURE ENABLED
                            

 You acknowledge and agree that DLR collects the following metrics to help improve its performance.                             
 By default, Amazon will collect and store the following information from your device:                             

 record_type: <enum, internal record status, such as model_loaded, model_>,                             
 arch: <string, platform architecture, eg 64bit>,                             
 osname: <string, platform os name, eg. Linux>,                             
 uuid: <string, one-way non-identifable hashed mac address, eg. 8fb35b79f7c7aa2f86afbcb231b1ba6e>,                             
 dist: <string, distribution of os, eg. Ubuntu 16.04 xenial>,                             
 machine: <string, retuns the machine type, eg. x86_64 or i386>,                             
 model: <string, one-way non-identifable hashed model name, eg. 36f613e00f707dbe53a64b1d9625ae7d>                             

 If you wish to opt-out of this data collection feature, please follow the steps below:                             
        1. Disable it with through code:                             
                 from dlr.counter.phone_home import PhoneHome                             
                 PhoneHome.disable_feature()                            
        2. Or, create a config file, ccm_config.json inside your DLR target directory path, i.e. python3.6/site-packages/dlr/counter/ccm_config.json. Then added below format content in it, {"enable_phone_home" : false}                             
        3. Restart DLR application.                             
        4. Validate this feature is disabled by verifying this notification is no longer displayed, or programmatically with following command:                             
                from dlr.counter.phone_home import PhoneHome                             
                PhoneHome.is_enabled() # false as disabled 
2022-03-09 05:45:35.948019: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:937] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero
2022-03-09 05:45:35.955873: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:937] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero
2022-03-09 05:45:35.956537: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:937] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero
2022-03-09 05:45:35.957721: I tensorflow/core/platform/cpu_feature_guard.cc:142] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  SSE3 SSE4.1 SSE4.2 AVX AVX2 AVX512F FMA
To enable them in other operations, rebuild TensorFlow with the appropriate compiler flags.
2022-03-09 05:45:35.958554: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:937] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero
2022-03-09 05:45:35.959198: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:937] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero
2022-03-09 05:45:35.959813: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:937] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero
2022-03-09 05:45:36.586782: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:937] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero
2022-03-09 05:45:36.587450: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:937] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero
2022-03-09 05:45:36.588067: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:937] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero
2022-03-09 05:45:36.588649: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1510] Created device /job:localhost/replica:0/task:0/device:GPU:0 with 13813 MB memory:  -> device: 0, name: Tesla T4, pci bus id: 0000:00:1e.0, compute capability: 7.5
WARNING:tensorflow:Skipping full serialization of Keras layer <__main__.TestModel object at 0x7ff8da343ac8>, because it is not built.
2022-03-09 05:45:37,061 INFO found TF2.x saved model, dlr will use TensorFlow runtime.
2022-03-09 05:45:37.191709: I tensorflow/compiler/mlir/mlir_graph_optimization_pass.cc:185] None of the MLIR Optimization Passes are enabled (registered 2)
All tests passed!
```