### PR TITLE
Add getter functions in TF2 Python API

### DIFF
--- a/python/dlr/tf2_model.py
+++ b/python/dlr/tf2_model.py
@@ -1,10 +1,12 @@
 import tensorflow as tf
 from tensorflow.python.tools import saved_model_utils
+from tensorflow.core.framework import types_pb2
 from packaging import version
 
 from .api import IDLRModel
 from .neologger import create_logger
 from .metadata import VERSION, MIN_TENSORFLOW_VERSION
+
 
 class TF2ModelImpl(IDLRModel):
     """
@@ -19,16 +21,28 @@ class TF2ModelImpl(IDLRModel):
         Device ID
     """
 
-    def __init__(self, model_path, dev_type=None, dev_id=None, error_log_file=None, use_default_dlr=False):
+    def __init__(
+        self,
+        model_path,
+        dev_type=None,
+        dev_id=None,
+        error_log_file=None,
+        use_default_dlr=False,
+    ):
         # check for Tensorflow 2.x
-        assert version.parse(tf.__version__) >= version.parse(MIN_TENSORFLOW_VERSION), \
-            "Minimem Tensorflow supported version is {}, got {}".format(MIN_TENSORFLOW_VERSION, tf.__version__)
+        assert version.parse(tf.__version__) >= version.parse(
+            MIN_TENSORFLOW_VERSION
+        ), "Minimem Tensorflow supported version is {}, got {}".format(
+            MIN_TENSORFLOW_VERSION, tf.__version__
+        )
         self.model_path = model_path
         self.logger = create_logger(log_file=error_log_file)
         self.use_default_dlr = use_default_dlr
         if dev_type is not None or dev_id is not None:
-            self.logger.warning("dev_type and dev_id are not supported for TF2 Models and the params are ignored.")
-        physical_devices = tf.config.list_physical_devices('GPU')
+            self.logger.warning(
+                "dev_type and dev_id are not supported for TF2 Models and the params are ignored."
+            )
+        physical_devices = tf.config.list_physical_devices("GPU")
         for physical_device in physical_devices:
             memory_growth = tf.config.experimental.get_memory_growth(physical_device)
             if not memory_growth:
@@ -36,12 +50,16 @@ class TF2ModelImpl(IDLRModel):
                     tf.config.experimental.set_memory_growth(physical_device, True)
                     assert tf.config.experimental.get_memory_growth(physical_device)
                 except:
-                    self.logger.warning("tf.config.experimental.set_memory_growth failed.")
+                    self.logger.warning(
+                        "tf.config.experimental.set_memory_growth failed."
+                    )
         self.version = VERSION
         self.saved_model = tf.saved_model.load(model_path)
-        tag_set = 'serve'
-        assert len(self.saved_model.signatures) > 0, "Found no signatures in the saved model."
-        signature_def_key = 'serving_default'
+        tag_set = "serve"
+        assert (
+            len(self.saved_model.signatures) > 0
+        ), "Found no signatures in the saved model."
+        signature_def_key = "serving_default"
         if signature_def_key not in self.saved_model.signatures:
             signature_def_key = list(self.saved_model.signatures.keys())[0]
         self.func = self.saved_model.signatures[signature_def_key]
@@ -50,6 +68,10 @@ class TF2ModelImpl(IDLRModel):
         outputs_tensor_info = meta_graph_def.signature_def[signature_def_key].outputs
         self.input_tensor_names = list(inputs_tensor_info.keys())
         self.output_tensor_names = list(outputs_tensor_info.keys())
+        self.num_inputs = len(self.input_tensor_names)
+        self.num_outputs = len(self.output_tensor_names)
+        self.input_dtypes = [tf.dtypes.DType(inputs_tensor_info[name].dtype).name for name in self.input_tensor_names]
+        self.output_dtypes = [tf.dtypes.DType(outputs_tensor_info[name].dtype).name for name in self.output_tensor_names]
 
     def get_input_names(self):
         """
@@ -69,6 +91,102 @@ class TF2ModelImpl(IDLRModel):
         """
         return self.output_tensor_names
 
