### PR TITLE
Use -D_GLIBCXX_USE_CXX11_ABI=0 for TF build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -231,9 +231,22 @@ if(USE_TENSORRT)
     set(USE_TENSORRT OFF)
 endif()
 if(WITH_TENSORFLOW2_LIB)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DDLR_TENSORFLOW2")
     if(NOT TENSORFLOW2_INCLUDE)
         message(FATAL_ERROR "TENSORFLOW2_INCLUDE is required.")
+    endif()
+    message(STATUS "Building WITH_TENSORFLOW2_LIB: ${WITH_TENSORFLOW2_LIB}")
+    message(STATUS "TENSORFLOW2_INCLUDE: ${TENSORFLOW2_INCLUDE}")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DDLR_TENSORFLOW2")
+    if(CMAKE_HOST_SYSTEM_NAME MATCHES "Linux")
+        # https://discuss.tensorflow.org/t/do-you-have-plan-to-remove-cxxopt-d-glibcxx-use-cxx11-abi-0-in-build/7530
+        execute_process(COMMAND nm -D ${WITH_TENSORFLOW2_LIB}/libtensorflow.so
+                        COMMAND grep protobuf.*fixed_address_empty_string.*cxx11
+                        COMMAND wc -l
+                        OUTPUT_VARIABLE IS_TF_USE_CXX11_ABI)
+        if(${IS_TF_USE_CXX11_ABI} EQUAL "0")
+            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_GLIBCXX_USE_CXX11_ABI=0")
+            message(WARNING "[WITH_TENSORFLOW2_LIB] Using CXX_FLAG -D_GLIBCXX_USE_CXX11_ABI=0")
+        endif()
     endif()
     include_directories("${TENSORFLOW2_INCLUDE}" "${TENSORFLOW2_INCLUDE}/src")
     list(APPEND DLR_SRC "src/dlr_tensorflow2/dlr_tensorflow2.cc")


### PR DESCRIPTION
If we use `libtensorflow.so` downloaded from tensorflow.org then DLR build WITH_TENSORFLOW2_LIB fails with the following error on Linux:
```
[ 70%] Linking CXX executable dlr_allocator_test
lib/libdlr.so: undefined reference to `google::protobuf::internal::fixed_address_empty_string[abi:cxx11]'
lib/libdlr.so: undefined reference to `google::protobuf::internal::LogMessage::operator<<(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
collect2: error: ld returned 1 exit status
CMakeFiles/dlr_allocator_test.dir/build.make:99: recipe for target 'dlr_allocator_test' failed
make[2]: *** [dlr_allocator_test] Error 1
CMakeFiles/Makefile2:450: recipe for target 'CMakeFiles/dlr_allocator_test.dir/all' failed
make[1]: *** [CMakeFiles/dlr_allocator_test.dir/all] Error 2
Makefile:145: recipe for target 'all' failed
make: *** [all] Error 2
```

I used `libtensorflow-gpu-linux-x86_64-2.7.0` downloaded from [tensorflow.org](https://www.tensorflow.org/install/lang_c)

Related links:
- https://stackoverflow.com/questions/30124264/undefined-reference-to-googleprotobufinternalempty-string-abicxx11
- https://discuss.tensorflow.org/t/do-you-have-plan-to-remove-cxxopt-d-glibcxx-use-cxx11-abi-0-in-build/7530

Recommendation is to "Build you app with `-D_GLIBCXX_USE_CXX11_ABI=0`. This will force GCC to use the old ABI version (for string)."

If we build DLR with manually built `libtensorflow.so` then we don not have this issue.

To determine problematic `libtensorflow.so`  we can use the following command
```
nm -D libtensorflow.so | grep "protobuf.*fixed_address_empty_string.*cxx11" | wc -l
```

DLR cmake output in case we set `WITH_TENSORFLOW2_LIB` to a folder containing `libtensorflow.so` downloaded from tensorflow.org.
```
-- Building WITH_TENSORFLOW2_LIB: /home/ubuntu/workspace/libtensorflow-gpu-linux-x86_64-2.7.0/lib
-- TENSORFLOW2_INCLUDE: /home/ubuntu/workspace/tensorflow/bazel-bin/tensorflow/include
CMake Warning at CMakeLists.txt:247 (message):
  [WITH_TENSORFLOW2_LIB] Using CXX_FLAG -D_GLIBCXX_USE_CXX11_ABI=0
```