### PR TITLE
Use get-pip.py for python 3.6 (#408)

### DIFF
--- a/container/Dockerfile.cpu
+++ b/container/Dockerfile.cpu
@@ -15,7 +15,7 @@ RUN apt-get update && \
     ca-certificates \
     libnettle6 \
     && rm -rf /var/lib/apt/lists/* \
-    && curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python3 get-pip.py && rm get-pip.py \
+    && curl https://bootstrap.pypa.io/pip/3.6/get-pip.py -o get-pip.py && python3 get-pip.py && rm get-pip.py \
     && rm -rf /root/.cache/pip
 
 RUN pip3 install -U pip setuptools wheel

--- a/container/Dockerfile.gpu
+++ b/container/Dockerfile.gpu
@@ -24,7 +24,7 @@ RUN apt-get update && \
     libssl1.1 \
     libzstd1 \
     && rm -rf /var/lib/apt/lists/* \
-    && curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python3 get-pip.py && rm get-pip.py \
+    && curl https://bootstrap.pypa.io/pip/3.6/get-pip.py -o get-pip.py && python3 get-pip.py && rm get-pip.py \
     && rm -rf /root/.cache/pip
 
 RUN pip3 install -U pip setuptools wheel

--- a/container/ec2_compilation_container/Dockerfile
+++ b/container/ec2_compilation_container/Dockerfile
@@ -4,11 +4,14 @@ RUN apt update
 
 RUN apt install -y build-essential
 RUN apt install -y llvm-6.0 clang-6.0
-RUN apt install -y cmake git wget curl vim zip
+RUN apt install -y git wget curl ca-certificates openssl vim zip
 RUN apt install -y python3 python3-dev python3-distutils
 RUN apt install -y libedit-dev libxml2-dev antlr4
 
-RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python3 get-pip.py && rm get-pip.py
+RUN wget https://cmake.org/files/v3.22/cmake-3.22.0-linux-x86_64.sh \
+    && bash cmake-3.22.0-linux-x86_64.sh --skip-license --prefix=/usr/local
+
+RUN curl https://bootstrap.pypa.io/pip/3.6/get-pip.py -o get-pip.py && python3 get-pip.py && rm get-pip.py
 
 RUN pip3 install -U pip setuptools wheel
 RUN pip3 install numpy decorator attrs antlr4-python3-runtime

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -48,7 +48,7 @@ Ensure that all necessary software packages are installed: GCC (or Clang), CMake
 
   sudo apt-get update
   sudo apt-get install -y python3 python3-distutils build-essential cmake curl ca-certificates
-  curl https://bootstrap.pypa.io/get-pip.py -o /tmp/get-pip.py
+  curl https://bootstrap.pypa.io/pip/3.6/get-pip.py -o /tmp/get-pip.py
   sudo python3 /tmp/get-pip.py
   rm /tmp/get-pip.py
   sudo pip3 install -U pip setuptools wheel

--- a/examples/android/tvm_compiler/Dockerfile
+++ b/examples/android/tvm_compiler/Dockerfile
@@ -8,7 +8,7 @@ RUN apt install -y cmake git wget curl vim zip
 RUN apt install -y python3 python3-dev python3-distutils
 RUN apt install -y libedit-dev libxml2-dev antlr4
 
-RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python3 get-pip.py && rm get-pip.py
+RUN curl https://bootstrap.pypa.io/pip/3.6/get-pip.py -o get-pip.py && python3 get-pip.py && rm get-pip.py
 
 RUN pip3 install -U pip setuptools wheel
 RUN pip3 install numpy decorator attrs antlr4-python3-runtime

--- a/tests/ci_build/Dockerfile.cpu_bare
+++ b/tests/ci_build/Dockerfile.cpu_bare
@@ -5,7 +5,7 @@ RUN apt-get update && \
     libtinfo-dev zlib1g-dev build-essential libedit-dev libxml2-dev \
     antlr4 gnupg git clang-format-10 \
     && rm -rf /var/lib/apt/lists/* \
-    && curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python3 get-pip.py && rm get-pip.py \
+    && curl https://bootstrap.pypa.io/pip/3.6/get-pip.py -o get-pip.py && python3 get-pip.py && rm get-pip.py \
     && rm -rf /root/.cache/pip
 
 RUN pip3 install -U pip setuptools wheel

--- a/tests/ci_build/Dockerfile.gpu_bare
+++ b/tests/ci_build/Dockerfile.gpu_bare
@@ -16,7 +16,7 @@ RUN apt-get update && \
     curl \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/* \
-    && curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python3 get-pip.py && rm get-pip.py \
+    && curl https://bootstrap.pypa.io/pip/3.6/get-pip.py -o get-pip.py && python3 get-pip.py && rm get-pip.py \
     && rm -rf /root/.cache/pip
 
 RUN pip3 install -U pip setuptools wheel

--- a/tests/ci_build/Dockerfile.manylinux
+++ b/tests/ci_build/Dockerfile.manylinux
@@ -11,7 +11,7 @@ RUN yum -y update && \
 
 # Python
 RUN yum install -y python3 && \
-    wget https://bootstrap.pypa.io/get-pip.py && \
+    wget https://bootstrap.pypa.io/pip/3.6/get-pip.py && \
     python3 get-pip.py
 
 # CMake


### PR DESCRIPTION
fix pip install for python3.6 in CI in release-1.10.0