+    def get_input_name(self, index):
+        """
+        Get input name
+        Parameters
+        ----------
+        index : int
+            The index of an input
+
+        Returns
+        -------
+        out : py:class:`str`
+        """
+        if not (0 <= index < self.num_inputs):
+            raise Exception(
+                "Index cannot be greater than {}".format(self.num_inputs - 1)
+            )
+        return self.get_input_names()[index]
+
+    def get_output_name(self, index):
+        """
+        Get output name
+        Parameters
+        ----------
+        index : int
+            The index of an output
+
+        Returns
+        -------
+        out : py:class:`str`
+        """
+        if not (0 <= index < self.num_outputs):
+            raise Exception(
+                "Index cannot be greater than {}".format(self.num_outputs - 1)
+            )
+        return self.get_output_names()[index]
+
+    def has_metadata(self) -> bool:
+        self.logger.warning("Metadata file is not used in DLR TF2 Python API.")
+        return False
+
+    def get_input_dtypes(self):
+        """
+        Get all input data types
+        Returns
+        -------
+        out : list of :py:class:`str`
+        """
+        return self.input_dtypes
+
+    def get_output_dtypes(self):
+        """
+        Get all output data types
+        Returns
+        -------
+        out : list of :py:class:`str`
+        """
+        return self.output_dtypes
+
+    def get_input_dtype(self, index):
+        """
+        Get input data type
+        Parameters
+        ----------
+        index : int
+            The index of an input
+
+        Returns
+        -------
+        out :
+            Dtype of an input.
+        """
+        if not (0 <= index < self.num_inputs):
+            raise Exception(
+                "Index cannot be greater than {}".format(self.num_inputs - 1)
+            )
+        return self.get_input_dtypes()[index]
+
+    def get_output_dtype(self, index):
+        """
+        Get output data type
+        Parameters
+        ----------
+        index : int
+            The index of an output
+
+        Returns
+        -------
+        out : str
+            Dtype of an output.
+        """
+        if not (0 <= index < self.num_outputs):
+            raise Exception(
+                "Index cannot be greater than {}".format(self.num_outputs - 1)
+            )
+        return self.get_output_dtypes()[index]
+
     def get_input(self, name, shape=None):
         """
         Get the current value of an input
@@ -79,6 +197,11 @@ class TF2ModelImpl(IDLRModel):
         shape : np.array (optional)
             If given, use as the shape of the returned array. Otherwise, the shape of
             the returned array will be inferred from the last call to set_input().
+
+        Returns
+        -------
+        out :
+            Value of an input.
         """
         self._validate_input_name(name)
         if name not in self.input_values:
@@ -91,7 +214,10 @@ class TF2ModelImpl(IDLRModel):
     def _validate_input_name(self, name):
         if name not in self.input_tensor_names:
             raise ValueError(
-                "Invalid input name '{}'. List of input names: {}".format(name, self.input_tensor_names))
+                "Invalid input name '{}'. List of input names: {}".format(
+                    name, self.input_tensor_names
+                )
+            )
 
     def _validate_input(self, input_values):
         if isinstance(input_values, dict):
@@ -101,12 +227,13 @@ class TF2ModelImpl(IDLRModel):
                 self._validate_input_name(k)
             self.input_values = input_values
         elif isinstance(input_values, (list, tuple)):
-            l_names, l_input_values = len(
-                self.input_tensor_names), len(input_values)
-            assert l_names == l_input_values, "Wrong number of inputs, expected {}, actual {}".format(
-                l_names, l_input_values)
-            self.input_values = dict(
-                zip(self.input_tensor_names, input_values))
+            l_names, l_input_values = len(self.input_tensor_names), len(input_values)
+            assert (
+                l_names == l_input_values
+            ), "Wrong number of inputs, expected {}, actual {}".format(
+                l_names, l_input_values
+            )
+            self.input_values = dict(zip(self.input_tensor_names, input_values))
         else:
             self.input_values = {self.input_tensor_names[0]: input_values}
 

