### PR TITLE
[TF C] Fix GetDLRInput/Output Type to return type name

### DIFF
--- a/include/dlr_tensorflow2/dlr_tensorflow2.h
+++ b/include/dlr_tensorflow2/dlr_tensorflow2.h
@@ -32,8 +32,6 @@ class Tensorflow2Model : public DLRModel {
   std::vector<TF_Tensor*> output_tensors_;
   TF_Output ParseTensorName(const std::string& t_name);
   void DetectInputsAndOutputs(const InputOutputType& inputs, const InputOutputType& outputs);
-  void PrepInputs();
-  void PrepOutputs();
   int GetInputId(const char* name);
   TF_Tensor* AllocateInputTensor(int index, const int64_t* dims, const int n_dim);
 

--- a/tests/cpp/dlr_tensorflow2/dlr_tensorflow2_test.cc
+++ b/tests/cpp/dlr_tensorflow2/dlr_tensorflow2_test.cc
@@ -117,7 +117,7 @@ void CheckAllDLRMethods(DLRModelHandle& handle, const int batch_size, const int 
     FAIL() << "GetDLRInputType failed";
   }
   LOG(INFO) << "DLRInputType: " << input_type;
-  EXPECT_STREQ("1", input_type);
+  EXPECT_STREQ("DT_FLOAT", input_type);
 
   // GetDLROutputType
   const char* output_type;
@@ -125,7 +125,7 @@ void CheckAllDLRMethods(DLRModelHandle& handle, const int batch_size, const int 
     FAIL() << "GetDLROutputType failed";
   }
   LOG(INFO) << "DLROutputType: " << output_type;
-  EXPECT_STREQ("1", output_type);
+  EXPECT_STREQ("DT_FLOAT", output_type);
 
   CheckInputShape(handle, prev_batch_size);
 


### PR DESCRIPTION
Tensorflow C API:
Fix `GetDLRInputType` and `GetDLROutputType` to return type name instead of integer type_id.
Type name example: `DT_FLOAT`
