### PR TITLE
Use public.ecr.aws/ubuntu/ubuntu:18.04 for inf containers

### DIFF
--- a/container/Dockerfile.cpu
+++ b/container/Dockerfile.cpu
@@ -2,7 +2,7 @@
 ### Run "docker build" at the root directory of neo-ai-dlr
 
 ### Stage 0: Base image
-FROM ubuntu:18.04 AS base
+FROM public.ecr.aws/ubuntu/ubuntu:18.04 AS base
 
 ENV DEBIAN_FRONTEND noninteractive
 

--- a/container/Dockerfile.inf1-mx
+++ b/container/Dockerfile.inf1-mx
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM public.ecr.aws/ubuntu/ubuntu:18.04
 
 LABEL maintainer="guas@amazon.com"
 

--- a/container/Dockerfile.inf1-mx1.8
+++ b/container/Dockerfile.inf1-mx1.8
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM public.ecr.aws/ubuntu/ubuntu:18.04
 
 LABEL maintainer="guas@amazon.com"
 

--- a/container/Dockerfile.inf1-pyt
+++ b/container/Dockerfile.inf1-pyt
@@ -2,7 +2,7 @@
 ### Run "docker build" at the root directory of neo-ai-dlr
 
 ### Stage 0: Base image
-FROM ubuntu:18.04 AS base
+FROM public.ecr.aws/ubuntu/ubuntu:18.04 AS base
 
 ENV DEBIAN_FRONTEND noninteractive
 

--- a/container/Dockerfile.inf1-pyt1.10
+++ b/container/Dockerfile.inf1-pyt1.10
@@ -2,7 +2,7 @@
 ### Run "docker build" at the root directory of neo-ai-dlr
 
 ### Stage 0: Base image
-FROM ubuntu:18.04 AS base
+FROM public.ecr.aws/ubuntu/ubuntu:18.04 AS base
 
 ENV DEBIAN_FRONTEND noninteractive
 

--- a/container/Dockerfile.inf1-pyt1.8
+++ b/container/Dockerfile.inf1-pyt1.8
@@ -2,7 +2,7 @@
 ### Run "docker build" at the root directory of neo-ai-dlr
 
 ### Stage 0: Base image
-FROM ubuntu:18.04 AS base
+FROM public.ecr.aws/ubuntu/ubuntu:18.04 AS base
 
 ENV DEBIAN_FRONTEND noninteractive
 

--- a/container/Dockerfile.inf1-pyt1.9
+++ b/container/Dockerfile.inf1-pyt1.9
@@ -2,7 +2,7 @@
 ### Run "docker build" at the root directory of neo-ai-dlr
 
 ### Stage 0: Base image
-FROM ubuntu:18.04 AS base
+FROM public.ecr.aws/ubuntu/ubuntu:18.04 AS base
 
 ENV DEBIAN_FRONTEND noninteractive
 

--- a/container/sagemaker-tensorflow-inferentia/Dockerfile.inf1-tf
+++ b/container/sagemaker-tensorflow-inferentia/Dockerfile.inf1-tf
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM public.ecr.aws/ubuntu/ubuntu:18.04
 
 LABEL maintainer="Amazon AI"
 # Specify LABEL for inference pipelines to use SAGEMAKER_BIND_TO_PORT

--- a/container/sagemaker-tensorflow-inferentia/Dockerfile.inf1-tf2.5
+++ b/container/sagemaker-tensorflow-inferentia/Dockerfile.inf1-tf2.5
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM public.ecr.aws/ubuntu/ubuntu:18.04
 
 LABEL maintainer="Amazon AI"
 # Specify LABEL for inference pipelines to use SAGEMAKER_BIND_TO_PORT


### PR DESCRIPTION
I noticed several cases where CI CodeBuild projects for main branch failed because dockerhub refused to serve `docker pull ubuntu:18.04` with error `toomanyrequests`.

Instead of `hub.docker.com` we can try to use `public.ecr.aws` to get `ubuntu:18.04` docker image.

This PR updates inf containers to use `public.ecr.aws/ubuntu/ubuntu:18.04`

Full error from CodeBuild for
- projects/InferenceContainersImageCod-mtifFDLI9miC   container/Dockerfile.cpu
- projects/InferentiaInferenceContaine-tseVYOAc1j1S   container/Dockerfile.inf1-pyt
```

Step 1/40 : FROM ubuntu:18.04 AS base
--
154 | 18.04: Pulling from library/ubuntu
155 | toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit
156 |  
157 | [Container] 2022/04/12 03:08:11 Command did not exit successfully docker build --build-arg APP=xgboost -t xgboost-cpu -f container/Dockerfile.cpu . exit status 1
158 | [Container] 2022/04/12 03:08:11 Phase complete: BUILD State: FAILED
159 | [Container] 2022/04/12 03:08:11 Phase context status code: COMMAND_EXECUTION_ERROR Message: Error while executing command: docker build --build-arg APP=xgboost -t xgboost-cpu -f container/Dockerfile.cpu .. Reason: exit status 1

```