--- a/tests/python/unittest/test_tf2.py
+++ b/tests/python/unittest/test_tf2.py
@@ -5,11 +5,14 @@ from tensorflow.keras import Model
 
 SAVED_MODEL_PATH = "/tmp/saved_model"
 
-signature_list = [tf.TensorSpec(shape=[2,2], dtype=tf.float32, name="input1"),
-                  tf.TensorSpec(shape=[2,2], dtype=tf.float32, name="input2") ]
+signature_list = [
+    tf.TensorSpec(shape=[2, 2], dtype=tf.float32, name="input1"),
+    tf.TensorSpec(shape=[2, 2], dtype=tf.float32, name="input2"),
+]
+
 
 class TestTF2Model(Model):
-    @tf.function(input_signature = [signature_list])
+    @tf.function(input_signature=[signature_list])
     def call(self, inputs):
         a, b = inputs
         ab = tf.matmul(a, b)
@@ -17,7 +20,8 @@ class TestTF2Model(Model):
         output1 = tf.square(mm)
         mm_flat = tf.reshape(mm, shape=[-1])
         output2 = tf.argmax(mm_flat)
-        return {"output1": output1, "output2" : output2}
+        return {"output1": output1, "output2": output2}
+
 
 def test_tf2_model(dev_type=None, dev_id=None):
 
@@ -26,31 +30,45 @@ def test_tf2_model(dev_type=None, dev_id=None):
     tf.saved_model.save(model, SAVED_MODEL_PATH)
     model = DLRModel(SAVED_MODEL_PATH, dev_type, dev_id)
 
-    inp1 = tf.constant([[4., 1.], [3., 2.]])
-    inp2 = tf.constant([[0., 1.], [1., 0.]])
+    inp1 = tf.constant([[4.0, 1.0], [3.0, 2.0]])
+    inp2 = tf.constant([[0.0, 1.0], [1.0, 0.0]])
     # list input
     inputs = [inp1, inp2]
     res = model.run(inputs)
     # dict input
-    inputs = {"input1" : inp1, "input2" : inp2}
+    inputs = {"input1": inp1, "input2": inp2}
     res = model.run(inputs)
 
     inp_names = model.get_input_names()
-    assert inp_names == ['input1', 'input2']
+    assert sorted(inp_names) == sorted(["input1", "input2"])
 
     out_names = model.get_output_names()
-    assert out_names == ['output1', 'output2']
+    assert sorted(out_names) == sorted(["output1", "output2"])
+
+    input_name_0 = model.get_input_name(0)
+    assert input_name_0 == inp_names[0]
+
+    output_name_0 = model.get_output_name(0)
+    assert output_name_0 == out_names[0]
+
+    input_dtypes = model.get_input_dtypes()
+    print("Model input types: ", input_dtypes)
+    assert model.get_input_dtype(0) == input_dtypes[0]
+    output_dtypes = model.get_output_dtypes()
+    print("Model output types: ", output_dtypes)
+    assert model.get_output_dtype(0) == output_dtypes[0]
 
     assert res is not None
     assert len(res) == 2
-    assert np.alltrue(res['output1'] == [[36., 361.], [49.,  324.]])
-    assert res['output2'] == 1
+    assert np.alltrue(res["output1"] == [[36.0, 361.0], [49.0, 324.0]])
+    assert res["output2"] == 1
 
-    m_inp1 = model.get_input('input1')
-    m_inp2 = model.get_input('input2')
+    m_inp1 = model.get_input("input1")
+    m_inp2 = model.get_input("input2")
     assert np.alltrue(m_inp1 == inp1)
     assert np.alltrue(m_inp2 == inp2)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     test_tf2_model()
-    print('All tests passed!')
+    print("All tests passed!")


### PR DESCRIPTION
This PR adds missing TF2ModelImpl functions
```
get_input_dtype
get_input_dtypes
get_input_name
get_output_dtype
get_output_dtypes
get_output_name
has_metadata
```